### PR TITLE
Change app name on Home Screen to Quorum

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-  <string name="app_name">quorum-mobile</string>
+  <string name="app_name">Quorum</string>
   <string name="expo_system_ui_user_interface_style" translatable="false">automatic</string>
   <string name="expo_splash_screen_resize_mode" translatable="false">cover</string>
   <string name="expo_splash_screen_status_bar_translucent" translatable="false">false</string>

--- a/app.json
+++ b/app.json
@@ -1,6 +1,6 @@
 {
   "expo": {
-    "name": "quorum-mobile",
+    "name": "Quorum",
     "slug": "quorum-mobile",
     "version": "1.0.0",
     "orientation": "portrait",

--- a/ios/quorummobile/Info.plist
+++ b/ios/quorummobile/Info.plist
@@ -7,7 +7,7 @@
     <key>CFBundleDevelopmentRegion</key>
     <string>$(DEVELOPMENT_LANGUAGE)</string>
     <key>CFBundleDisplayName</key>
-    <string>quorum-mobile</string>
+    <string>Quorum</string>
     <key>CFBundleExecutable</key>
     <string>$(EXECUTABLE_NAME)</string>
     <key>CFBundleIdentifier</key>


### PR DESCRIPTION
The app name that shows up on the Home Screen and app dock is 'quorum-mobile', the dev string, but should be changed to the more polished, "Quorum" (or alternatively, "QM").

While Quorum Mobile is the official name of this app, it would be more of Quorum (Mobile). The app is Quorum Messenger, but we should just leave it at Quorum or QM so it appears without any truncation. I think Quorum would be better than QM to those not new to the ecosystem.