### PR TITLE
fix: display reply indicators for received DM replies

### DIFF
--- a/services/storage/mmkvAdapter.ts
+++ b/services/storage/mmkvAdapter.ts
@@ -123,6 +123,19 @@ export class MMKVAdapter implements StorageAdapter {
     const data = storage.getString(key);
     const messages: Message[] = data ? JSON.parse(data) : [];
 
+    // Populate replyMetadata for replies (E2E encrypted, so client must do this lookup)
+    const content = message.content as Record<string, unknown> | undefined;
+    if (content?.repliesToMessageId && !message.replyMetadata) {
+      const parentMessage = messages.find((m) => m.messageId === content.repliesToMessageId);
+      const parentContent = parentMessage?.content as Record<string, unknown> | undefined;
+      if (parentContent?.senderId) {
+        message.replyMetadata = {
+          parentAuthor: parentContent.senderId as string,
+          parentChannelId: parentMessage.channelId,
+        };
+      }
+    }
+
     // Update or add message
     const existingIdx = messages.findIndex((m) => m.messageId === message.messageId);
     if (existingIdx >= 0) {


### PR DESCRIPTION
## Summary
Populates `replyMetadata` when saving DM messages that contain `repliesToMessageId`, enabling the existing reply display UI to show "Replying to X".

## Problem
For Quorum DMs, the relay hub only sees encrypted blobs (E2E encryption via X3DH + Double Ratchet). Unlike Farcaster where the server returns `inReplyTo` with full context, Quorum's API only returns the message ID reference inside encrypted content.

The mobile app has full support for displaying reply indicators (`MessagesList.tsx` checks `replyToAuthor`), but `replyMetadata` was never being populated for DMs.

## Solution
In `mmkvAdapter.saveMessage()`, after loading existing messages, look up the parent message and populate `replyMetadata`:

```typescript
if (content?.repliesToMessageId && !message.replyMetadata) {
  const parentMessage = messages.find((m) => m.messageId === content.repliesToMessageId);
  if (parentMessage?.content?.senderId) {
    message.replyMetadata = {
      parentAuthor: parentContent.senderId,
      parentChannelId: parentMessage.channelId,
    };
  }
}
```

## Testing
- Unit tests verify the logic handles: normal replies, non-replies, missing parents, existing metadata, malformed parents
- Lint passes

## Edge Cases
- Parent message not loaded yet → `replyMetadata` stays undefined (graceful degradation)
- Parent message deleted → same graceful handling
- Existing `replyMetadata` → not overwritten