### PR TITLE
chore(channels): remove unused usePinChannel mutation

### DIFF
--- a/hooks/chat/index.ts
+++ b/hooks/chat/index.ts
@@ -68,7 +68,6 @@ export {
   useAddChannel,
   useUpdateChannel,
   useDeleteChannel,
-  usePinChannel,
   useAddGroup,
   useUpdateGroup,
   useDeleteGroup,

--- a/hooks/chat/useChannelManagement.ts
+++ b/hooks/chat/useChannelManagement.ts
@@ -5,7 +5,6 @@
  * - useAddChannel: Create a new channel
  * - useUpdateChannel: Update channel properties
  * - useDeleteChannel: Delete a channel
- * - usePinChannel: Pin/unpin a channel
  * - useAddGroup: Create a new channel group
  * - useUpdateGroup: Update group properties
  * - useDeleteGroup: Delete a channel group
@@ -224,59 +223,6 @@ export function useDeleteChannel() {
         ...space,
         groups: updatedGroups,
         modifiedDate: Date.now(),
-      };
-
-      saveSpace(updatedSpace);
-      const adapter = getMMKVAdapter();
-      await adapter.saveSpace(updatedSpace);
-    },
-    onSuccess: (_, params) => {
-      queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['spaces', params.spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['spaces'] });
-    },
-  });
-}
-
-interface PinChannelParams {
-  spaceId: string;
-  channelId: string;
-  isPinned: boolean;
-}
-
-/**
- * Pin or unpin a channel
- */
-export function usePinChannel() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (params: PinChannelParams): Promise<void> => {
-      const space = getSpace(params.spaceId);
-      if (!space) {
-        throw new Error('Space not found');
-      }
-
-      const timestamp = Date.now();
-      const updatedGroups = space.groups.map(group => ({
-        ...group,
-        channels: group.channels.map(channel => {
-          if (channel.channelId === params.channelId) {
-            return {
-              ...channel,
-              isPinned: params.isPinned,
-              pinnedAt: params.isPinned ? timestamp : undefined,
-              modifiedDate: timestamp,
-            };
-          }
-          return channel;
-        }),
-      }));
-
-      const updatedSpace: Space = {
-        ...space,
-        groups: updatedGroups,
-        modifiedDate: timestamp,
       };
 
       saveSpace(updatedSpace);


### PR DESCRIPTION
## Summary

\`usePinChannel\` was implemented in \`hooks/chat/useChannelManagement.ts\` but never wired to any UI on mobile. Verified by grep across \`master\`: zero call sites.

It also writes to \`Channel.isPinned\` / \`pinnedAt\`, fields that are about to be removed from \`@quilibrium/quorum-shared\` as part of dropping the channel-pinning feature on desktop in favour of the new drag-and-drop channel ordering ([quorum-desktop task](https://github.com/QuilibriumNetwork/quorum-desktop/blob/develop/.agents/tasks/2026-01-07-channel-ordering-feature.md)).

This PR removes \`usePinChannel\` and its barrel re-export so the upcoming shared type cleanup does not break mobile's compile.

## Important: message pinning is NOT touched

\`Message.isPinned\` / \`pinnedAt\` (used by \`usePinnedMessages\`, \`MessageActionSheet\`, \`MessagesList\`, \`SpaceChatArea\`) are a completely separate feature with the same field name. Those stay.

