### PR TITLE
Android: fix JVM target mismatch + opt-in side-by-side debug install

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -108,6 +108,14 @@ android {
     buildTypes {
         debug {
             signingConfig signingConfigs.debug
+            // Opt-in side-by-side install: build with `-PsideBySide=true` to
+            // get a `.debug`-suffixed application ID so the dev build can be
+            // installed alongside the production app (from Play / sideloaded
+            // release APKs). Default build (no flag) is unchanged.
+            if (project.hasProperty('sideBySide')) {
+                applicationIdSuffix '.debug'
+                versionNameSuffix '-debug'
+            }
         }
         release {
             // Caution! In production, you need to generate your own keystore file.

--- a/android/app/src/debug/res/values/strings.xml
+++ b/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+  <string name="app_name">Quorum Debug</string>
+</resources>

--- a/modules/quorum-crypto/android/build.gradle
+++ b/modules/quorum-crypto/android/build.gradle
@@ -40,16 +40,13 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
-    }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
 
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.majorVersion
-    }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   namespace "expo.modules.quorumcrypto"

--- a/modules/quorum-translation/android/build.gradle
+++ b/modules/quorum-translation/android/build.gradle
@@ -39,16 +39,13 @@ afterEvaluate {
 android {
   compileSdkVersion safeExtGet("compileSdkVersion", 34)
 
-  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-  if (agpVersion.tokenize('.')[0].toInteger() < 8) {
-    compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
-    }
+  compileOptions {
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
+  }
 
-    kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.majorVersion
-    }
+  kotlinOptions {
+    jvmTarget = JavaVersion.VERSION_17.majorVersion
   }
 
   namespace "expo.modules.quorumtranslation"


### PR DESCRIPTION
Two related changes that together unblock local Android development on a phone that already has the production Quorum installed.

### 1. Fix: pin local module JVM target to 17 (`d051669`)

`quorum-crypto` and `quorum-translation` only set their JVM target when AGP version < 8. With current AGP (8+), Java compiles to 17 but Kotlin defaults to 21, which Gradle rejects:

> Inconsistent JVM-target compatibility detected for tasks 'compileDebugJavaWithJavac' (17) and 'compileDebugKotlin' (21).

The `expo run:android` build fails for this reason on a fresh checkout today. Setting both to 17 unconditionally matches the rest of the Android build and restores building.

### 2. Feature: opt-in `-PsideBySide=true` flag (`40f68c9`)

When set, debug builds get a `.debug` applicationId suffix and `-debug` versionName suffix. This lets a developer install the dev build alongside the production app (Play Store / sideloaded release APK) on the same device without uninstalling and losing local app data.

**Default behavior is unchanged.** Verified empirically: running `./gradlew :app:assembleDebug` without the flag produces an APK with `applicationId: com.quilibrium.quorummobile` (same as before this PR).

Invocation:

```
./gradlew :app:assembleDebug -PsideBySide=true
adb install -r app/build/outputs/apk/debug/app-debug.apk
```

Note: `expo run:android` does not forward unknown args to Gradle, so the flag has to be passed via direct Gradle invocation.

### 3. Feature: label all debug builds as "Quorum Debug" in the launcher (`80b7c1a`)

Override `app_name` to "Quorum Debug" via the existing `src/debug/` source set so debug installs are visually distinguishable from the production app on the same home screen. Release builds are unaffected.
