### PR TITLE
Enforce message-delete and read-only-channel permissions on receipt

### DIFF
--- a/app/(tabs)/spaces/[id]/[channelId].tsx
+++ b/app/(tabs)/spaces/[id]/[channelId].tsx
@@ -21,7 +21,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useWebSocket, useSpaceCall } from '@/context';
 import { useQueryClient } from '@tanstack/react-query';
-import { queryKeys, type Message } from '@quilibrium/quorum-shared';
+import { canManageReadOnlyChannel, queryKeys, type Message } from '@quilibrium/quorum-shared';
 import { sendSpaceCallStartMessage } from '@/services/space/spaceMessageService';
 import * as Skin from '@/theme/skins/geometry';
 import { createSkinnable } from '@/theme/skins/skinnableStyleSheet';
@@ -57,6 +57,23 @@ export default function SpaceChannelChat() {
   const hasRoleDelete = useHasPermission(spaceId, user?.address, 'message:delete');
   const hasPinPermission = hasRolePin || isSpaceOwner;
   const hasDeletePermission = hasRoleDelete || isSpaceOwner;
+
+  // The current channel object (not just its name). Read-only channels need
+  // isReadOnly + managerRoleIds to gate posting.
+  const currentChannel = useMemo(() => {
+    if (!channelsData || !channelId) return undefined;
+    return channelsData.find((c) => c.channelId === channelId);
+  }, [channelsData, channelId]);
+
+  // Can the current user post here? Regular channels: always. Read-only
+  // channels: only managers (a role in managerRoleIds). No owner bypass —
+  // receivers can't verify ownership, so owners must hold a manager role,
+  // matching desktop + the receive-side guard in WebSocketContext.
+  const canPost = useMemo(() => {
+    if (!currentChannel?.isReadOnly) return true;
+    if (!user?.address) return false;
+    return canManageReadOnlyChannel(user.address, false, spaceData ?? undefined, currentChannel);
+  }, [currentChannel, spaceData, user?.address]);
 
   const memberMap = useMemo<MemberMap>(() => {
     if (!membersData) return {};
@@ -141,11 +158,7 @@ export default function SpaceChannelChat() {
     [spaceId]
   );
 
-  const channelName = useMemo(() => {
-    if (!channelsData || !channelId) return 'Channel';
-    const ch = channelsData.find((c) => c.channelId === channelId);
-    return ch?.channelName ?? 'Channel';
-  }, [channelsData, channelId]);
+  const channelName = currentChannel?.channelName ?? 'Channel';
 
   const queryClient = useQueryClient();
   const { joinCall: joinSpaceCall } = useSpaceCall();
@@ -236,6 +249,8 @@ export default function SpaceChannelChat() {
         isSpaceOwner={isSpaceOwner}
         hasPinPermission={hasPinPermission}
         hasDeletePermission={hasDeletePermission}
+        canPost={canPost}
+        isReadOnlyChannel={!!currentChannel?.isReadOnly}
         onShowSidebars={handleShowSidebars}
         onUserPress={handleUserPress}
         onLinkPress={handleLinkPress}

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -64,6 +64,10 @@ interface SpaceChatAreaProps {
   isSpaceOwner: boolean;
   hasPinPermission: boolean;
   hasDeletePermission: boolean;
+  /** Whether the current user may post in this channel (false = read-only and not a manager). */
+  canPost?: boolean;
+  /** Whether this channel is read-only (drives the locked-composer banner copy). */
+  isReadOnlyChannel?: boolean;
   onShowSidebars: () => void;
   onUserPress: (userInfo: MessageUserInfo) => void;
   onLinkPress: (url: string) => void;
@@ -93,6 +97,8 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
   isSpaceOwner,
   hasPinPermission,
   hasDeletePermission,
+  canPost = true,
+  isReadOnlyChannel = false,
   onShowSidebars,
   onUserPress,
   onLinkPress,
@@ -719,31 +725,39 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
           onReport={handleReportMessage}
         />
 
-        <MessageInput
-          ref={spaceMessageInputRef}
-          value={messageText}
-          onChangeText={setMessageText}
-          onSend={handleSendMessage}
-          channelName={selectedChannelData?.name || 'general'}
-          theme={theme}
-          isSending={sendMessageMutation.isPending || sendEmbedMutation.isPending}
-          onAttachmentPress={handleAttachmentPress}
-          pendingAttachment={pendingAttachment}
-          onClearAttachment={handleClearAttachment}
-          bottomInset={0}
-          replyTo={replyToMessage}
-          onDismissReply={handleDismissReply}
-          castReplyAvailable={isCastReply && Boolean(farcasterAuthToken)}
-          alsoReplyOnFarcaster={alsoReplyOnFarcaster}
-          onToggleAlsoReplyOnFarcaster={setAlsoReplyOnFarcaster}
-          customEmojis={spaceData?.emojis}
-          stickers={spaceData?.stickers}
-          onSendSticker={handleSendSticker}
-          members={membersData}
-          channels={channelsData}
-          editingMessage={editingMessage}
-          onCancelEdit={handleCancelEdit}
-        />
+        {!canPost && isReadOnlyChannel ? (
+          <View style={styles.readOnlyBanner}>
+            <IconSymbol name="lock.fill" size={16} color={theme.colors.textMuted} />
+            <Text style={styles.readOnlyBannerText}>You cannot post in this channel</Text>
+          </View>
+        ) : (
+          <MessageInput
+            ref={spaceMessageInputRef}
+            value={messageText}
+            onChangeText={setMessageText}
+            onSend={handleSendMessage}
+            channelName={selectedChannelData?.name || 'general'}
+            theme={theme}
+            isSending={sendMessageMutation.isPending || sendEmbedMutation.isPending}
+            onAttachmentPress={handleAttachmentPress}
+            pendingAttachment={pendingAttachment}
+            onClearAttachment={handleClearAttachment}
+            bottomInset={0}
+            replyTo={replyToMessage}
+            onDismissReply={handleDismissReply}
+            castReplyAvailable={isCastReply && Boolean(farcasterAuthToken)}
+            alsoReplyOnFarcaster={alsoReplyOnFarcaster}
+            onToggleAlsoReplyOnFarcaster={setAlsoReplyOnFarcaster}
+            customEmojis={spaceData?.emojis}
+            stickers={spaceData?.stickers}
+            onSendSticker={handleSendSticker}
+            members={membersData}
+            channels={channelsData}
+            editingMessage={editingMessage}
+            onCancelEdit={handleCancelEdit}
+            disabled={!canPost}
+          />
+        )}
       </View>
 
       {pinnedMessagesPanelVisible && (
@@ -792,5 +806,20 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     flex: 1,
     flexDirection: 'column',
     backgroundColor: theme.colors.surface1,
+  },
+  readOnlyBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    paddingVertical: 14,
+    paddingHorizontal: 16,
+    backgroundColor: theme.colors.surface2,
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: theme.colors.border,
+  },
+  readOnlyBannerText: {
+    fontSize: 14,
+    color: theme.colors.textMuted,
   },
 });

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -10,6 +10,7 @@
 
 import {
   bytesToHex,
+  canManageReadOnlyChannel,
   createChannelPermissionChecker,
   createRNWebSocketClient,
   int64ToBytes,
@@ -1976,6 +1977,43 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               return;
             }
 
+            // Read-only channel enforcement (receive-side). Postable content
+            // (post/embed/sticker) authored by a non-manager must not land in a
+            // read-only channel — the sender's client should have blocked it, but
+            // we can't trust that (same reasoning as the remove-message guard).
+            // Covers all three postable types and runs BEFORE storage.saveMessage
+            // so a dropped message can't resurrect from disk on refetch.
+            if (
+              contentType === 'post' ||
+              contentType === 'embed' ||
+              contentType === 'sticker'
+            ) {
+              const channel: Channel | undefined = space?.groups
+                ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+                ?.channels.find((c) => c.channelId === channelId);
+
+              if (channel?.isReadOnly) {
+                const senderId = 'senderId' in spaceMessage.content
+                  ? spaceMessage.content.senderId
+                  : undefined;
+                const canPost = !!senderId
+                  && canManageReadOnlyChannel(senderId, false, space ?? undefined, channel);
+                if (!canPost) {
+                  logger.debug(
+                    `[SpaceMsg] dropped read-only-channel post from ${senderId?.slice(0, 12)} in ${channelId?.slice(0, 12)}`
+                  );
+                  if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                    deleteSpaceInboxMessages(
+                      spaceInboxKey.address,
+                      [message.timestamp],
+                      { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                    ).catch(err => {});
+                  }
+                  return;
+                }
+              }
+            }
+
             // Regular message types (post, embed, sticker, join, leave, kick, etc.)
             // Save message to storage
             await storage.saveMessage(
@@ -3149,6 +3187,32 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             });
 
             continue;
+          }
+
+          // Read-only channel enforcement (receive-side) — same rule as the
+          // live path above. Drop non-manager post/embed/sticker before the
+          // save so it can't resurrect from disk.
+          if (
+            contentType === 'post' ||
+            contentType === 'embed' ||
+            contentType === 'sticker'
+          ) {
+            const channel: Channel | undefined = space?.groups
+              ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+              ?.channels.find((c) => c.channelId === channelId);
+            if (channel?.isReadOnly) {
+              const senderId = 'senderId' in spaceMessage.content
+                ? spaceMessage.content.senderId
+                : undefined;
+              const canPost = !!senderId
+                && canManageReadOnlyChannel(senderId, false, space ?? undefined, channel);
+              if (!canPost) {
+                logger.debug(
+                  `[BatchMsg] dropped read-only-channel post from ${senderId?.slice(0, 12)} in ${channelId?.slice(0, 12)}`
+                );
+                continue;
+              }
+            }
           }
 
           // Regular message - save and update cache

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -10,6 +10,7 @@
 
 import {
   bytesToHex,
+  createChannelPermissionChecker,
   createRNWebSocketClient,
   int64ToBytes,
   logger,
@@ -33,9 +34,11 @@ import { recordSpaceActivity } from '@/hooks/chat/useSpaceActivity';
 import { messagePreview as getSpaceMessagePreview, messageSenderName } from '@/utils/messagePreview';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type {
+  Channel,
   EncryptedWebSocketMessage,
   KickMessage,
   Message,
+  RemoveMessage,
   SealedMessage,
   Space,
   SpaceMember,
@@ -1813,9 +1816,59 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }
 
             if (contentType === 'remove-message') {
-              // Remove message from cache and storage
-              const removeContent = spaceMessage.content as { removeMessageId: string };
+              const removeContent = spaceMessage.content as RemoveMessage;
 
+              // Receive-side permission enforcement. The sender's own client
+              // gates the delete button, but we can't trust that — a modified
+              // or buggy client (or a space owner relying on the owner-bypass
+              // footgun) could broadcast a delete it shouldn't. So we re-validate
+              // here against the sender's role, exactly as desktop does
+              // (MessageService.ts remove-message handling). No isSpaceOwner
+              // bypass: receivers can't verify ownership, so owners must hold a
+              // role with message:delete to delete others' messages.
+              //
+              // Self-deletes never reach this handler — own echoes are filtered
+              // upstream (sent-envelope / senderId checks) and the local removal
+              // is optimistic — so this guard can't block a legitimate own delete.
+              const targetMessage = await storage.getMessage({
+                spaceId,
+                channelId,
+                messageId: removeContent.removeMessageId,
+              });
+
+              if (targetMessage) {
+                // Resolve the channel for read-only / manager-role handling.
+                const channel: Channel | undefined = space?.groups
+                  ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+                  ?.channels.find((c) => c.channelId === channelId);
+
+                const checker = createChannelPermissionChecker({
+                  userAddress: removeContent.senderId,
+                  isSpaceOwner: false,
+                  space: space ?? undefined,
+                  channel,
+                });
+
+                if (!checker.canDeleteMessage(targetMessage)) {
+                  // Unauthorized delete — drop it, but still clear the inbox
+                  // entry so we don't reprocess it on every reconnect.
+                  logger.debug(
+                    `[SpaceMsg] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+                  );
+                  if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                    deleteSpaceInboxMessages(
+                      spaceInboxKey.address,
+                      [message.timestamp],
+                      { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                    ).catch(err => {});
+                  }
+                  return;
+                }
+              }
+              // targetMessage missing → nothing to protect; honor the removal so
+              // a stale reference doesn't linger in the cache.
+
+              // Remove message from cache and storage
               queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
                 if (!old) return old;
                 return {
@@ -2993,7 +3046,36 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           }
 
           if (contentType === 'remove-message') {
-            const removeContent = spaceMessage.content as { removeMessageId: string };
+            const removeContent = spaceMessage.content as RemoveMessage;
+
+            // Receive-side permission enforcement — same rule as the live path
+            // above. Validate the sender's role before honoring a delete; never
+            // trust the sender's client. No isSpaceOwner bypass (receivers can't
+            // verify ownership). Self-deletes are filtered upstream as self-echoes,
+            // so this won't block legitimate own deletes.
+            const targetMessage = await storage.getMessage({
+              spaceId,
+              channelId,
+              messageId: removeContent.removeMessageId,
+            });
+            if (targetMessage) {
+              const channel: Channel | undefined = space?.groups
+                ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+                ?.channels.find((c) => c.channelId === channelId);
+              const checker = createChannelPermissionChecker({
+                userAddress: removeContent.senderId,
+                isSpaceOwner: false,
+                space: space ?? undefined,
+                channel,
+              });
+              if (!checker.canDeleteMessage(targetMessage)) {
+                logger.debug(
+                  `[BatchMsg] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+                );
+                continue;
+              }
+            }
+
             queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
               if (!old) return old;
               return { ...old, pages: old.pages.map(page => ({


### PR DESCRIPTION
## What

Mobile applied incoming space messages without checking whether the sender was allowed to send them. Two permission checks that desktop already enforces were missing on mobile, so they're added here on the receive side.

### 1. Message deletions
Incoming `remove-message` events were applied unconditionally, so any client could delete another user's messages on every receiving mobile device regardless of role. Now the sender's permission is re-checked on receipt (own message, read-only-channel manager, or a role granting `message:delete`) before the delete is honored.

### 2. Read-only channels
Read-only channels were unenforced: the composer was always active, and incoming posts to a read-only channel were saved and displayed regardless of sender. Now:
- the composer shows a locked banner ("You cannot post in this channel") for non-managers, and
- incoming `post`/`embed`/`sticker` to a read-only channel from non-managers are dropped before being persisted.

## Why

Clients can't verify who the space owner is (privacy), so space-content permissions have to be enforced on the receive side against the sender's role — which is what desktop does. Mobile was trusting any signed message. There is no owner bypass: owners need a role for these actions, matching desktop.

Both changes reuse the shared `createChannelPermissionChecker` / `canManageReadOnlyChannel` helpers (the same ones desktop uses), and both cover the live and batch receive paths. Own messages are unaffected (self-echoes are filtered upstream).

## Testing

Done (single client):
- Normal message sends, appears, and persists across a channel reload.
- Image + caption sends and displays.
- App builds; `tsc` and `lint` clean (no new errors).

Not yet verified (needs a setup we don't have right now):
- Two-client enforcement (an unauthorized delete / read-only post from another client is actually dropped) — needs a second participant in a shared space.
- Loading a large pre-existing backlog via the batch path — current test environment has only empty channels. The batch path mirrors the live path, which is verified.

These are low-risk: the enforcement only activates on conditions that don't occur in normal solo use, and if a guard were wrong it degrades to current behavior rather than breaking the app.

## Scope

Mobile only. No changes to quorum-shared or quorum-desktop.