### PR TITLE
Drop unsupported control messages instead of rendering them as chat bubbles

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -1977,6 +1977,28 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               return;
             }
 
+            // Unsupported control messages. Mobile has no handler for pin,
+            // mute, or thread control messages yet (pin/mute exist locally but
+            // don't sync from desktop; threads are unimplemented). Without this
+            // they fall through to the generic save below and render as junk
+            // chat bubbles (the renderer defaults unknown types to 'post').
+            // Drop them. Receiving + applying these is separate future feature
+            // work (pin-sync / mute-sync / threads), not done here.
+            if (
+              contentType === 'pin' ||
+              contentType === 'mute' ||
+              contentType === 'thread'
+            ) {
+              if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                deleteSpaceInboxMessages(
+                  spaceInboxKey.address,
+                  [message.timestamp],
+                  { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                ).catch(err => {});
+              }
+              return;
+            }
+
             // Read-only channel enforcement (receive-side). Postable content
             // (post/embed/sticker) authored by a non-manager must not land in a
             // read-only channel — the sender's client should have blocked it, but
@@ -3186,6 +3208,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               return [...old, merged];
             });
 
+            continue;
+          }
+
+          // Unsupported control messages (pin/mute/thread) — same as the live
+          // path: mobile has no handler, so drop them before the generic save
+          // to avoid junk chat bubbles. Receiving/applying these is future
+          // feature work, not done here.
+          if (
+            contentType === 'pin' ||
+            contentType === 'mute' ||
+            contentType === 'thread'
+          ) {
             continue;
           }
 


### PR DESCRIPTION
## What

Mobile has no receive handler for `pin`, `mute`, or `thread` control messages. They fell through to the generic message-save path and rendered as junk chat bubbles (the message renderer defaults unknown content types to a post). For example, pinning a message on desktop showed mobile users a garbage bubble instead of a pin.

This drops those three control types on both the live and batch receive paths before they reach storage, so they no longer appear as junk messages.

## What this does NOT do

This is a bugfix, not a feature. It does not make mobile support pins, mutes, or threads from desktop — it just stops them rendering as junk. Actually receiving and applying them is separate future work:
- pin sync (validate sender role, apply to the local pin store, reconcile with mobile's existing local pins)
- mute sync (validate role, apply, hide muted users)
- threads (not implemented on mobile at all)

## Why drop rather than apply

Even for pin, where mobile already has a local pin store, applying a received pin would need receive-side role validation (otherwise anyone could pin anything, same class of issue as message deletion) plus a design decision about reconciling local vs synced pins. That's feature scope, so it's deferred.

## Testing

- App builds; `tsc` and `lint` clean (no new errors).
- Runtime confirmation (no junk bubble when a desktop user pins/mutes/threads) needs a second client in a shared space; low-risk since the change only drops three control types that were previously mis-saved and leaves normal messages untouched.

## Scope

Mobile only.