### PR TITLE
Sync channel and group edits between mobile and desktop

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -1356,6 +1356,34 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     const decryptedText = new TextDecoder().decode(new Uint8Array(decryptedBytes));
                     const updatedSpace = JSON.parse(decryptedText) as Space;
 
+                    // Staleness guard. The hub replays historical log entries on
+                    // every reconnect (log-since-result), so OLD space manifests
+                    // routinely arrive after newer local changes. Applying them
+                    // blindly clobbers the newer state (e.g. a fresh rename snaps
+                    // back to an older name). Skip any manifest that is not newer
+                    // than what we already have.
+                    //
+                    // Compare the signed manifest.timestamp (set at broadcast
+                    // time) against the stored space's modifiedDate (the sender's
+                    // Date.now() when it last wrote the space). Fail OPEN: apply
+                    // when there's no stored space yet, when the stored space has
+                    // no modifiedDate, or on an exact tie — never block a
+                    // first-seen or legitimately-newer update.
+                    const existingSpace = getSpace(spaceId);
+                    const incomingTs = manifest.timestamp;
+                    const existingTs = existingSpace?.modifiedDate;
+                    if (
+                      existingSpace &&
+                      typeof existingTs === 'number' &&
+                      typeof incomingTs === 'number' &&
+                      incomingTs < existingTs
+                    ) {
+                      logger.debug(
+                        `[space-manifest] skipped: stale manifest for space=${spaceId?.slice(0, 12)} (incoming=${incomingTs} < local=${existingTs})`
+                      );
+                      break;
+                    }
+
                     // Save updated space
                     saveSpace(updatedSpace);
                     logger.debug(`[space-manifest] applied + saved for space=${spaceId?.slice(0, 12)} (name="${updatedSpace.spaceName}", channels=${updatedSpace.groups?.flatMap(g => g.channels)?.length ?? 0})`);

--- a/hooks/chat/index.ts
+++ b/hooks/chat/index.ts
@@ -68,7 +68,6 @@ export {
   useAddChannel,
   useUpdateChannel,
   useDeleteChannel,
-  usePinChannel,
   useAddGroup,
   useUpdateGroup,
   useDeleteGroup,

--- a/hooks/chat/useChannelManagement.ts
+++ b/hooks/chat/useChannelManagement.ts
@@ -5,18 +5,25 @@
  * - useAddChannel: Create a new channel
  * - useUpdateChannel: Update channel properties
  * - useDeleteChannel: Delete a channel
- * - usePinChannel: Pin/unpin a channel
  * - useAddGroup: Create a new channel group
  * - useUpdateGroup: Update group properties
  * - useDeleteGroup: Delete a channel group
  * - useMoveChannel: Move a channel between groups or reorder within a group
  * - useReorderGroups: Reorder channel groups
+ * - useReorderChannels: Reorder channels within a group
+ *
+ * Every mutation that changes the space manifest also broadcasts the updated
+ * manifest to all members (API upload + hub WebSocket), matching the pattern
+ * in useSpaceSettings and useRoleManagement. Without this, mobile-side channel
+ * and group edits would stay local and never reach other devices (e.g. desktop).
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { getSpace, saveSpace, saveSpaceKey } from '@/services/config/spaceStorage';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
 import { NativeCryptoProvider } from '@/services/crypto/native-provider';
+import { broadcastSpaceUpdate } from '@/services/space/broadcastSpaceUpdate';
+import { useWebSocket } from '@/context/WebSocketContext';
 import { bytesToHex } from '@quilibrium/quorum-shared';
 import type { Space, Channel, Group } from '@quilibrium/quorum-shared';
 import { sha256 } from '@noble/hashes/sha2.js';
@@ -48,6 +55,7 @@ interface AddChannelParams {
  */
 export function useAddChannel() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: AddChannelParams): Promise<Channel> => {
@@ -113,6 +121,12 @@ export function useAddChannel() {
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
 
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
+
       return newChannel;
     },
     onSuccess: (_, params) => {
@@ -139,6 +153,7 @@ interface UpdateChannelParams {
  */
 export function useUpdateChannel() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UpdateChannelParams): Promise<Channel> => {
@@ -182,6 +197,12 @@ export function useUpdateChannel() {
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
 
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
+
       return foundChannel;
     },
     onSuccess: (_, params) => {
@@ -202,6 +223,7 @@ interface DeleteChannelParams {
  */
 export function useDeleteChannel() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: DeleteChannelParams): Promise<void> => {
@@ -229,59 +251,12 @@ export function useDeleteChannel() {
       saveSpace(updatedSpace);
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
-    },
-    onSuccess: (_, params) => {
-      queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['spaces', params.spaceId] });
-      queryClient.invalidateQueries({ queryKey: ['spaces'] });
-    },
-  });
-}
 
-interface PinChannelParams {
-  spaceId: string;
-  channelId: string;
-  isPinned: boolean;
-}
-
-/**
- * Pin or unpin a channel
- */
-export function usePinChannel() {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: async (params: PinChannelParams): Promise<void> => {
-      const space = getSpace(params.spaceId);
-      if (!space) {
-        throw new Error('Space not found');
-      }
-
-      const timestamp = Date.now();
-      const updatedGroups = space.groups.map(group => ({
-        ...group,
-        channels: group.channels.map(channel => {
-          if (channel.channelId === params.channelId) {
-            return {
-              ...channel,
-              isPinned: params.isPinned,
-              pinnedAt: params.isPinned ? timestamp : undefined,
-              modifiedDate: timestamp,
-            };
-          }
-          return channel;
-        }),
-      }));
-
-      const updatedSpace: Space = {
-        ...space,
-        groups: updatedGroups,
-        modifiedDate: timestamp,
-      };
-
-      saveSpace(updatedSpace);
-      const adapter = getMMKVAdapter();
-      await adapter.saveSpace(updatedSpace);
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
     },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
@@ -303,6 +278,7 @@ interface AddGroupParams {
  */
 export function useAddGroup() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: AddGroupParams): Promise<Group> => {
@@ -328,6 +304,12 @@ export function useAddGroup() {
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
 
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
+
       return newGroup;
     },
     onSuccess: (_, params) => {
@@ -348,6 +330,7 @@ interface DeleteGroupParams {
  */
 export function useDeleteGroup() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: DeleteGroupParams): Promise<void> => {
@@ -377,6 +360,12 @@ export function useDeleteGroup() {
       saveSpace(updatedSpace);
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
+
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
     },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
@@ -399,6 +388,7 @@ interface UpdateGroupParams {
  */
 export function useUpdateGroup() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UpdateGroupParams): Promise<Group> => {
@@ -433,6 +423,12 @@ export function useUpdateGroup() {
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
 
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
+
       return updatedGroup;
     },
     onSuccess: (_, params) => {
@@ -456,6 +452,7 @@ interface MoveChannelParams {
  */
 export function useMoveChannel() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: MoveChannelParams): Promise<void> => {
@@ -513,6 +510,12 @@ export function useMoveChannel() {
       saveSpace(updatedSpace);
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
+
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
     },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
@@ -532,6 +535,7 @@ interface ReorderGroupsParams {
  */
 export function useReorderGroups() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: ReorderGroupsParams): Promise<void> => {
@@ -566,6 +570,12 @@ export function useReorderGroups() {
       saveSpace(updatedSpace);
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
+
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
     },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });
@@ -586,6 +596,7 @@ interface ReorderChannelsParams {
  */
 export function useReorderChannels() {
   const queryClient = useQueryClient();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: ReorderChannelsParams): Promise<void> => {
@@ -626,6 +637,12 @@ export function useReorderChannels() {
       saveSpace(updatedSpace);
       const adapter = getMMKVAdapter();
       await adapter.saveSpace(updatedSpace);
+
+      // Broadcast to all members (API + hub)
+      enqueueOutbound(async () => {
+        const result = await broadcastSpaceUpdate(updatedSpace);
+        return result ? [result.wsEnvelope] : [];
+      });
     },
     onSuccess: (_, params) => {
       queryClient.invalidateQueries({ queryKey: ['channels', params.spaceId] });


### PR DESCRIPTION
## What this fixes

Editing a channel or group on **mobile** (rename, delete, add, move, reorder) did not reach **desktop**, even after refresh. The reverse direction (desktop → mobile) already worked, so space sync looked one-directional.

## Root cause

`hooks/chat/useChannelManagement.ts` saved every mutation locally (`saveSpace` + MMKV) and stopped there. Unlike space-settings (space rename) and role mutations, it never broadcast the updated space manifest, so other devices never saw the change.

## Changes

1. **Broadcast channel/group mutations.** Add the existing broadcast pattern (`enqueueOutbound` → `broadcastSpaceUpdate`) to all channel/group mutations, matching `useSpaceSettings` and `useRoleManagement`. Fire-and-forget (a failed broadcast doesn't fail the local save); non-owners no-op silently, same as role management.

2. **Guard against stale incoming manifests.** While testing the above, a separate issue surfaced: the hub replays historical log entries on reconnect, so an *older* space manifest could overwrite a *newer* local change (a fresh rename snapping back to the old name). The inbound `space-manifest` handler now skips any manifest whose timestamp is older than the stored space. Fails open — first-seen and genuinely newer manifests always apply.

3. **Remove the unused `usePinChannel` hook** (no call sites).

## Testing

Runtime-verified on a physical Android device: renaming and deleting a channel on mobile now appears on desktop within seconds; space rename sticks on mobile (no snap-back). Lint passes; no new type errors.

## Notes

- Replaces #73 (which was conflicted, behind master, and mixed in unrelated changes).
- Channel **icons** still don't render across platforms — that's a separate icon-name vocabulary mismatch, not a sync issue. Tracked separately.
- A deeper improvement (per-field manifest merge instead of whole-object last-write-wins) is noted for follow-up; the staleness guard handles the common case.