### PR TITLE
Bridge synced profile fields (bio, public toggle) into user on mobile

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -49,6 +49,7 @@ export interface UserInfo {
   bio?: string;
   profileImage?: string;
   isProfilePublic?: boolean;    // Whether profile is visible to anyone (opt-in)
+  profileUpdatedAt?: number;    // ms epoch of last local profile write; used to decide whether a synced config (also Date.now()-stamped) is newer when bridging config -> user on login
   privacyLevel: PrivacyLevel;
   farcaster?: FarcasterInfo;
 }
@@ -307,15 +308,37 @@ export function AuthProvider({ children }: AuthProviderProps) {
               }
             })();
 
-            // Config sync runs in parallel with encryption setup
+            // Config sync runs in parallel with encryption setup.
+            //
+            // This is the config -> user read-back bridge. Synced config fields
+            // (name, profile_image, bio, isProfilePublic) arrive from the server
+            // but only name/profile_image were previously copied into `user`, so
+            // a value set on another device (e.g. the public-profile toggle)
+            // never reached this device's `user` and showed stale. We now also
+            // bridge bio + isProfilePublic.
+            //
+            // Precedence: config sync is last-write-wins by server timestamp
+            // (saveConfig stamps config.timestamp = Date.now()). Only let the
+            // remote config win for the synced toggle/text fields when it is
+            // newer than this device's last local profile write
+            // (profileUpdatedAt), so an unsynced fresh local change isn't
+            // clobbered. name/profile_image keep their original truthy-fill
+            // behavior to avoid regressing the working display-name sync.
             const configTask = (async () => {
               try {
                 const config = await getConfig(parsedUser.address);
-                if (config.name || config.profile_image) {
+                const configIsNewer =
+                  typeof config.timestamp === 'number' &&
+                  config.timestamp > (parsedUser.profileUpdatedAt ?? 0);
+                if (config.name || config.profile_image || configIsNewer) {
                   const updatedUser = {
                     ...parsedUser,
                     displayName: config.name || parsedUser.displayName,
                     profileImage: config.profile_image || parsedUser.profileImage,
+                    ...(configIsNewer && {
+                      bio: config.bio ?? parsedUser.bio,
+                      isProfilePublic: config.isProfilePublic ?? parsedUser.isProfilePublic,
+                    }),
                   };
                   setUser(updatedUser);
                   mmkvStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(updatedUser));
@@ -422,7 +445,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const updateProfile = useCallback((updates: Partial<UserInfo>) => {
     setUser((prev) => {
       if (!prev) return prev;
-      const updated = { ...prev, ...updates };
+      // Stamp the local write time so a later login can tell whether the
+      // synced config (also Date.now()-stamped in saveConfig) is newer than
+      // this device's last local change before overlaying it onto `user`.
+      const updated = { ...prev, ...updates, profileUpdatedAt: Date.now() };
       mmkvStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(updated));
 
       // Sync profile changes to server config (if allowSync is enabled)

--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -330,19 +330,53 @@ export function AuthProvider({ children }: AuthProviderProps) {
                 const configIsNewer =
                   typeof config.timestamp === 'number' &&
                   config.timestamp > (parsedUser.profileUpdatedAt ?? 0);
-                if (config.name || config.profile_image || configIsNewer) {
-                  const updatedUser = {
-                    ...parsedUser,
-                    displayName: config.name || parsedUser.displayName,
-                    profileImage: config.profile_image || parsedUser.profileImage,
+                if (!(config.name || config.profile_image || configIsNewer)) return;
+
+                // Privacy guard: for existing users we have no local write
+                // stamp yet, so a config that is merely "newer than 0" would
+                // win by default. Never let that silently turn a profile that
+                // is locally OFF back ON — an unexpected "public" is the worst
+                // failure direction for an opt-in privacy toggle. Once the user
+                // touches the setting again it gets a real stamp and normal
+                // LWW resumes.
+                const neverStamped = parsedUser.profileUpdatedAt === undefined;
+                const remotePublic = config.isProfilePublic ?? parsedUser.isProfilePublic;
+                const guardPublic =
+                  neverStamped && parsedUser.isProfilePublic === false && remotePublic
+                    ? false
+                    : remotePublic;
+
+                // Functional update + merge onto the freshest stored copy, so
+                // this doesn't clobber a concurrent write from farcasterPfpTask
+                // (which runs in parallel and also calls setUser).
+                setUser((prev) => {
+                  const base = prev ?? parsedUser;
+                  return {
+                    ...base,
+                    displayName: config.name || base.displayName,
+                    profileImage: config.profile_image || base.profileImage,
                     ...(configIsNewer && {
-                      bio: config.bio ?? parsedUser.bio,
-                      isProfilePublic: config.isProfilePublic ?? parsedUser.isProfilePublic,
+                      bio: config.bio ?? base.bio,
+                      isProfilePublic: guardPublic,
                     }),
                   };
-                  setUser(updatedUser);
-                  mmkvStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(updatedUser));
-                }
+                });
+
+                const raw = mmkvStorage.getItem(STORAGE_KEYS.USER);
+                const cur = raw ? (JSON.parse(raw) as UserInfo) : parsedUser;
+                const merged: UserInfo = {
+                  ...cur,
+                  displayName: config.name || cur.displayName,
+                  profileImage: config.profile_image || cur.profileImage,
+                  ...(configIsNewer && {
+                    bio: config.bio ?? cur.bio,
+                    isProfilePublic:
+                      neverStamped && cur.isProfilePublic === false && remotePublic
+                        ? false
+                        : remotePublic,
+                  }),
+                };
+                mmkvStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(merged));
               } catch (configError) {
               }
             })();


### PR DESCRIPTION
## What this does

On mobile, synced config fields (`name`, `profile_image`, `bio`, `isProfilePublic`) arrive from the server but only `name`/`profile_image` were copied into the in-memory `user` object on login. `bio` and `isProfilePublic` were saved to storage but never read back into `user`, so a value set on **another device** showed stale on **this device**.

This adds the config→user read-back bridge for `bio` and `isProfilePublic`, with timestamp-based precedence and a privacy guard.

## Direction this fixes (please note)

This fixes the **other-device → this-mobile-device** direction: a change made elsewhere (e.g. desktop) is now picked up by mobile on next launch.

It does **NOT** fix the originally-reported `isProfilePublic` **mobile → desktop** bug. Investigation during this PR showed that bug is **desktop-side**: desktop only server-fetches config at app startup (no periodic/foreground/websocket refetch), so it shows a stale cached value until restart. Mobile already sends `isProfilePublic` correctly and desktop reads it correctly — the gap is desktop's refetch. Filed separately.

## Changes (`context/AuthContext.tsx`)

1. **Read-back bridge** in `configTask`: overlay `bio` + `isProfilePublic` from synced config onto `user` on login.
2. **Timestamp precedence**: remote config wins for those fields only when `config.timestamp` > this device's last local profile write (`profileUpdatedAt`), mirroring config sync's own last-write-wins. Avoids clobbering a fresh offline change.
3. **Privacy guard**: a never-stamped (existing) user's locally-OFF public toggle can't be silently turned ON by a stale remote.
4. **Functional `setUser` + MMKV merge**: avoids clobbering the parallel Farcaster-pfp write.
5. `updateProfile` stamps `profileUpdatedAt` on each profile write.

## Scope

- `primaryUsername` is **not** bridged yet — its `UserConfig` field landed in quorum-shared 2.1.0-30 (merged) but isn't published to npm / consumed by mobile yet. Once it is, bridging it is a one-line addition next to `bio`/`isProfilePublic`.
- Caveat: the bridge runs at login. A foreground re-sync (so changes apply without a relaunch) is a sensible follow-up.

## Testing

Lint passes; no new type errors vs. the pre-existing baseline. JS-only (no native rebuild). Code-reviewed (race + privacy-guard findings addressed).