### PR TITLE
fix: channel list shows saved icon

### DIFF
--- a/app/(tabs)/spaces/[id]/index.tsx
+++ b/app/(tabs)/spaces/[id]/index.tsx
@@ -5,7 +5,7 @@
  * Header provides quick access to settings and invite.
  */
 
-import { IconSymbol } from '@/components/ui/IconSymbol';
+import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
 import { useChannels } from '@/hooks/chat/useChannels';
 import { useReplyTracking } from '@/hooks/chat/useReplyTracking';
 import { useSpace } from '@/hooks/chat/useSpaces';
@@ -115,7 +115,11 @@ export default function SpaceChannelsScreen() {
                   onPress={() => handleSelectChannel(channel.channelId)}
                   activeOpacity={0.6}
                 >
-                  <IconSymbol name="number" size={18} color={theme.colors.textMuted} />
+                  <IconSymbol
+                    name={(channel.icon || 'number') as IconSymbolName}
+                    size={18}
+                    color={channel.iconColor || theme.colors.textMuted}
+                  />
                   <Text style={styles.channelName} numberOfLines={1}>
                     {channel.channelName}
                   </Text>


### PR DESCRIPTION
## What

The space channel list always rendered the default hashtag, even when a channel had a custom icon set in its settings.

## Root cause

The channel row in `app/(tabs)/spaces/[id]/index.tsx` hardcoded `<IconSymbol name="number" ... />` and never read the channel's own `icon` / `iconColor`.

## Fix

Read `channel.icon` / `channel.iconColor` (falling back to the hashtag and the muted color). A custom icon + color set in channel settings now shows in the list.

## Scope / caveat

Surfaces icons set **on mobile**. A desktop-set icon (Tabler name) may still not resolve in the list until the icon-name vocabulary is unified across platforms (separate, deferred work). One-line change; lint + type-check clean.