### PR TITLE
Harden unsupported message type handling (default-deny)

### DIFF
--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -162,7 +162,10 @@ export const DMChatArea = React.memo(function DMChatArea({
   const dmMessages = useMemo(() => {
     if (!dmMessagesPages) return [];
     const allMessages = flattenMessages(dmMessagesPages.pages);
-    return allMessages.map((msg: Message) => toDisplayMessage(msg, effectiveDmMemberMap, user?.address));
+    // Drop 'unsupported' rows (no render branch) so they never reach the list.
+    return allMessages
+      .map((msg: Message) => toDisplayMessage(msg, effectiveDmMemberMap, user?.address))
+      .filter((m) => m.renderType !== 'unsupported');
   }, [dmMessagesPages, effectiveDmMemberMap, user?.address]);
 
   const dmSearch = useMessageSearch(dmMessages);

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1066,6 +1066,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
           return renderCast(item);
         case 'error':
           return renderErrorMessage(item);
+        case 'unsupported':
+          // Defense-in-depth: filtered out upstream, so unreachable in practice.
+          // If one slips through, render nothing rather than a phantom 'post' bubble.
+          return null;
         case 'post':
         default:
           return renderPostMessage(item);

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -288,7 +288,9 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
       }
     }
     out.sort((a, b) => a.timestamp - b.timestamp);
-    return filterMutedMessages(out);
+    // Drop 'unsupported' rows (no render branch) so they never reach the list.
+    const supported = out.filter((m) => m.renderType !== 'unsupported');
+    return filterMutedMessages(supported);
   }, [
     messagesPages,
     effectiveMemberMap,
@@ -764,7 +766,9 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         <PinnedMessagesPanel
           visible={pinnedMessagesPanelVisible}
           onClose={() => setPinnedMessagesPanelVisible(false)}
-          pinnedMessages={(pinnedMessages ?? []).map((msg: Message) => toDisplayMessage(msg, effectiveMemberMap, user?.address))}
+          pinnedMessages={(pinnedMessages ?? [])
+            .map((msg: Message) => toDisplayMessage(msg, effectiveMemberMap, user?.address))
+            .filter((m) => m.renderType !== 'unsupported')}
           onUnpin={hasPinPermission ? handleUnpinMessage : undefined}
           onNavigateToMessage={(messageId: string) => {
             spaceMessagesListRef.current?.scrollToMessage(messageId, true);

--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -19,7 +19,50 @@ export type MessageRenderType =
   | 'call-event'  // Voice/video call event (1-to-1)
   | 'space-call'  // Space (group) call indicator
   | 'cast'        // Farcaster cast from a linked channel
-  | 'error';      // Malformed message — surfaced inline so prod issues are visible without logs
+  | 'error'       // Malformed message — surfaced inline so prod issues are visible without logs
+  | 'unsupported'; // Known-but-unrendered or genuinely unknown type — filtered out of the list, never bubble-rendered
+
+/**
+ * Default-deny allowlist of types mobile persists AND renders. Single source of
+ * truth shared by the receive paths (WebSocketContext live + batch) and the
+ * render fallback below. Anything not here fails closed: dropped before save,
+ * and mapped to 'unsupported' (then filtered out) if a pre-fix build persisted
+ * it — so a new/unrecognized desktop type produces nothing, not a junk bubble.
+ * Applied types (reaction/edit/remove/update-profile) and dropped control types
+ * (pin/mute/thread) are excluded because they never reach the save path.
+ */
+export const PERSISTABLE_TYPES: ReadonlySet<string> = new Set([
+  'post',
+  'embed',
+  'sticker',
+  'join',
+  'leave',
+  'kick',
+  'event',
+  'call-event',
+  'space-call-start',
+  'space-call-end',
+]);
+
+// Invariant: every persistable type must have a real render branch in
+// getMessageRenderType (i.e. not fall through to 'unsupported'), or the receive
+// path would save it while the render path filters it out — a message that
+// exists on disk but is invisible. The reverse (a render branch with no set
+// membership) is intentional for applied types (remove-message -> 'deleted')
+// that are consumed before the save path, so it isn't checked here. Dev-only;
+// stripped from production bundles by the `__DEV__` guard.
+if (__DEV__) {
+  for (const t of PERSISTABLE_TYPES) {
+    const rt = getMessageRenderType({ content: { type: t } } as unknown as SharedMessage);
+    if (rt === 'unsupported') {
+      // eslint-disable-next-line no-console
+      console.error(
+        `[Chat/types] PERSISTABLE_TYPES contains '${t}' but getMessageRenderType maps it to 'unsupported' — ` +
+        `add a render branch or remove it from PERSISTABLE_TYPES.`
+      );
+    }
+  }
+}
 
 // Reaction display info
 export interface DisplayReaction {
@@ -264,8 +307,13 @@ export function getMessageRenderType(message: SharedMessage): MessageRenderType 
     case 'space-call-start':
     case 'space-call-end':
       return 'space-call';
-    default:
+    case 'post':
       return 'post';
+    default:
+      // Default-deny: unknown types map to 'unsupported' (not 'post', which made
+      // phantom empty bubbles). Catches types persisted by an older build; the
+      // chat areas filter 'unsupported' out before the list.
+      return 'unsupported';
   }
 }
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -18,6 +18,7 @@ import {
   queryKeys,
 } from '@quilibrium/quorum-shared';
 import { useQueryClient } from '@tanstack/react-query';
+import { PERSISTABLE_TYPES } from '@/components/Chat/types';
 import React, {
   createContext,
   useCallback,
@@ -2033,18 +2034,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               return;
             }
 
-            // Unsupported control messages. Mobile has no handler for pin,
-            // mute, or thread control messages yet (pin/mute exist locally but
-            // don't sync from desktop; threads are unimplemented). Without this
-            // they fall through to the generic save below and render as junk
-            // chat bubbles (the renderer defaults unknown types to 'post').
-            // Drop them. Receiving + applying these is separate future feature
-            // work (pin-sync / mute-sync / threads), not done here.
-            if (
-              contentType === 'pin' ||
-              contentType === 'mute' ||
-              contentType === 'thread'
-            ) {
+            // Default-deny: only PERSISTABLE_TYPES reach saveMessage. Runs after
+            // the applied-type handlers above (reaction/edit/remove/update-profile,
+            // which all return earlier) and before the save. Subsumes the old
+            // pin/mute/thread guard plus any future type mobile doesn't yet render;
+            // opting one in means adding it to PERSISTABLE_TYPES + a render branch.
+            if (contentType && !PERSISTABLE_TYPES.has(contentType)) {
+              logger.debug(`[SpaceMsg] default-deny dropped unsupported type=${contentType}`);
               if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
                 deleteSpaceInboxMessages(
                   spaceInboxKey.address,
@@ -3221,13 +3217,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           }
 
           if (contentType === 'update-profile') {
-            // Mirror of the legacy handler at the top of this file. Without
-            // this branch the batch path falls through to the "Regular
-            // message" save below and the profile broadcast renders as a
-            // chat post (getMessageRenderType defaults unknown types to
-            // 'post'). The once-per-launch profile re-broadcast that fires
-            // on every connect would then spam every space with a phantom
-            // message every time anyone opened the app.
+            // Mirror of the live handler. Must run BEFORE the default-deny:
+            // update-profile is an applied type, not persistable, so without this
+            // the connect-time profile re-broadcast would be dropped and the
+            // member's profile update would never reach this device.
             const profileContent = spaceMessage.content as {
               senderId: string;
               displayName?: string;
@@ -3278,15 +3271,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             continue;
           }
 
-          // Unsupported control messages (pin/mute/thread) — same as the live
-          // path: mobile has no handler, so drop them before the generic save
-          // to avoid junk chat bubbles. Receiving/applying these is future
-          // feature work, not done here.
-          if (
-            contentType === 'pin' ||
-            contentType === 'mute' ||
-            contentType === 'thread'
-          ) {
+          // Default-deny — identical rule to the live path, same PERSISTABLE_TYPES
+          // set (no divergence). Runs after the applied-type handlers that
+          // `continue` earlier.
+          if (contentType && !PERSISTABLE_TYPES.has(contentType)) {
+            logger.debug(`[BatchMsg] default-deny dropped unsupported type=${contentType}`);
             continue;
           }
 


### PR DESCRIPTION
## What

Converts mobile's protection against unrecognized message types from a fragile allowlist-by-omission into an explicit **default-deny**. Previously only `pin`/`mute`/`thread` were explicitly dropped; everything else fell through to storage and, if mobile had no render branch for it, showed as a phantom empty bubble (sender + timestamp, blank body). The renderer defaulted unknown types to `'post'`.

## Changes

- **Single source of truth:** new `PERSISTABLE_TYPES` set in `components/Chat/types.ts` lists the types mobile both persists and renders.
- **Receive side (`context/WebSocketContext.tsx`):** both the live and batch space-message paths now drop any type not in `PERSISTABLE_TYPES` before `storage.saveMessage`, using the same shared set (no divergence). This subsumes the old `pin/mute/thread` guard and any future unknown type. Applied types (reaction/edit/remove/update-profile) still run and return before the gate.
- **Render side:** `getMessageRenderType` now maps unknown types to a new `'unsupported'` render type instead of `'post'`; `SpaceChatArea`, `DMChatArea`, and the pinned-messages panel filter those rows out of the list. Catches junk persisted by an older build. A `MessagesList` switch case returns `null` as defense-in-depth.
- **Drift guard:** a `__DEV__`-only invariant errors if a persistable type maps to `'unsupported'` (i.e. the set and the render switch fall out of sync). Stripped from production bundles.

## Verification

- `tsc --noEmit`: no new type errors (touched-file errors unchanged from the master baseline).
- Logic traced + reviewed across multiple angles: applied types return before the gate; `remove-message` is consumed before the gate; no circular import; `post`/`embed`/`sticker` all pass the allowlist.

### Runtime verification gap (please note)

The task flagged `runtime_test: required`. Mobile-local sends were exercised, but the **desktop -> mobile** acceptance criteria (rendered types rendering, applied types like react/edit/delete/profile-update from desktop) **could not be runtime-verified** because desktop -> mobile messaging is currently broken by an unrelated crypto bug: incoming space messages fail native Double-Ratchet decryption (`decrypt_failed`) and are dropped before any code in this PR runs. That issue is tracked separately and is not caused by this change.

Blast radius is small and fail-safe: the change cannot crash or corrupt data; the degenerate case is an unrecognized type rendering as nothing instead of an empty junk bubble (the intended improvement).

## Follow-ups (out of scope, tracked separately)

- Extend the same default-deny to the DM receive path (currently render-filtered only; blocked on a shared-package publish for DM update-profile).
- `messagePreview` returns empty for `call-event`/`space-call-*` in the inbox (pre-existing).