### PR TITLE
Bump quorum-shared 2.1.0-26 to 2.1.0-29

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@polkadot/keyring": "14.0.1",
     "@polkadot/util": "14.0.1",
     "@polkadot/util-crypto": "14.0.1",
-    "@quilibrium/quorum-shared": "2.1.0-26",
+    "@quilibrium/quorum-shared": "2.1.0-29",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "7.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,10 +1952,10 @@
     tslib "^2.8.0"
     ws "^8.18.0"
 
-"@quilibrium/quorum-shared@2.1.0-26":
-  version "2.1.0-26"
-  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-26.tgz#e7b5c7b720b2ebdafd082b05daac034b19b6dbfc"
-  integrity sha512-znD4NejhabOOHcfh3HUcVqv/Jfm9HIFjQKi+rEVzFFFv6AW0+LOioHzijAUd2TZY454rYEcq3OEjFaVXYypegA==
+"@quilibrium/quorum-shared@2.1.0-29":
+  version "2.1.0-29"
+  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-29.tgz#fc056918c77d9e4ba17a67d891b13546663cbba7"
+  integrity sha512-rigQ1QW/wNE1NTLkI4FfRieAD67GqX04Qlxjnm5tBEcG9T6XWLGBol3HP7hwJd0zHzRDHM7PqQg42HMosSMPVg==
   dependencies:
     "@noble/hashes" "1.8.0"
     dayjs "1.11.19"


### PR DESCRIPTION
## What

Bumps `@quilibrium/quorum-shared` from `2.1.0-26` to `2.1.0-29` (the latest published version).

## Why

The published `2.1.0-26` shipped a **stale dist**: its compiled `dist/` lagged its source, so types added at the source level (e.g. `Conversation.bio`) were missing from the `.d.ts` files mobile actually resolves. `2.1.0-29` ships a correctly-built dist that includes them.

`2.1.0-29` is internally consistent (not stale like `-26`); it is simply an older line than the local `2.1.0-30` source. It does **not** yet include `DMUpdateProfileMessage` (added after `-29`), so it does not unblock the DM update-profile port — that still needs a newer published version.

## Verification

- Registry-pinned (no local linking). `yarn install` resolves `-29` from the registry; lockfile updated.
- `tsc --noEmit`: no new type errors (project error count unchanged from the master baseline; zero shared-related errors).