### PR TITLE
fix: mobile join signature joinedat

### DIFF
--- a/hooks/chat/useSpaceActions.ts
+++ b/hooks/chat/useSpaceActions.ts
@@ -582,10 +582,15 @@ export function useJoinSpace() {
             const identityKeyHex = bytesToHex(deviceKeyset.identityPublicKey);
             const preKeyHex = bytesToHex(deviceKeyset.preKeyPublicKey);
 
-            // Build the message to sign (same as desktop)
-            // address + id + inboxAddress + pubKey + inboxKey + identityKey + preKey + userIcon + displayName
+            // Build the message to sign (must match desktop byte-for-byte).
+            // Desktop signs a 10-field blob ending in joinedAt (InvitationService.ts:826-838);
+            // mobile previously signed only 9 fields (stopping at displayName), so desktop's
+            // verify always failed and never saved us as a space member. Append joinedAt last.
+            // address + id + inboxAddress + pubKey + inboxKey + identityKey + preKey + userIcon + displayName + joinedAt
             const userIcon = user?.profileImage || '';
             const displayName = user?.displayName || user?.username || '';
+            // Mint once so the signed value and the wire value are identical.
+            const joinedAt = Date.now();
             const msgToSign = user!.address +
               ratchet.id +
               inboxAddress +
@@ -594,8 +599,13 @@ export function useJoinSpace() {
               identityKeyHex +
               preKeyHex +
               userIcon +
-              displayName;
-            const msgToSignBase64 = btoa(msgToSign);
+              displayName +
+              joinedAt;
+            // UTF-8 base64 to match desktop's Buffer.from(str,'utf-8').toString('base64').
+            // (Plain btoa() is latin1 and throws/diverges on non-ASCII display names or pfp URLs.)
+            const msgToSignBase64 = numberArrayToBase64(
+              Array.from(new TextEncoder().encode(msgToSign))
+            );
 
             // Sign with the inbox private key (Ed448)
             const inboxPrivateKeyBase64 = numberArrayToBase64(inboxKeypair.private_key);
@@ -612,6 +622,7 @@ export function useJoinSpace() {
               preKey: preKeyHex,
               userIcon: userIcon,
               displayName: displayName,
+              joinedAt,
               signature: signatureBase64,
             };
 

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -468,6 +468,7 @@ export interface JoinParticipant {
   preKey: string;       // Pre-key public key (hex)
   userIcon: string;
   displayName: string;
+  joinedAt: number;     // Join timestamp (ms since epoch) — must be in the signed blob (desktop verifies it)
   signature: string;    // Ed448 signature (base64)
 }
 


### PR DESCRIPTION
When a mobile user joins a space, mobile broadcasts a signed "join" message. Desktop verifies that signature over a 10-field blob ending in a `joinedAt` timestamp before saving the member. Mobile signed only 9 fields and omitted `joinedAt`, so desktop's verify always failed for mobile joins and never created the member row — mobile users rendered on desktop as a truncated 6-char address with a blank avatar instead of their real name/pfp.

This aligns mobile's join with desktop:
- Add `joinedAt` to the `JoinParticipant` interface and the participant object so it goes out on the wire.
- Append `joinedAt` as the last field of the signed blob, matching desktop's field order.
- Switch the signed-string encoding from latin1 `btoa` to UTF-8 base64 so non-ASCII display names and pfp URLs match desktop byte-for-byte.

Statically verified: tsc and lint clean (no new errors), field order matches desktop, and the UTF-8 base64 helper was confirmed equal to Node's `Buffer.from(str,'utf-8').toString('base64')` for ASCII, accented, and emoji inputs.

Note: old mobile builds still sign the previous 9-field format. Joins are transient announcements (not stored signed state), so old vs new builds signing differently during rollout is expected and needs no migration.