### PR TITLE
Render and send images as post + embeddedMedia

### DIFF
--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -416,8 +416,32 @@ export function toDisplayMessage(
     if (content.height) displayMessage.mediaHeight = parseInt(content.height, 10);
   }
 
-  // Check for embedded image URLs in post text (e.g., from desktop sending "[Media]" with URL)
-  if (content.type === 'post' && displayMessage.content) {
+  // Desktop (and converged mobile) sends a captioned/standalone image as a
+  // `post` with the image bytes inlined in `content.embeddedMedia`, NOT as an
+  // `embed`. Extract the image here so it renders through the existing embed
+  // image path; the `post.text` stays as the caption (already in
+  // displayMessage.content via getMessageText).
+  let renderedEmbeddedMedia = false;
+  if (content.type === 'post' && Array.isArray(content.embeddedMedia) && content.embeddedMedia.length > 0) {
+    const media = content.embeddedMedia;
+    const image = media.find((m) => m.type === 'image');
+    if (image) {
+      // Match a thumbnail to the full image by shared `key` (the large-GIF /
+      // thumbnailed case). data is raw base64 (no data: prefix) — wrap it.
+      const thumbnail = media.find((m) => m.type === 'image-thumbnail' && m.key === image.key);
+      displayMessage.renderType = 'embed';
+      displayMessage.imageUrl = `data:${image.mimeType};base64,${image.data}`;
+      if (thumbnail) {
+        displayMessage.thumbnailUrl = `data:${thumbnail.mimeType};base64,${thumbnail.data}`;
+      }
+      renderedEmbeddedMedia = true;
+    }
+  }
+
+  // Back-compat: older desktop builds sent images as "[Media]" + an inline
+  // image URL in the post text. Only scan when embeddedMedia didn't already
+  // produce an image, so we don't double-handle a converged message.
+  if (!renderedEmbeddedMedia && content.type === 'post' && displayMessage.content) {
     const embeddedImages = extractImageUrls(displayMessage.content);
     if (embeddedImages.length > 0) {
       // Upgrade to embed render type and extract the image

--- a/hooks/chat/useSendEmbedMessage.ts
+++ b/hooks/chat/useSendEmbedMessage.ts
@@ -4,9 +4,9 @@
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth, useWebSocket } from '@/context';
-import { sendEmbedMessage } from '@/services/space/spaceMessageService';
+import { sendEmbedMessage, buildPostWithEmbeddedMedia } from '@/services/space/spaceMessageService';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
-import type { Message, GetMessagesResult, EmbedMessage } from '@quilibrium/quorum-shared';
+import type { Message, GetMessagesResult } from '@quilibrium/quorum-shared';
 
 export interface UseSendEmbedMessageParams {
   spaceId: string;
@@ -78,15 +78,14 @@ export function useSendEmbedMessage() {
         createdDate: timestamp,
         modifiedDate: timestamp,
         lastModifiedHash: '',
-        content: {
-          type: 'embed',
-          senderId: user.address,
-          imageUrl: params.imageUrl,
-          thumbnailUrl: params.thumbnailUrl,
-          width: params.width?.toString(),
-          height: params.height?.toString(),
-          text: params.text,
-        } as EmbedMessage & { text?: string },
+        // Mirror the sent shape (post + embeddedMedia) so the sender's own
+        // optimistic row renders through the same path as the received message.
+        content: buildPostWithEmbeddedMedia(
+          user.address,
+          params.imageUrl,
+          params.thumbnailUrl,
+          params.text
+        ),
         reactions: [],
         mentions: { memberIds: [], roleIds: [], channelIds: [] },
         sendStatus: 'sending',

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -962,7 +962,27 @@ export interface SendEmbedMessageParams {
 }
 
 /**
- * Send an embed message (image/video)
+ * Split a base64 data URL ("data:<mime>;base64,<data>") into its mimeType and
+ * raw base64 payload. Returns null if the input is not a base64 data URL
+ * (e.g. a remote http(s) URL), in which case there is nothing to inline.
+ */
+function parseDataUrl(dataUrl: string): { mimeType: string; data: string } | null {
+  const match = /^data:([^;]+);base64,(.*)$/s.exec(dataUrl);
+  if (!match) return null;
+  return { mimeType: match[1], data: match[2] };
+}
+
+/**
+ * Send an image as a `post` + `embeddedMedia` (the converged cross-platform
+ * shape — see .agents/tasks/2026-06-13-converge-image-caption-to-post-embeddedmedia.md).
+ *
+ * Desktop already emits this shape and mobile's renderer reads `embeddedMedia`
+ * (toDisplayMessage). We stop emitting `type:'embed'` for sending; the embed
+ * renderer stays for receiving old persisted `embed` messages.
+ *
+ * `imageUrl`/`thumbnailUrl` arrive as base64 data URLs; we inline the raw
+ * base64 in `embeddedMedia[].data` exactly like desktop (thumbnail entry first
+ * when present, then the full image, sharing one `key`).
  */
 export async function sendEmbedMessage(
   params: SendEmbedMessageParams
@@ -972,27 +992,55 @@ export async function sendEmbedMessage(
     channelId,
     senderAddress,
     imageUrl,
-    videoUrl,
     thumbnailUrl,
-    width,
-    height,
     repliesToMessageId,
     text,
   } = params;
 
-  const content: EmbedMessage & { text?: string } = {
-    type: 'embed',
-    senderId: senderAddress,
-    imageUrl,
-    videoUrl,
-    thumbnailUrl,
-    width,
-    height,
-    repliesToMessageId,
-    text,
-  };
-
+  const content = buildPostWithEmbeddedMedia(senderAddress, imageUrl, thumbnailUrl, text, repliesToMessageId);
   return sendGenericMessage({ spaceId, channelId, senderAddress, content });
+}
+
+/**
+ * Build the `post` + `embeddedMedia` content from base64-data-URL image inputs.
+ * Shared by the send path and the optimistic-update path so the local sender
+ * and remote receiver render identically. Falls back to a plain `post` (no
+ * media) if `imageUrl` is missing or not an inlinable data URL.
+ */
+export function buildPostWithEmbeddedMedia(
+  senderAddress: string,
+  imageUrl?: string,
+  thumbnailUrl?: string,
+  text?: string,
+  repliesToMessageId?: string
+): PostMessage {
+  const embeddedMedia: NonNullable<PostMessage['embeddedMedia']> = [];
+  const image = imageUrl ? parseDataUrl(imageUrl) : null;
+  if (image) {
+    // One shared key links the thumbnail to its full image (the large-GIF case).
+    const key = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+    const thumb = thumbnailUrl ? parseDataUrl(thumbnailUrl) : null;
+    // Only emit a thumbnail entry when it's DISTINCT from the full image.
+    // Mobile's GIF processing sets thumbnailUrl === imageUrl (no separate static
+    // frame is generated), so a thumbnail entry there would just duplicate the
+    // full GIF bytes on the wire AND make receivers read it as a thumbnailed
+    // "large GIF". Dropping the duplicate avoids the double payload and the
+    // mis-classification. (GIF animation itself is a separate, pre-existing
+    // render concern — see the GIF bug report.)
+    if (thumb && thumb.data !== image.data) {
+      embeddedMedia.push({ type: 'image-thumbnail', key, data: thumb.data, mimeType: thumb.mimeType });
+    }
+    embeddedMedia.push({ type: 'image', key, data: image.data, mimeType: image.mimeType });
+  }
+
+  const content: PostMessage = {
+    type: 'post',
+    senderId: senderAddress,
+    text: text ?? '',
+    ...(repliesToMessageId ? { repliesToMessageId } : {}),
+    ...(embeddedMedia.length > 0 ? { embeddedMedia } : {}),
+  };
+  return content;
 }
 
 // Space Call Messages


### PR DESCRIPTION
## What

Mobile now reads `embeddedMedia` on `post` messages, so captioned and standalone images sent from desktop render on mobile. Previously mobile only knew how to pull an image off `type:'embed'` messages, so a desktop `post` + `embeddedMedia` rendered as caption text only — the image was silently dropped.

Mobile also now **sends** images as `post` + `embeddedMedia` (matching desktop) instead of the legacy `embed` type. The `embed` render path is kept so old persisted `embed` messages still display.

## Changes
- `components/Chat/types.ts` — `toDisplayMessage` reads `content.embeddedMedia` on a `post`, builds the image data-URI, renders via the existing embed image path. Caption stays as the post text. Legacy text-URL scan kept for back-compat.
- `services/space/spaceMessageService.ts` — new `buildPostWithEmbeddedMedia` helper; `sendEmbedMessage` now emits `post` + `embeddedMedia`. A thumbnail identical to the full image (mobile's GIF case) is not duplicated on the wire.
- `hooks/chat/useSendEmbedMessage.ts` — optimistic message uses the same builder so the sender's own bubble matches what receivers get.

## Verification
- ✅ tsc clean (no new errors), lint clean on changed files.
- ✅ `post` is signed/canonicalized over text only on both apps — `embeddedMedia` is not part of the messageId, so no signature divergence.
- ✅ mobile → desktop image + caption confirmed at runtime.
- ⚠️ desktop → mobile render is statically verified but not runtime-confirmed: a separate, pre-existing delivery issue prevents the test account from receiving any desktop messages. The render change is purely additive (new branch for a field mobile currently ignores) so it can't affect existing message types.
- ℹ️ GIFs still render static in mobile chat — this is pre-existing (mobile has never animated chat GIFs) and out of scope; tracked separately.