### PR TITLE
User profile modal improvements

### DIFF
--- a/app/(tabs)/spaces/[id]/[channelId].tsx
+++ b/app/(tabs)/spaces/[id]/[channelId].tsx
@@ -6,8 +6,10 @@ import { SpaceChatArea, type MemberMap, type MessageUserInfo } from '@/component
 import { useAuth } from '@/context/AuthContext';
 import { useMiniappOverlay } from '@/context/MiniappOverlayContext';
 import { useChannels } from '@/hooks/chat/useChannels';
-import { useHasPermission } from '@/hooks/chat/useRoleManagement';
+import { useHasPermission, useRoles } from '@/hooks/chat/useRoleManagement';
 import { useReplyTracking, setActiveChannel, clearActiveChannel } from '@/hooks/chat/useReplyTracking';
+import { useStartDirectMessage } from '@/hooks/chat/useStartDirectMessage';
+import { useUserMuting } from '@/hooks/chat/useUserMuting';
 import { useSpace, useSpaceMembers } from '@/hooks/chat/useSpaces';
 import { useBookmarks } from '@/hooks/useUserConfig';
 import { getSpaceKey } from '@/services/config/spaceStorage';
@@ -47,6 +49,8 @@ export default function SpaceChannelChat() {
   const { data: channelsData } = useChannels(spaceId, { enabled: !!spaceId });
 
   const { bookmarks, addBookmark, removeBookmark, isBookmarked } = useBookmarks();
+  const startDirectMessage = useStartDirectMessage();
+  const { toggleMuteUser, isUserMuted } = useUserMuting(spaceId);
 
   const isSpaceOwner = useMemo(() => {
     if (!spaceId) return false;
@@ -57,6 +61,11 @@ export default function SpaceChannelChat() {
   const hasRoleDelete = useHasPermission(spaceId, user?.address, 'message:delete');
   const hasPinPermission = hasRolePin || isSpaceOwner;
   const hasDeletePermission = hasRoleDelete || isSpaceOwner;
+
+  // The space's roles, passed to UserProfileModal so the owner can assign /
+  // remove roles from a member's profile (tapped from a message avatar).
+  // Without this prop the modal's role section never renders.
+  const { data: roles } = useRoles(spaceId);
 
   // The current channel object (not just its name). Read-only channels need
   // isReadOnly + managerRoleIds to gate posting.
@@ -277,7 +286,14 @@ export default function SpaceChannelChat() {
             onClose={() => setSelectedUserProfile(null)}
             user={selectedUserProfile}
             spaceId={spaceId}
+            roles={roles}
             isSpaceOwner={isSpaceOwner}
+            onStartDM={(userId) => {
+              setSelectedUserProfile(null);
+              startDirectMessage(userId);
+            }}
+            onMuteUser={(userId) => toggleMuteUser(userId)}
+            isUserMuted={isUserMuted(selectedUserProfile.userId)}
             onOpenFarcasterProfile={({ fid, username }) => {
               setSelectedUserProfile(null);
               router.push({

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -43,6 +43,8 @@ import {
   useReorderChannels,
 } from '@/hooks/chat';
 import { useSpaceMembers } from '@/hooks/chat/useSpaces';
+import { useStartDirectMessage } from '@/hooks/chat/useStartDirectMessage';
+import { useUserMuting } from '@/hooks/chat/useUserMuting';
 import { useDeleteSpace, useLeaveSpace, useUpdateSpace } from '@/hooks/chat/useSpaceSettings';
 import { useSpaceApexConfig, useSetSpaceApexConfig } from '@/hooks/useApex';
 import { useWalletSelection } from '@/hooks/useWalletSelection';
@@ -64,7 +66,10 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import { truncateAddress } from '@/utils/formatAddress';
 import { hexToBytes, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
 import * as Clipboard from 'expo-clipboard';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import type { UserProfileInfo } from '@/components/UserProfileModal';
+
+const UserProfileModal = React.lazy(() => import('@/components/UserProfileModal'));
 import { ActivityIndicator, Alert, Dimensions, Image, ScrollView, StyleSheet, Switch, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -487,6 +492,18 @@ export default function SpaceSettingsModal({
     const ownerKey = getSpaceKey(spaceId, 'owner');
     return !!ownerKey;
   }, [spaceId]);
+
+  // Tapping a member avatar opens their profile (same as tapping an avatar on
+  // a message). This is the members-list entry point for viewing a profile,
+  // messaging/muting the user, and — for owners — assigning/removing roles.
+  const [selectedUserProfile, setSelectedUserProfile] = useState<UserProfileInfo | null>(null);
+  const startDirectMessage = useStartDirectMessage();
+  // Own the mute logic locally (same hook the channel screen uses) so the
+  // members-list profile modal can Mute/Unmute regardless of whether the
+  // parent passed mute props. Falls back to the parent props if provided.
+  const { toggleMuteUser: localToggleMuteUser, isUserMuted: localIsUserMuted } = useUserMuting(spaceId);
+  const toggleMuteUser = onToggleMuteUser ?? localToggleMuteUser;
+  const isUserMutedFn = isUserMuted ?? localIsUserMuted;
 
   // Load space data
   const [space, setSpace] = useState<Space | null>(null);
@@ -1717,6 +1734,7 @@ export default function SpaceSettingsModal({
 
 
   const renderMembersTab = () => (
+    <>
     <ScrollView
       style={styles.membersScrollView}
       showsVerticalScrollIndicator={true}
@@ -1731,7 +1749,26 @@ export default function SpaceSettingsModal({
           const memberRoles = getMemberRoles(member.address);
           return (
             <View key={member.address} style={styles.memberItem}>
-              <View style={styles.memberAvatar}>
+              <TouchableOpacity
+                style={styles.memberAvatar}
+                activeOpacity={0.7}
+                onPress={() => {
+                  // Enrich with fields the SpaceMember record carries that the
+                  // shared type doesn't declare (farcaster linkage).
+                  const m = member as typeof member & {
+                    farcasterFid?: number;
+                    farcasterUsername?: string;
+                  };
+                  setSelectedUserProfile({
+                    userId: member.address,
+                    userName: member.display_name || member.name || truncateAddress(member.address),
+                    userAvatar: member.profile_image,
+                    bio: member.bio,
+                    farcasterFid: m.farcasterFid,
+                    farcasterUsername: m.farcasterUsername,
+                  });
+                }}
+              >
                 {member.profile_image ? (
                   <Image source={{ uri: member.profile_image }} style={styles.memberAvatarImage} />
                 ) : (
@@ -1741,7 +1778,7 @@ export default function SpaceSettingsModal({
                     size={44}
                   />
                 )}
-              </View>
+              </TouchableOpacity>
               <View style={styles.memberInfo}>
                 <Text style={styles.memberName}>
                   {member.display_name || member.name || truncateAddress(member.address)}
@@ -1804,6 +1841,26 @@ export default function SpaceSettingsModal({
           </View>
         )}
     </ScrollView>
+
+    {selectedUserProfile && (
+      <Suspense fallback={null}>
+        <UserProfileModal
+          visible
+          onClose={() => setSelectedUserProfile(null)}
+          user={selectedUserProfile}
+          spaceId={spaceId}
+          roles={roles}
+          isSpaceOwner={isSpaceOwner}
+          onStartDM={(userId) => {
+            setSelectedUserProfile(null);
+            startDirectMessage(userId);
+          }}
+          onMuteUser={(userId) => toggleMuteUser(userId)}
+          isUserMuted={isUserMutedFn(selectedUserProfile.userId)}
+        />
+      </Suspense>
+    )}
+    </>
   );
 
   const renderChannelsTab = () => (

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -1,7 +1,9 @@
 import { BaseModal } from '@/components/shared';
+import { KickUserModal } from '@/components/KickUserModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
+import { useAuth } from '@/context';
 import { useToast } from '@/context/ToastContext';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import { truncateAddress } from '@/utils/formatAddress';
@@ -57,8 +59,10 @@ export default function UserProfileModal({
 }: UserProfileModalProps) {
   const { theme, isDark } = useTheme();
   const { showToast } = useToast();
+  const { user: authUser } = useAuth();
   const insets = useSafeAreaInsets();
   const [loadingRoles, setLoadingRoles] = useState<Set<string>>(new Set());
+  const [kickVisible, setKickVisible] = useState(false);
 
   const assignRoleMutation = useAssignRole();
   const removeRoleMutation = useRemoveFromRole();
@@ -140,6 +144,13 @@ export default function UserProfileModal({
   const hasValidAvatar = user?.userAvatar?.startsWith('data:');
 
   const showRolesSection = roles && roles.length > 0 && (userRoles.length > 0 || isSpaceOwner);
+
+  // Whether this profile is the current user's own. Message/Mute/Kick don't
+  // make sense on yourself.
+  const isSelf = !!(user && authUser?.address && user.userId === authUser.address);
+
+  // Space owners can kick any member other than themselves
+  const canKick = !!(isSpaceOwner && spaceId && !isSelf);
 
   if (!user) return null;
 
@@ -245,49 +256,81 @@ export default function UserProfileModal({
         )}
 
         {/* Bio Section */}
-        <View style={styles.section}>
-          <Text style={styles.sectionTitle}>Bio</Text>
-          <View style={styles.bioContainer}>
-            <Text style={[styles.bioText, !user.bio && styles.bioPlaceholder]}>
-              {user.bio || 'No bio yet'}
-            </Text>
+        {user.bio && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Bio</Text>
+            <View style={styles.bioContainer}>
+              <Text style={styles.bioText}>{user.bio}</Text>
+            </View>
           </View>
-        </View>
+        )}
 
-        {/* Actions */}
-        <View style={styles.actionsContainer}>
-          {onStartDM && (
-            <TouchableOpacity
-              style={styles.actionButton}
-              onPress={() => {
-                onStartDM(user.userId);
-                onClose();
-              }}
-            >
-              <IconSymbol name="bubble.left.fill" size={20} color="#fff" />
-              <Text style={styles.actionButtonText}>Message</Text>
-            </TouchableOpacity>
-          )}
-          {onMuteUser && (
-            <TouchableOpacity
-              style={[styles.actionButton, styles.muteButton]}
-              onPress={() => {
-                onMuteUser(user.userId);
-                onClose();
-              }}
-            >
-              <IconSymbol
-                name={isUserMuted ? 'bell.fill' : 'bell.slash.fill'}
-                size={20}
-                color="#fff"
-              />
-              <Text style={styles.actionButtonText}>
-                {isUserMuted ? 'Unmute' : 'Mute'}
-              </Text>
-            </TouchableOpacity>
-          )}
-        </View>
+        {/* Actions - styled as tappable rows */}
+        {((onStartDM && !isSelf) || (onMuteUser && !isSelf) || canKick) && (
+          <View style={styles.actionsContainer}>
+            {onStartDM && !isSelf && (
+              <>
+                <View style={styles.divider} />
+                <TouchableOpacity
+                  style={styles.actionRow}
+                  onPress={() => {
+                    onStartDM(user.userId);
+                    onClose();
+                  }}
+                >
+                  <IconSymbol name="bubble.left" size={20} color={theme.colors.textMain} />
+                  <Text style={styles.actionRowText}>Message</Text>
+                </TouchableOpacity>
+              </>
+            )}
+            {onMuteUser && !isSelf && (
+              <>
+                <View style={styles.divider} />
+                <TouchableOpacity
+                  style={styles.actionRow}
+                  onPress={() => {
+                    onMuteUser(user.userId);
+                    onClose();
+                  }}
+                >
+                  <IconSymbol
+                    name={isUserMuted ? 'bell' : 'bell.slash'}
+                    size={20}
+                    color={theme.colors.textMain}
+                  />
+                  <Text style={styles.actionRowText}>
+                    {isUserMuted ? 'Unmute' : 'Mute'}
+                  </Text>
+                </TouchableOpacity>
+              </>
+            )}
+            {/* Kick (space owners only) - destructive row */}
+            {canKick && (
+              <>
+                <View style={styles.divider} />
+                <TouchableOpacity
+                  style={styles.actionRow}
+                  onPress={() => setKickVisible(true)}
+                >
+                  <IconSymbol name="person.crop.circle.badge.exclamationmark" size={20} color={theme.colors.danger} />
+                  <Text style={[styles.actionRowText, styles.dangerText]}>Kick from Space</Text>
+                </TouchableOpacity>
+              </>
+            )}
+          </View>
+        )}
       </ScrollView>
+
+      {canKick && (
+        <KickUserModal
+          visible={kickVisible}
+          onClose={() => setKickVisible(false)}
+          spaceId={spaceId!}
+          userName={user.userName}
+          userIcon={hasValidAvatar ? user.userAvatar : undefined}
+          userAddress={user.userId}
+        />
+      )}
     </BaseModal>
   );
 }
@@ -369,10 +412,6 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       color: theme.colors.textMain,
       lineHeight: Skin.font(20),
     },
-    bioPlaceholder: {
-      color: theme.colors.textMuted,
-      fontStyle: 'italic',
-    },
     rolesRow: {
       flexDirection: 'row',
       flexWrap: 'wrap',
@@ -411,25 +450,23 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
     },
     actionsContainer: {
       marginBottom: Skin.space(24),
-      gap: Skin.space(10),
     },
-    actionButton: {
+    divider: {
+      height: 1,
+      backgroundColor: theme.colors.border ?? theme.colors.surface3,
+    },
+    actionRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: theme.colors.primary,
       paddingVertical: Skin.space(14),
-      paddingHorizontal: Skin.space(24),
-      borderRadius: Skin.radius(12),
-      gap: Skin.space(8),
+      gap: Skin.space(12),
     },
-    muteButton: {
-      backgroundColor: theme.colors.surface4,
-    },
-    actionButtonText: {
+    actionRowText: {
       fontSize: Skin.font(16),
-      color: '#fff',
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
+      color: theme.colors.textMain,
+      fontFamily: theme.fonts.regular.fontFamily,
+    },
+    dangerText: {
+      color: theme.colors.danger,
     },
   });

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -437,7 +437,9 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       alignItems: 'center',
       gap: Skin.space(4),
       borderWidth: Skin.border(1),
-      borderColor: theme.colors.surface4,
+      // `border` (= surface6) is the token meant for borders; surface4 is a
+      // surface tone that washes out against lighter drawer surfaces. Re-skins.
+      borderColor: theme.colors.border,
       borderStyle: 'dashed',
       borderRadius: Skin.radius(14),
       paddingVertical: Skin.space(4),

--- a/components/shared/BaseModal.tsx
+++ b/components/shared/BaseModal.tsx
@@ -17,7 +17,7 @@ export interface BaseModalProps {
   children: React.ReactNode;
   /** Fraction of screen height (0-1), default 0.9 */
   height?: number;
-  /** Backdrop opacity (0-1), default 0.5 */
+  /** Backdrop opacity (0-1), default 0.6 */
   backdropDarkness?: number;
   showHandle?: boolean;
   handleContainerStyle?: ViewStyle;
@@ -45,7 +45,7 @@ export function BaseModal({
   onClose,
   children,
   height = 0.9,
-  backdropDarkness = 0.5,
+  backdropDarkness = 0.6,
   showHandle = true,
   handleContainerStyle,
   testID,
@@ -180,9 +180,18 @@ const createStyles = (
       bottom: 0,
       left: 0,
       right: 0,
-      backgroundColor: theme.colors.background,
+      // Sheet sits a step above the page background so it reads as a distinct
+      // floating panel rather than blending into the dimmed backdrop — most
+      // noticeable in dark mode, where the page background is near-black.
+      backgroundColor: theme.colors.surface1,
       borderTopLeftRadius: Skin.radius(20),
       borderTopRightRadius: Skin.radius(20),
+      // Soft elevation so the rounded top edge reads above the backdrop.
+      shadowColor: '#000',
+      shadowOpacity: 0.3,
+      shadowRadius: 16,
+      shadowOffset: { width: 0, height: -2 },
+      elevation: 12,
       ...frameAccentBorder(theme),
       ...(fillHeight ? { height: SCREEN_HEIGHT * height } : {}),
       ...(minHeight ? { minHeight: SCREEN_HEIGHT * minHeight } : {}),

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -283,6 +283,7 @@ const SF_TO_TABLER: Record<string, TablerComponentName> = {
   // Notifications
   'bell': tabler('IconBell'),
   'bell.fill': tabler('IconBell', 'IconBellFilled'),
+  'bell.slash': tabler('IconBellOff'),
   'bell.slash.fill': tabler('IconBellOff'),
 
   // History / time

--- a/hooks/chat/useStartDirectMessage.ts
+++ b/hooks/chat/useStartDirectMessage.ts
@@ -1,0 +1,60 @@
+/**
+ * useStartDirectMessage — open (or create) the 1:1 conversation with a user
+ * and navigate to the DM screen.
+ *
+ * Mirrors NewConversationModal's create-or-open logic: a 1:1 Quorum
+ * conversation id has the form `address/address`. If a conversation with
+ * this user already exists (matched by its `address`) we reuse it; otherwise
+ * we persist a fresh row before navigating. The first sent message creates
+ * the conversation server-side.
+ *
+ * This is the mobile equivalent of desktop's `useUserProfileActions.sendMessage`,
+ * which navigates to `/messages/<address>`.
+ */
+
+import { useCallback } from 'react';
+import { router } from 'expo-router';
+import { useStorageAdapter } from '@/context/StorageContext';
+import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
+
+export function useStartDirectMessage() {
+  const storage = useStorageAdapter();
+  const { conversations } = useUnifiedConversations();
+
+  return useCallback(
+    async (userAddress: string) => {
+      const targetAddress = userAddress.trim();
+      if (!targetAddress) return;
+
+      // Reuse an existing 1:1 conversation with this user if we have one.
+      const existing = conversations.find(
+        (c) => c.address?.toLowerCase() === targetAddress.toLowerCase()
+      );
+
+      if (existing) {
+        router.push(`/messages/dm/${encodeURIComponent(existing.conversationId)}`);
+        return;
+      }
+
+      // Otherwise create the conversation locally (format: address/address).
+      const conversationId = `${targetAddress}/${targetAddress}`;
+      try {
+        await storage.saveConversation({
+          conversationId,
+          address: targetAddress,
+          type: 'direct',
+          timestamp: Date.now(),
+          // Back-filled by the DM screen from the recipient's public profile.
+          icon: '',
+          displayName: '',
+        });
+      } catch {
+        // Non-fatal: the DM screen synthesizes a minimal conversation from
+        // the id, and the first message creates it server-side anyway.
+      }
+
+      router.push(`/messages/dm/${encodeURIComponent(conversationId)}`);
+    },
+    [storage, conversations]
+  );
+}


### PR DESCRIPTION
Improvements to the user profile modal and how it's reached.

## Changes
- **Add Message / Mute / Kick actions to the user profile modal** — the modal opened from a message avatar now offers Message, Mute, and (for owners) Kick.
- **Improve modal / backdrop separation in dark mode** — clearer surface separation between the modal and its backdrop.
- **Fix add-role pill border contrast on lighter surfaces** — the '+ add role' pill used a surface tone (surface4) as its border, which washed out against the lighter modal surface; switched to the border token (surface6), which holds contrast across skins and light/dark themes.
- **Open the user profile from the members list avatar** — tapping a member's avatar in Space Settings > Members now opens the same profile modal (previously only reachable from a message avatar). From there an owner can assign/remove roles and anyone can Message or Mute the user. Mute is sourced from the local useUserMuting hook so it works without parent-passed props.

## Verification
- tsc: no new type errors (project baseline unchanged).
- eslint: no new lint errors on the changed files.
- Profile modal, role assignment, pill contrast, and members-list avatar tap verified on a physical Android device during development.