### PR TITLE
Role colors via shared palette + tag/name uniqueness + UX polish

### DIFF
--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -64,7 +64,7 @@ import { pickImage, compressAvatarImage } from '@/services/media/imageAttachment
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import { truncateAddress } from '@/utils/formatAddress';
-import { hexToBytes, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
+import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
 import * as Clipboard from 'expo-clipboard';
 import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import type { UserProfileInfo } from '@/components/UserProfileModal';
@@ -107,17 +107,9 @@ const MAX_DESCRIPTION_LENGTH = 300;
 const MAX_EMOJIS = 50;
 const MAX_STICKERS = 50;
 
-// Role colors palette
-const ROLE_COLORS = [
-  '#ef4444', '#f97316', '#f59e0b', '#eab308',
-  '#84cc16', '#22c55e', '#14b8a6', '#06b6d4',
-  '#0ea5e9', '#3b82f6', '#6366f1', '#8b5cf6',
-  '#a855f7', '#d946ef', '#ec4899', '#f43f5e',
-];
-
-function getRandomColor(): string {
-  return ROLE_COLORS[Math.floor(Math.random() * ROLE_COLORS.length)];
-}
+// Role colors are now a shared palette: roles store a named token and a default
+// color is derived from the roleId in useAddRole (getDefaultRoleColor), resolved
+// to hex on read in useRoles (getRoleColorHex). No local random-hex palette.
 
 // Available permissions for roles
 const AVAILABLE_PERMISSIONS: { value: Permission; label: string }[] = [
@@ -130,18 +122,23 @@ const AVAILABLE_PERMISSIONS: { value: Permission; label: string }[] = [
 // RoleEditor component for inline editing
 interface RoleEditorProps {
   role: Role;
+  /** All roles in the space — used to validate tag/name uniqueness on save. */
+  allRoles: Role[];
   spaceId: string;
   theme: AppTheme;
   styles: ReturnType<typeof createStyles>;
   onDelete: () => void;
 }
 
-function RoleEditor({ role, spaceId, theme, styles, onDelete }: RoleEditorProps) {
+function RoleEditor({ role, allRoles, spaceId, theme, styles, onDelete }: RoleEditorProps) {
   const [displayName, setDisplayName] = useState(role.displayName);
   const [roleTag, setRoleTag] = useState(role.roleTag);
   const [permissions, setPermissions] = useState<Permission[]>(role.permissions);
   const [isPublic, setIsPublic] = useState(role.isPublic !== false);
   const [showPermissions, setShowPermissions] = useState(false);
+  // Inline error when the typed tag/name collides with another role. The text
+  // stays as the user typed it (so they can fix it); nothing is persisted.
+  const [conflictError, setConflictError] = useState<string | null>(null);
 
   const updateRoleMutation = useUpdateRole();
 
@@ -156,19 +153,37 @@ function RoleEditor({ role, spaceId, theme, styles, onDelete }: RoleEditorProps)
 
   const handleSave = useCallback(async () => {
     if (!hasChanges) return;
+    // The tag is normalized the same way the mutation stores it, so validate
+    // the normalized value. Block the save (and surface an inline error) if the
+    // tag or name collides with another role in the space.
+    const normalizedTag = roleTag.toLowerCase().replace(/[^a-z0-9_]/g, '');
+    const conflict = findRoleConflict(
+      allRoles,
+      { roleTag: normalizedTag, displayName },
+      role.roleId,
+    );
+    if (conflict) {
+      setConflictError(
+        conflict.field === 'roleTag'
+          ? `Tag "@${normalizedTag}" is already used by another role`
+          : `Name "${displayName.trim()}" is already used by another role`,
+      );
+      return;
+    }
+    setConflictError(null);
     try {
       await updateRoleMutation.mutateAsync({
         spaceId,
         roleId: role.roleId,
         displayName,
-        roleTag: roleTag.toLowerCase().replace(/[^a-z0-9_]/g, ''),
+        roleTag: normalizedTag,
         permissions,
         isPublic,
       });
     } catch (error) {
       Alert.alert('Error', 'Failed to save role');
     }
-  }, [spaceId, role.roleId, displayName, roleTag, permissions, isPublic, hasChanges, updateRoleMutation]);
+  }, [spaceId, role.roleId, allRoles, displayName, roleTag, permissions, isPublic, hasChanges, updateRoleMutation]);
 
   // Auto-save when permissions or isPublic change (toggle actions)
   const isInitialMount = React.useRef(true);
@@ -193,12 +208,20 @@ function RoleEditor({ role, spaceId, theme, styles, onDelete }: RoleEditorProps)
       <View style={styles.roleHeader}>
         <View style={[styles.roleColorDot, { backgroundColor: role.color }]} />
         <View style={styles.roleInfo}>
+          <TextInput
+            style={[styles.roleNameInput, { color: role.color }]}
+            value={displayName}
+            onChangeText={(text) => { setDisplayName(text); setConflictError(null); }}
+            onBlur={handleSave}
+            placeholder="Role Name"
+            placeholderTextColor={theme.colors.textMuted}
+          />
           <View style={styles.roleTagRow}>
             <Text style={styles.roleTagPrefix}>@</Text>
             <TextInput
               style={styles.roleTagInput}
               value={roleTag}
-              onChangeText={(text) => setRoleTag(text.toLowerCase().replace(/[^a-z0-9_]/g, ''))}
+              onChangeText={(text) => { setRoleTag(text.toLowerCase().replace(/[^a-z0-9_]/g, '')); setConflictError(null); }}
               onBlur={handleSave}
               placeholder="tag"
               placeholderTextColor={theme.colors.textMuted}
@@ -206,14 +229,9 @@ function RoleEditor({ role, spaceId, theme, styles, onDelete }: RoleEditorProps)
               autoCorrect={false}
             />
           </View>
-          <TextInput
-            style={[styles.roleNameInput, { color: role.color }]}
-            value={displayName}
-            onChangeText={setDisplayName}
-            onBlur={handleSave}
-            placeholder="Role Name"
-            placeholderTextColor={theme.colors.textMuted}
-          />
+          {conflictError ? (
+            <Text style={styles.roleConflictError}>{conflictError}</Text>
+          ) : null}
         </View>
         <View style={styles.roleActions}>
           <TouchableOpacity
@@ -1148,18 +1166,22 @@ export default function SpaceSettingsModal({
 
   const handleAddRole = useCallback(async () => {
     try {
+      // Auto-numbered unique defaults ("New Role 2", "newrole-2", …) so
+      // repeatedly tapping add never creates duplicate-named roles (this
+      // section auto-saves; there is no save gate to validate against).
+      const { displayName, roleTag } = getUniqueRoleDefaults(roles);
       await addRoleMutation.mutateAsync({
         spaceId,
-        displayName: 'New Role',
-        roleTag: 'newrole',
-        color: getRandomColor(),
+        displayName,
+        roleTag,
+        // color omitted — the hook derives a stable token from the roleId.
         permissions: [],
         isPublic: true,
       });
     } catch (error) {
       Alert.alert('Error', 'Failed to add role');
     }
-  }, [spaceId, addRoleMutation]);
+  }, [spaceId, addRoleMutation, roles]);
 
   const handleDeleteRole = useCallback(async (roleId: string) => {
     Alert.alert(
@@ -2103,6 +2125,7 @@ export default function SpaceSettingsModal({
         <RoleEditor
           key={role.roleId}
           role={role}
+          allRoles={roles}
           spaceId={spaceId}
           theme={theme}
           styles={styles}
@@ -2949,14 +2972,15 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
     roleTagRow: {
       flexDirection: 'row',
       alignItems: 'center',
+      marginTop: Skin.space(2),
     },
     roleTagPrefix: {
-      fontSize: Skin.font(12),
+      fontSize: Skin.font(13),
       fontFamily: theme.fonts.mono?.fontFamily || theme.fonts.regular.fontFamily,
       color: theme.colors.textMuted,
     },
     roleTagInput: {
-      fontSize: Skin.font(12),
+      fontSize: Skin.font(13),
       fontFamily: theme.fonts.mono?.fontFamily || theme.fonts.regular.fontFamily,
       color: theme.colors.textMuted,
       padding: 0,
@@ -2967,7 +2991,11 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       fontFamily: theme.fonts.medium.fontFamily,
       fontWeight: theme.fonts.medium.fontWeight,
       padding: 0,
-      marginTop: Skin.space(2),
+    },
+    roleConflictError: {
+      fontSize: Skin.font(12),
+      color: theme.colors.danger,
+      marginTop: Skin.space(4),
     },
     rolePermissionsHeader: {
       flexDirection: 'row',

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -108,7 +108,7 @@ export default function UserProfileModal({
     }
   };
 
-  const handleRemoveRole = async (roleId: string) => {
+  const removeRole = async (roleId: string) => {
     if (!spaceId || !user) return;
     setLoadingRoles(prev => new Set(prev).add(roleId));
     try {
@@ -130,6 +130,20 @@ export default function UserProfileModal({
         return next;
       });
     }
+  };
+
+  // Confirm before removing a role from the user (don't fire immediately).
+  const handleRemoveRole = (roleId: string) => {
+    const role = userRoles.find(r => r.roleId === roleId);
+    const roleLabel = role ? role.displayName : 'this role';
+    Alert.alert(
+      'Remove role',
+      `Remove ${roleLabel} from ${user?.userName ?? 'this user'}?`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Remove', style: 'destructive', onPress: () => { void removeRole(roleId); } },
+      ],
+    );
   };
 
 
@@ -209,10 +223,12 @@ export default function UserProfileModal({
             {userRoles.length > 0 && (
               <View style={styles.rolesRow}>
                 {userRoles.map(role => (
-                  <View key={role.roleId} style={[styles.roleBadge, { borderColor: role.color }]}>
+                  <View key={role.roleId} style={[styles.roleBadge, { backgroundColor: role.color + '20' }]}>
                     {loadingRoles.has(role.roleId) ? (
                       <ActivityIndicator size={10} color={role.color} />
-                    ) : null}
+                    ) : (
+                      <View style={[styles.roleBadgeDot, { backgroundColor: role.color }]} />
+                    )}
                     <Text style={[styles.roleBadgeText, { color: role.color }]}>
                       {role.displayName}
                     </Text>
@@ -422,10 +438,16 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       flexDirection: 'row',
       alignItems: 'center',
       gap: Skin.space(6),
-      borderWidth: Skin.border(1),
+      // Tinted fill + a solid color dot (matches the members-list pill) so the
+      // pill reads against any drawer surface, not relying on a thin border.
       borderRadius: Skin.radius(14),
       paddingVertical: Skin.space(4),
       paddingHorizontal: Skin.space(10),
+    },
+    roleBadgeDot: {
+      width: 8,
+      height: 8,
+      borderRadius: Skin.radius(4),
     },
     roleBadgeText: {
       fontSize: Skin.font(13),

--- a/hooks/chat/useRoleManagement.ts
+++ b/hooks/chat/useRoleManagement.ts
@@ -20,7 +20,17 @@ import { getSpace, saveSpace } from '@/services/config/spaceStorage';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
 import { broadcastSpaceUpdate } from '@/services/space/broadcastSpaceUpdate';
 import type { Space, Role, Permission } from '@quilibrium/quorum-shared';
-import { toggleRolePermission } from '@quilibrium/quorum-shared';
+import { toggleRolePermission, getRoleColorHex, getDefaultRoleColor } from '@quilibrium/quorum-shared';
+
+/**
+ * Resolve a role's stored `color` (a palette token, or a legacy raw hex /
+ * desktop CSS-var string) to a render-safe hex. Returns a NEW role object so
+ * consumers can use `role.color` directly in RN style props. Idempotent on
+ * already-hex values.
+ */
+function withResolvedColor(role: Role): Role {
+  return { ...role, color: getRoleColorHex(role.color) };
+}
 
 /**
  * Generate a UUID v4 using crypto.getRandomValues
@@ -45,7 +55,10 @@ export function useRoles(spaceId: string | undefined) {
     queryFn: async (): Promise<Role[]> => {
       if (!spaceId) return [];
       const space = getSpace(spaceId);
-      return space?.roles ?? [];
+      // Resolve each role's color to a render-safe hex here, the single read
+      // chokepoint, so every consumer (pills, editor) gets a usable color —
+      // including legacy desktop roles stored as `rgb(var(--success))`.
+      return (space?.roles ?? []).map(withResolvedColor);
     },
     enabled: !!spaceId,
   });
@@ -115,7 +128,12 @@ interface AddRoleParams {
   spaceId: string;
   displayName: string;
   roleTag: string;
-  color: string;
+  /**
+   * Optional palette token (e.g. 'blue'). If omitted, a stable, distinct color
+   * is derived from the new roleId via `getDefaultRoleColor` — deterministic so
+   * the same role resolves to the same color on every device, and it syncs.
+   */
+  color?: string;
   permissions?: Permission[];
   isPublic?: boolean;
 }
@@ -134,11 +152,14 @@ export function useAddRole() {
         throw new Error('Space not found');
       }
 
+      const roleId = generateUUID();
       const newRole: Role = {
-        roleId: generateUUID(),
+        roleId,
         displayName: params.displayName,
         roleTag: params.roleTag,
-        color: params.color,
+        // Store a portable palette TOKEN (not a raw hex). Default deterministically
+        // from the roleId so the color is stable + distinct + syncs.
+        color: params.color ?? getDefaultRoleColor(roleId),
         members: [],
         permissions: params.permissions ?? [],
         isPublic: params.isPublic ?? true,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@polkadot/keyring": "14.0.1",
     "@polkadot/util": "14.0.1",
     "@polkadot/util-crypto": "14.0.1",
-    "@quilibrium/quorum-shared": "2.1.0-29",
+    "@quilibrium/quorum-shared": "2.1.0-31",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "7.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1952,10 +1952,10 @@
     tslib "^2.8.0"
     ws "^8.18.0"
 
-"@quilibrium/quorum-shared@2.1.0-29":
-  version "2.1.0-29"
-  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-29.tgz#fc056918c77d9e4ba17a67d891b13546663cbba7"
-  integrity sha512-rigQ1QW/wNE1NTLkI4FfRieAD67GqX04Qlxjnm5tBEcG9T6XWLGBol3HP7hwJd0zHzRDHM7PqQg42HMosSMPVg==
+"@quilibrium/quorum-shared@2.1.0-31":
+  version "2.1.0-31"
+  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-31.tgz#ad903235335fe00448af5aebec3e25b8716fe7ca"
+  integrity sha512-XY+Hec8A4YgXGWDqR18KVFXSgow5Cz7QDOXHIVrPj0KYz2HrMeV6PAGVhRHwQWLhgsPwNEMpcN1tS1acMKM5/w==
   dependencies:
     "@noble/hashes" "1.8.0"
     dayjs "1.11.19"


### PR DESCRIPTION
## What
Adopts the shared role-color vocabulary and adds role tag/name uniqueness + UX polish.

**Color**
- Roles store a portable color token; `useRoles` resolves it to a render hex via `getRoleColorHex`, so desktop-assigned roles (previously stored as `rgb(var(--success))`, which React Native can't render) now show a valid color instead of an invisible/invalid one.
- New roles get a stable, distinct color from the roleId via `getDefaultRoleColor`; removed the local random-hex `ROLE_COLORS` palette.
- Unified the `UserProfileModal` current-role pill with the members-list pill (tinted fill + color dot) so it reads on the lighter drawer surface.

**Uniqueness**
- Adding a role uses `getUniqueRoleDefaults` so repeatedly tapping Add never creates duplicate-named roles (auto-numbered).
- Editing a role's tag/name to collide with another is blocked with an inline error (`findRoleConflict`), keeping the typed text.

**UX**
- Removing a role from a user now shows a confirmation prompt first.
- Role row layout: name on top (role color), @tag below at a readable size.

## Shared dependency
Bumps `@quilibrium/quorum-shared` `2.1.0-29` → `2.1.0-31` for the resolver + uniqueness helpers (shared PR #42/#43). `-31` is the clean re-publish.

## Verification
- `tsc`: the role consumers (`useRoleManagement.ts`, `UserProfileModal`, `SpaceSettingsModal`) compile clean against the published `-31`; no error references the shared role exports.
- Runtime-verified on device: desktop-assigned roles render correct colors, new roles auto-numbered + distinct, edit-collision inline error, remove-role confirm, role-row layout.
- Desktop parity shipped separately (quorum-desktop PR #204).