### PR TITLE
style: ui polish chat feed menus

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -22,7 +22,6 @@ installReactQueryRnBridges();
 
 import { QueryClient } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
-import { useFonts } from 'expo-font';
 import { Slot, router, useSegments } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
@@ -255,10 +254,6 @@ function StatusBarWrapper() {
 }
 
 export default function RootLayout() {
-  const [loaded] = useFonts({
-    AtAero: require('../assets/fonts/AtAeroVARVF.ttf'),
-  });
-
   // Resolve the active skin synchronously (MMKV) and preload its embedded font
   // before revealing the UI, so a skinned launch never flashes the default
   // theme/font. Tokens (colors/radii/borders) apply instantly; only the font
@@ -281,7 +276,7 @@ export default function RootLayout() {
     return () => { cancelled = true; };
   }, [bootSkin]);
 
-  if (!loaded || !skinReady) {
+  if (!skinReady) {
     return null;
   }
 

--- a/components/AudioSpaceOverlay.tsx
+++ b/components/AudioSpaceOverlay.tsx
@@ -951,7 +951,7 @@ function ChatPanel({
                       style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(4) }}
                       accessibilityLabel={recasted ? 'Undo recast' : 'Recast'}
                     >
-                      <IconSymbol name="arrowshape.turn.up.right" size={14} color={recasted ? theme.colors.success : theme.colors.textMuted} />
+                      <IconSymbol name="arrow.triangle.2.circlepath" size={14} color={recasted ? theme.colors.success : theme.colors.textMuted} />
                       {recastCount > 0 && (
                         <Text style={{ color: recasted ? theme.colors.success : theme.colors.textMuted, fontSize: Skin.font(12) }}>{recastCount}</Text>
                       )}

--- a/components/Chat/ChannelHeader.tsx
+++ b/components/Chat/ChannelHeader.tsx
@@ -7,6 +7,12 @@ import * as Skin from '@/theme/skins/geometry';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
+// Expands the tap target of header icon buttons without changing layout (the
+// glyphs and their 16px spacing stay identical). Horizontal slop is kept at 8
+// so adjacent icons' touch zones meet but don't overlap; vertical slop is
+// larger since nothing sits above/below in the header row. ~34x42 effective.
+const headerIconHitSlop = { top: 12, bottom: 12, left: 8, right: 8 };
+
 interface ChannelHeaderProps {
   channelName: string;
   sidebarsVisible: boolean;
@@ -38,7 +44,7 @@ export const ChannelHeader = React.memo(function ChannelHeader({
     <View style={styles.container}>
       <View style={styles.left}>
         {!sidebarsVisible && (
-          <TouchableOpacity onPress={onShowSidebars} style={styles.menuButton}>
+          <TouchableOpacity onPress={onShowSidebars} style={styles.menuButton} hitSlop={headerIconHitSlop}>
             <IconSymbol name="line.3.horizontal" color={theme.colors.textMuted} size={20} />
           </TouchableOpacity>
         )}
@@ -47,27 +53,27 @@ export const ChannelHeader = React.memo(function ChannelHeader({
       </View>
       <View style={styles.right}>
         {onOpenSearch && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSearch}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSearch} hitSlop={headerIconHitSlop}>
             <IconSymbol name="magnifyingglass" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onOpenPinnedMessages && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenPinnedMessages}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenPinnedMessages} hitSlop={headerIconHitSlop}>
             <IconSymbol name="pin.fill" color={pinnedCount > 0 ? theme.colors.primary : theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onOpenBookmarks && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenBookmarks}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenBookmarks} hitSlop={headerIconHitSlop}>
             <IconSymbol name="bookmark" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onInvite && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onInvite}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onInvite} hitSlop={headerIconHitSlop}>
             <IconSymbol name="person.badge.plus" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onOpenSettings && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSettings}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSettings} hitSlop={headerIconHitSlop}>
             <IconSymbol name="gearshape" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}

--- a/components/Chat/DMChatHeader.tsx
+++ b/components/Chat/DMChatHeader.tsx
@@ -14,6 +14,12 @@ import * as Skin from '@/theme/skins/geometry';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
+// Expands the tap target of header icon buttons without changing layout (the
+// glyphs and their 16px spacing stay identical). Horizontal slop is kept at 8
+// so adjacent icons' touch zones meet but don't overlap; vertical slop is
+// larger since nothing sits above/below in the header row. ~34x42 effective.
+const headerIconHitSlop = { top: 12, bottom: 12, left: 8, right: 8 };
+
 interface DMChatHeaderProps {
   conversation: Conversation;
   sidebarsVisible: boolean;
@@ -47,7 +53,11 @@ export const DMChatHeader = React.memo(function DMChatHeader({
     <View style={styles.container}>
       <View style={styles.left}>
         {!sidebarsVisible && (
-          <TouchableOpacity onPress={onShowSidebars} style={styles.menuButton}>
+          <TouchableOpacity
+            onPress={onShowSidebars}
+            style={styles.menuButton}
+            hitSlop={{ top: 12, bottom: 12, left: 10, right: 10 }}
+          >
             <IconSymbol name="line.3.horizontal" color={theme.colors.textMuted} size={20} />
           </TouchableOpacity>
         )}
@@ -60,21 +70,21 @@ export const DMChatHeader = React.memo(function DMChatHeader({
       </View>
       <View style={styles.right}>
         {onVideoCallPress && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onVideoCallPress}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onVideoCallPress} hitSlop={headerIconHitSlop}>
             <IconSymbol name="video" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onCallPress && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onCallPress}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onCallPress} hitSlop={headerIconHitSlop}>
             <IconSymbol name="phone" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
         {onOpenSearch && (
-          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSearch}>
+          <TouchableOpacity style={styles.headerIconButton} onPress={onOpenSearch} hitSlop={headerIconHitSlop}>
             <IconSymbol name="magnifyingglass" color={theme.colors.textMuted} size={18} />
           </TouchableOpacity>
         )}
-        <TouchableOpacity style={styles.headerIconButton} onPress={onInfoPress}>
+        <TouchableOpacity style={styles.headerIconButton} onPress={onInfoPress} hitSlop={headerIconHitSlop}>
           <IconSymbol name="info.circle" color={theme.colors.textMuted} size={18} />
         </TouchableOpacity>
       </View>

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -4,9 +4,8 @@
 
 import type { AppTheme } from '@/theme';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Modal, Pressable, Alert, Switch } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
-import { IconSymbol } from '@/components/ui/IconSymbol';
+import { View, Text, StyleSheet, Alert, Switch } from 'react-native';
+import { BaseModal, ActionRow, ActionRowGroup } from '@/components/shared';
 import { resetDMSession } from '@/hooks/chat/useSendDirectMessage';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import * as Skin from '@/theme/skins/geometry';
@@ -81,144 +80,83 @@ export function DMSettingsSheet({
   };
 
   return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={guardedClose}
-    >
-      <View style={styles.overlay}>
-        <Pressable style={styles.backdrop} onPress={guardedClose} />
-        <View style={styles.container}>
-          <View style={styles.header}>
-            <Text style={styles.headerText}>Conversation Settings</Text>
-          </View>
-          {onToggleRepudiable && (
-            <>
-              <View style={styles.divider} />
-              <View style={styles.toggleRow}>
-                <View style={styles.actionContent}>
-                  <Text style={styles.actionText}>Repudiable Messages</Text>
-                  <Text style={styles.actionSubtext}>Messages can't be proven as yours</Text>
-                </View>
-                <Switch
-                  value={isRepudiable ?? false}
-                  onValueChange={onToggleRepudiable}
-                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                />
-              </View>
-            </>
-          )}
-          {onToggleEditHistory && (
-            <>
-              <View style={styles.divider} />
-              <View style={styles.toggleRow}>
-                <View style={styles.actionContent}>
-                  <Text style={styles.actionText}>Save Edit History</Text>
-                  <Text style={styles.actionSubtext}>Keep previous versions of edits</Text>
-                </View>
-                <Switch
-                  value={saveEditHistory ?? true}
-                  onValueChange={onToggleEditHistory}
-                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                />
-              </View>
-            </>
-          )}
-          <View style={styles.divider} />
-          <TouchableOpacity style={styles.actionButton} onPress={handleFixEncryption}>
-            <IconSymbol
-              name="arrow.triangle.2.circlepath"
-              size={20}
-              color={theme.colors.warning ?? theme.colors.textMuted}
-            />
-            <View style={styles.actionContent}>
-              <Text style={styles.actionText}>Fix Encryption</Text>
-              <Text style={styles.actionSubtext}>Reset if messages fail to send/decrypt</Text>
-            </View>
-          </TouchableOpacity>
-          <View style={styles.divider} />
-          <TouchableOpacity style={styles.actionButton} onPress={handleDeleteConversation}>
-            <IconSymbol
-              name="trash"
-              size={20}
-              color={theme.colors.danger ?? theme.colors.danger}
-            />
-            <View style={styles.actionContent}>
-              <Text style={[styles.actionText, styles.dangerText]}>Delete Conversation</Text>
-              <Text style={styles.actionSubtext}>Only deletes from your device</Text>
-            </View>
-          </TouchableOpacity>
+    <BaseModal visible={visible} onClose={guardedClose} showHandle>
+      <View style={styles.container}>
+        <View style={styles.header}>
+          <Text style={styles.headerText}>Conversation Settings</Text>
         </View>
+
+        {(onToggleRepudiable || onToggleEditHistory) && (
+          <ActionRowGroup style={styles.group}>
+            {onToggleRepudiable && (
+              <ActionRow
+                label="Repudiable Messages"
+                sublabel="Messages can't be proven as yours"
+                trailing={
+                  <Switch
+                    value={isRepudiable ?? false}
+                    onValueChange={onToggleRepudiable}
+                    trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  />
+                }
+              />
+            )}
+            {onToggleEditHistory && (
+              <ActionRow
+                label="Save Edit History"
+                sublabel="Keep previous versions of edits"
+                trailing={
+                  <Switch
+                    value={saveEditHistory ?? true}
+                    onValueChange={onToggleEditHistory}
+                    trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  />
+                }
+              />
+            )}
+          </ActionRowGroup>
+        )}
+
+        <ActionRowGroup style={styles.group}>
+          <ActionRow
+            icon="arrow.triangle.2.circlepath"
+            label="Fix Encryption"
+            sublabel="Reset if messages fail to send/decrypt"
+            onPress={handleFixEncryption}
+          />
+          <ActionRow
+            icon="trash"
+            label="Delete Conversation"
+            sublabel="Only deletes from your device"
+            destructive
+            onPress={handleDeleteConversation}
+          />
+        </ActionRowGroup>
       </View>
       {confirmDialog}
-    </Modal>
+    </BaseModal>
   );
 }
 
 const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
-    overlay: {
-      flex: 1,
-      justifyContent: 'center',
-      alignItems: 'center',
-    },
-    backdrop: {
-      ...StyleSheet.absoluteFillObject,
-      backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    },
     container: {
-      backgroundColor: theme.colors.surface1 ?? theme.colors.background,
-      borderRadius: Skin.radius(12),
-      minWidth: 280,
-      maxWidth: 320,
-      overflow: 'hidden',
+      paddingHorizontal: Skin.space(12),
+      paddingTop: Skin.space(12),
+      paddingBottom: Skin.space(8),
     },
     header: {
-      paddingVertical: Skin.space(14),
-      paddingHorizontal: Skin.space(20),
+      alignItems: 'center',
+      paddingTop: Skin.space(4),
+      paddingBottom: Skin.space(14),
     },
     headerText: {
-      fontSize: Skin.font(16),
-      fontWeight: '600',
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.medium?.fontFamily ?? theme.fonts.regular.fontFamily,
+      ...theme.textStyles.headline,
+      color: theme.colors.textStrong,
       textAlign: 'center',
     },
-    actionButton: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(14),
-      paddingHorizontal: Skin.space(20),
-      gap: Skin.space(12),
-    },
-    actionContent: {
-      flex: 1,
-    },
-    actionText: {
-      fontSize: Skin.font(16),
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.regular.fontFamily,
-    },
-    actionSubtext: {
-      fontSize: Skin.font(12),
-      color: theme.colors.textMuted,
-      fontFamily: theme.fonts.regular.fontFamily,
-      marginTop: Skin.space(2),
-    },
-    dangerText: {
-      color: theme.colors.danger ?? theme.colors.danger,
-    },
-    toggleRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(14),
-      paddingHorizontal: Skin.space(20),
-      gap: Skin.space(12),
-    },
-    divider: {
-      height: 1,
-      backgroundColor: theme.colors.border ?? theme.colors.surface3,
+    group: {
+      marginBottom: Skin.space(12),
     },
   });
 

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -324,8 +324,6 @@ const createStyles = (theme: AppTheme) =>
     quickReactionsContainer: {
       paddingVertical: Skin.space(12),
       paddingHorizontal: Skin.space(16),
-      borderBottomWidth: Skin.border(1),
-      borderBottomColor: theme.colors.border ?? theme.colors.surface3,
     },
     quickReactionsContent: {
       flexDirection: 'row',

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -10,6 +10,7 @@ import { View, Text, StyleSheet, Modal, Pressable, Dimensions } from 'react-nati
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Clipboard from 'expo-clipboard';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { ActionRow, ActionRowGroup } from '@/components/shared';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { getRecentEmojis } from '@/services/emojiFrecency';
 import { requestTranslateText } from '@/services/translation/forceTranslate';
@@ -237,129 +238,52 @@ export function MessageActionSheet({
 
           {/* Action Buttons */}
           <View style={styles.actionsContainer}>
-            {onReply && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleReply}>
-                  <IconSymbol
-                    name="arrowshape.turn.up.left.fill"
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>Reply</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {canEdit && onEdit && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleEdit}>
-                  <IconSymbol
-                    name="pencil"
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>Edit Message</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {hasEditHistory && onViewEditHistory && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleViewEditHistory}>
-                  <IconSymbol
-                    name="clock.arrow.circlepath"
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>View Edit History</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {canPin && (onPin || onUnpin) && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handlePin}>
-                  <IconSymbol
-                    name={isPinned ? 'pin.slash' : 'pin.fill'}
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>{isPinned ? 'Unpin Message' : 'Pin Message'}</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {onBookmark && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleBookmark}>
-                  <IconSymbol
-                    name={isBookmarked ? 'bookmark.slash.fill' : 'bookmark'}
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>
-                    {isBookmarked ? 'Remove Bookmark' : 'Bookmark'}
-                  </Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {messageText && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleCopyText}>
-                  <IconSymbol
-                    name="doc.on.doc"
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionText}>Copy Text</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            {canTranslate && (
-              <>
-                <TouchableOpacity style={styles.actionButton} onPress={handleTranslate}>
-                  <IconSymbol name="globe" size={20} color={theme.colors.textMain} />
-                  <Text style={styles.actionText}>Translate</Text>
-                </TouchableOpacity>
-                <View style={styles.divider} />
-              </>
-            )}
-            <TouchableOpacity style={styles.actionButton} onPress={handleReact}>
-              <IconSymbol
-                name="face.smiling"
-                size={20}
-                color={theme.colors.textMain}
-              />
-              <Text style={styles.actionText}>Add Reaction</Text>
-            </TouchableOpacity>
-            {onReport && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity style={styles.actionButton} onPress={handleReport}>
-                  <IconSymbol
-                    name="flag"
-                    size={20}
-                    color={theme.colors.danger}
-                  />
-                  <Text style={[styles.actionText, styles.dangerText]}>Report</Text>
-                </TouchableOpacity>
-              </>
-            )}
-            {canDelete && onDelete && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity style={styles.actionButton} onPress={handleDelete}>
-                  <IconSymbol
-                    name="trash"
-                    size={20}
-                    color={theme.colors.danger}
-                  />
-                  <Text style={[styles.actionText, styles.dangerText]}>Delete</Text>
-                </TouchableOpacity>
-              </>
-            )}
+            <ActionRowGroup>
+              {onReply && (
+                <ActionRow
+                  icon="arrowshape.turn.up.left.fill"
+                  label="Reply"
+                  onPress={handleReply}
+                />
+              )}
+              {canEdit && onEdit && (
+                <ActionRow icon="pencil" label="Edit Message" onPress={handleEdit} />
+              )}
+              {hasEditHistory && onViewEditHistory && (
+                <ActionRow
+                  icon="clock.arrow.circlepath"
+                  label="View Edit History"
+                  onPress={handleViewEditHistory}
+                />
+              )}
+              {canPin && (onPin || onUnpin) && (
+                <ActionRow
+                  icon={isPinned ? 'pin.slash' : 'pin.fill'}
+                  label={isPinned ? 'Unpin Message' : 'Pin Message'}
+                  onPress={handlePin}
+                />
+              )}
+              {onBookmark && (
+                <ActionRow
+                  icon={isBookmarked ? 'bookmark.slash.fill' : 'bookmark'}
+                  label={isBookmarked ? 'Remove Bookmark' : 'Bookmark'}
+                  onPress={handleBookmark}
+                />
+              )}
+              {messageText && (
+                <ActionRow icon="doc.on.doc" label="Copy Text" onPress={handleCopyText} />
+              )}
+              {canTranslate && (
+                <ActionRow icon="globe" label="Translate" onPress={handleTranslate} />
+              )}
+              <ActionRow icon="face.smiling" label="Add Reaction" onPress={handleReact} />
+              {onReport && (
+                <ActionRow icon="flag" label="Report" destructive onPress={handleReport} />
+              )}
+              {canDelete && onDelete && (
+                <ActionRow icon="trash" label="Delete" destructive onPress={handleDelete} />
+              )}
+            </ActionRowGroup>
           </View>
         </View>
       </View>
@@ -419,27 +343,8 @@ const createStyles = (theme: AppTheme) =>
       fontSize: Skin.font(22),
     },
     actionsContainer: {
+      paddingHorizontal: Skin.space(12),
       paddingVertical: Skin.space(4),
-    },
-    actionButton: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(14),
-      paddingHorizontal: Skin.space(20),
-      gap: Skin.space(12),
-    },
-    actionText: {
-      fontSize: Skin.font(16),
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.regular.fontFamily,
-    },
-    dangerText: {
-      color: theme.colors.danger,
-    },
-    divider: {
-      height: 1,
-      backgroundColor: theme.colors.border ?? theme.colors.surface3,
-      marginHorizontal: Skin.space(16),
     },
   });
 

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -577,10 +577,21 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
               autoCorrect={false}
             />
             {searchQuery.length > 0 && (
-              <TouchableOpacity onPress={() => setSearchQuery('')}>
+              <TouchableOpacity onPress={() => setSearchQuery('')} hitSlop={8}>
                 <IconSymbol name="xmark.circle.fill" size={16} color={theme.colors.textMuted} />
               </TouchableOpacity>
             )}
+            {/* Close the picker. The composer also dismisses it on text input,
+                but an explicit control is clearer. */}
+            <TouchableOpacity
+              onPress={handleToggleEmojiPicker}
+              hitSlop={8}
+              style={styles.emojiCloseButton}
+              accessibilityRole="button"
+              accessibilityLabel="Close emoji picker"
+            >
+              <IconSymbol name="xmark" size={18} color={theme.colors.textMuted} />
+            </TouchableOpacity>
           </View>
 
           {/* Category tabs */}
@@ -994,40 +1005,55 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   searchContainer: {
     flexDirection: 'row',
     alignItems: 'center',
-    paddingHorizontal: Skin.space(12),
-    paddingVertical: Skin.space(8),
-    borderBottomWidth: Skin.border(1),
-    borderBottomColor: theme.colors.border ?? theme.colors.surface3,
+    paddingHorizontal: Skin.space(14),
+    // More breathing room: clears the panel's rounded top and gives the field
+    // air before the category band. No bottom border — the band below provides
+    // separation by color instead of a hard line.
+    paddingTop: Skin.space(14),
+    paddingBottom: Skin.space(12),
     gap: Skin.space(8),
   },
   searchInput: {
     flex: 1,
-    fontSize: Skin.font(14),
-    lineHeight: Skin.font(18),
+    fontSize: Skin.font(15),
+    lineHeight: Skin.font(20),
     color: theme.colors.textMain,
     fontFamily: theme.fonts.regular.fontFamily,
     padding: 0,
   },
+  emojiCloseButton: {
+    marginLeft: Skin.space(4),
+  },
   categoryTabs: {
-    maxHeight: 40,
-    borderBottomWidth: Skin.border(1),
-    borderBottomColor: theme.colors.border ?? theme.colors.surface3,
+    // A continuous band (no top/bottom separators) one shade below the panel
+    // (panel is surface5). Tall enough that the 20px emoji + pill padding
+    // aren't clipped.
+    maxHeight: 48,
+    backgroundColor: theme.colors.surface4,
   },
   categoryTabsContent: {
-    paddingHorizontal: Skin.space(4),
+    paddingHorizontal: Skin.space(6),
+    // Vertical padding inside the band so the active pill floats and never
+    // touches the band's edges.
+    paddingVertical: Skin.space(6),
     alignItems: 'center',
   },
   categoryTab: {
-    paddingHorizontal: Skin.space(10),
-    paddingVertical: Skin.space(6),
+    paddingHorizontal: Skin.space(9),
+    paddingVertical: Skin.space(5),
     marginHorizontal: Skin.space(2),
-    borderRadius: Skin.radius(8),
+    borderRadius: Skin.radius(10),
   },
   categoryTabActive: {
-    backgroundColor: theme.colors.surface3 ?? theme.colors.surface2,
+    // Floating pill one step above the band so it reads as raised, inset by the
+    // content padding so it never touches the band edges.
+    backgroundColor: theme.colors.surface6,
   },
   categoryTabEmoji: {
     fontSize: Skin.font(20),
+    // Explicit line-height so the glyph box is tall enough on Android (where
+    // emoji overshoot the default line box and clip).
+    lineHeight: Skin.font(26),
   },
   emojiGrid: {
     flex: 1,

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -1,5 +1,6 @@
 import type { AppTheme } from '@/theme';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { SendIcon } from '@/components/Chat/SendIcon';
 import { useEmojiFrecency } from '@/hooks/useEmojiFrecency';
 import { useDebouncedValue } from '@/hooks/useFarcasterSearch';
 import type { ProcessedAttachment } from '@/services/media/imageAttachment';
@@ -823,18 +824,20 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
         </View>
         <View style={styles.actions}>
           <TouchableOpacity
-            style={[styles.sendButton]}
+            style={[
+              styles.sendButton,
+              {
+                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
+                opacity: canSend ? 1 : 0.6,
+              },
+            ]}
             onPress={handleSend}
             disabled={!canSend}
           >
             {isSending ? (
-              <ActivityIndicator size="small" color={theme.colors.primary} />
+              <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <IconSymbol
-                name="paperplane.fill"
-                color={canSend ? theme.colors.primary : theme.colors.textMuted}
-                size={24}
-              />
+              <SendIcon color="#fff" size={18} />
             )}
           </TouchableOpacity>
         </View>
@@ -976,8 +979,9 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     padding: Skin.space(4),
   },
   sendButton: {
-    width: 36,
-    height: 36,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/components/Chat/SendIcon.tsx
+++ b/components/Chat/SendIcon.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface SendIconProps {
+  /** Render width in px. Height is derived from the 5:4 (100:80) aspect ratio. */
+  size?: number;
+  color: string;
+}
+
+/**
+ * Quorum send arrow — the chevron/arrowhead lifted from the Quorum symbol,
+ * used as the message composer's send button. Geometry matches the desktop
+ * web composer (viewBox 0 0 100 80) so the send glyph is identical across
+ * platforms.
+ */
+export function SendIcon({ size = 22, color }: SendIconProps) {
+  const height = (size * 80) / 100;
+  return (
+    <Svg width={size} height={height} viewBox="0 0 100 80" fill="none">
+      <Path d="M0 80L25 40.4181L0 0L100 40.4181L0 80Z" fill={color} />
+    </Svg>
+  );
+}
+
+export default SendIcon;

--- a/components/ShareInviteSheet.tsx
+++ b/components/ShareInviteSheet.tsx
@@ -14,6 +14,7 @@
 
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { ActionRow, ActionRowGroup } from '@/components/shared';
 import { useToast } from '@/context/ToastContext';
 import { useConversations } from '@/hooks/chat/useConversations';
 import { useShareInvite } from '@/hooks/chat/useInviteManagement';
@@ -155,36 +156,34 @@ export default function ShareInviteSheet({
             </View>
           )}
 
-          {directConversations.map((conv) => {
-            const sending = sendingTo === conv.conversationId;
-            return (
-              <TouchableOpacity
-                key={conv.conversationId}
-                style={styles.row}
-                onPress={() => handleSendToDM(conv.conversationId, conv.address, conv.displayName)}
-                disabled={!!sendingTo}
-                activeOpacity={0.7}
-              >
-                <CachedAvatar
-                  source={conv.icon ? { uri: conv.icon } : null}
-                  style={styles.avatar}
-                />
-                <View style={styles.rowText}>
-                  <Text style={styles.rowName} numberOfLines={1}>
-                    {conv.displayName || conv.address.slice(0, 12)}
-                  </Text>
-                  <Text style={styles.rowAddress} numberOfLines={1}>
-                    {conv.address.slice(0, 16)}…
-                  </Text>
-                </View>
-                {sending ? (
-                  <ActivityIndicator size="small" color={theme.colors.accent} />
-                ) : (
-                  <IconSymbol name="paperplane.fill" size={16} color={theme.colors.accent} />
-                )}
-              </TouchableOpacity>
-            );
-          })}
+          {directConversations.length > 0 && (
+            <ActionRowGroup>
+              {directConversations.map((conv) => {
+                const sending = sendingTo === conv.conversationId;
+                return (
+                  <ActionRow
+                    key={conv.conversationId}
+                    leading={
+                      <CachedAvatar
+                        source={conv.icon ? { uri: conv.icon } : null}
+                        style={styles.avatar}
+                      />
+                    }
+                    label={conv.displayName || conv.address.slice(0, 12)}
+                    sublabel={`${conv.address.slice(0, 16)}…`}
+                    trailing={
+                      sending ? (
+                        <ActivityIndicator size="small" color={theme.colors.accent} />
+                      ) : (
+                        <IconSymbol name="paperplane.fill" size={16} color={theme.colors.accent} />
+                      )
+                    }
+                    onPress={() => handleSendToDM(conv.conversationId, conv.address, conv.displayName)}
+                  />
+                );
+              })}
+            </ActionRowGroup>
+          )}
         </ScrollView>
 
         <View style={styles.footer}>
@@ -281,32 +280,11 @@ const createStyles = (theme: AppTheme, insets: { top: number; bottom: number; le
       color: theme.colors.textMuted,
       textAlign: 'center',
     },
-    row: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: Skin.space(12),
-      paddingVertical: Skin.space(10),
-      paddingHorizontal: Skin.space(4),
-    },
     avatar: {
       width: 40,
       height: 40,
       borderRadius: Skin.radius(20),
       backgroundColor: theme.colors.surface3,
-    },
-    rowText: {
-      flex: 1,
-      minWidth: 0,
-    },
-    rowName: {
-      fontSize: Skin.font(15),
-      fontWeight: '600',
-      color: theme.colors.textStrong,
-    },
-    rowAddress: {
-      fontSize: Skin.font(12),
-      color: theme.colors.textMuted,
-      marginTop: Skin.space(2),
     },
     footer: {
       paddingVertical: Skin.space(12),

--- a/components/SocialFeed/content/CastActions.tsx
+++ b/components/SocialFeed/content/CastActions.tsx
@@ -83,7 +83,7 @@ export const CastActions = React.memo(function CastActions({
 
       <View style={styles.actionButton}>
         <IconSymbol
-          name={isRecast ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+          name="arrow.triangle.2.circlepath"
           color={isRecast ? theme.colors.success : theme.colors.textMuted}
           size={16}
         />

--- a/components/SocialFeed/content/CastActions.tsx
+++ b/components/SocialFeed/content/CastActions.tsx
@@ -5,8 +5,19 @@ import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { LikeIcon, getLikeIconType } from './LikeIcon';
 import { SnapIcon } from './SnapIcon';
+import { SnapIconOutline } from './SnapIconVariants';
 import * as Skin from '@/theme/skins/geometry';
 import { createSkinnable } from '@/theme/skins/skinnableStyleSheet';
+
+// Tip-icon source. 'current' = existing OpenMoji SnapIcon (in use now);
+// 'outline' = the chosen future replacement (see SnapIconVariants). Flip to
+// 'outline' to swap it in everywhere CastActions renders.
+const SNAP_VARIANT: 'current' | 'outline' = 'current';
+
+function SnapTipIcon({ color, size }: { color: string; size: number }) {
+  if (SNAP_VARIANT === 'outline') return <SnapIconOutline color={color} size={size} />;
+  return <SnapIcon color={color} size={size} />;
+}
 
 interface CastActionsProps {
   castHash: string;
@@ -60,7 +71,7 @@ export const CastActions = React.memo(function CastActions({
           isLiked={liked}
           color={theme.colors.textMuted}
           activeColor={theme.colors.danger}
-          size={16}
+          size={20}
         />
         {count > 0 && (
           <Text style={[styles.countText, { color: theme.colors.textMuted }]}>
@@ -73,7 +84,7 @@ export const CastActions = React.memo(function CastActions({
         style={styles.actionButton}
         onPress={onReplyPress}
       >
-        <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={16} />
+        <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={20} />
         {replyCount > 0 && (
           <Text style={[styles.countText, { color: theme.colors.textMuted }]}>
             {replyCount}
@@ -85,7 +96,7 @@ export const CastActions = React.memo(function CastActions({
         <IconSymbol
           name="arrow.triangle.2.circlepath"
           color={isRecast ? theme.colors.success : theme.colors.textMuted}
-          size={16}
+          size={20}
         />
         {recastCount > 0 && (
           <Text style={[styles.countText, { color: theme.colors.textMuted }]}>
@@ -96,7 +107,7 @@ export const CastActions = React.memo(function CastActions({
 
       {onTipPress && (
         <TouchableOpacity style={styles.actionButton} onPress={onTipPress}>
-          <SnapIcon color={theme.colors.textMuted} size={16} />
+          <SnapTipIcon color={theme.colors.textMuted} size={24} />
         </TouchableOpacity>
       )}
     </View>

--- a/components/SocialFeed/content/SnapIconVariants.tsx
+++ b/components/SocialFeed/content/SnapIconVariants.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface VariantProps {
+  /** Render size in px (height of the icon box). Width derives from the
+   *  tight content aspect ratio so the hand fills the box. */
+  size?: number;
+  color: string;
+}
+
+/**
+ * Candidate snap (tip) glyph — kept local to mobile (NOT in quorum-shared)
+ * for a future swap of the cast tip icon. See CastActions `SNAP_VARIANT`.
+ */
+
+/**
+ * Outline variant — line-art snapping hand with motion ticks.
+ *
+ * The source artwork lives in a 24x27 space but the hand only occupies part
+ * of it (wide left/right margins, slack above the motion ticks). Rendering
+ * that raw box at `size` makes the icon optically smaller than the SF Symbol
+ * action icons beside it AND taller than them (the box height = size, but the
+ * visible mass sits low → bottom-heavy, misaligned in a center-aligned row).
+ *
+ * Fix: a tight viewBox cropped to the hand's bounding box (content bounds
+ * x 4.18–19.36, y 2.57–25.24, plus ~1.4u stroke padding). Now the box wraps
+ * the content, so at `size={20}` the box is 20px tall — same as a 20px SF
+ * Symbol, no taller row — and the hand is centered, not bottom-weighted.
+ */
+const VIEWBOX = { x: 2.8, y: 1.2, w: 17.8, h: 25.2 };
+
+export function SnapIconOutline({ size = 20, color }: VariantProps) {
+  const width = (size * VIEWBOX.w) / VIEWBOX.h;
+  // Source stroke is 2 at viewBox-height 25.2; scale so it reads ~1.6px
+  // regardless of render size (matches the thin SF Symbol strokes).
+  const strokeWidth = (1.6 * VIEWBOX.h) / size;
+  const common = {
+    stroke: color,
+    strokeWidth,
+    fill: 'none' as const,
+    strokeLinecap: 'round' as const,
+    strokeLinejoin: 'round' as const,
+  };
+  return (
+    <Svg
+      width={width}
+      height={size}
+      viewBox={`${VIEWBOX.x} ${VIEWBOX.y} ${VIEWBOX.w} ${VIEWBOX.h}`}
+      fill="none"
+    >
+      <Path
+        d="M9.51163 12.802L15.652 6.92443C15.9394 6.64934 16.3243 6.49968 16.722 6.50838C17.1197 6.51708 17.4977 6.68341 17.7728 6.9708C18.0479 7.25819 18.1976 7.64308 18.1889 8.04081C18.1802 8.43854 18.0138 8.81653 17.7264 9.09161L12.3085 14.2777"
+        {...common}
+      />
+      <Path
+        d="M12.6696 13.9319L14.1144 12.5489C14.2567 12.4127 14.4244 12.3059 14.608 12.2345C14.7916 12.1631 14.9875 12.1286 15.1844 12.1329C15.3814 12.1372 15.5755 12.1803 15.7558 12.2596C15.9361 12.3389 16.099 12.453 16.2352 12.5953C16.3714 12.7376 16.4783 12.9053 16.5497 13.0889C16.621 13.2725 16.6556 13.4684 16.6513 13.6653C16.647 13.8623 16.6039 14.0564 16.5246 14.2367C16.4452 14.417 16.3311 14.5799 16.1888 14.7161L14.3829 16.4448"
+        {...common}
+      />
+      <Path
+        d="M15.4665 15.4076C15.7538 15.1325 16.1387 14.9828 16.5365 14.9915C16.9342 15.0002 17.3122 15.1666 17.5873 15.454C17.8624 15.7413 18.012 16.1262 18.0033 16.524C17.9946 16.9217 17.8283 17.2997 17.5409 17.5748L16.4573 18.612"
+        {...common}
+      />
+      <Path
+        d="M16.8184 18.2661C17.1058 17.991 17.4907 17.8414 17.8884 17.8501C18.2862 17.8588 18.6642 18.0251 18.9392 18.3125C19.2143 18.5999 19.364 18.9848 19.3553 19.3825C19.3466 19.7802 19.1803 20.1582 18.8929 20.4333L15.6421 23.545C14.4925 24.6453 12.953 25.2439 11.362 25.2092C9.77112 25.1744 8.25919 24.509 7.15884 23.3595L5.77588 21.9147L5.9197 22.0649C5.23249 21.3472 4.73427 20.4701 4.4698 19.5123C4.20533 18.5544 4.18289 17.5459 4.40448 16.5773C4.43125 16.4609 4.45831 16.3445 4.48567 16.2283C4.61596 15.6716 5.23784 13.5606 6.35135 9.89367C6.46485 9.51987 6.71971 9.20509 7.06171 9.01629C7.40371 8.82749 7.80588 8.77956 8.18267 8.8827C8.58414 8.99244 8.93742 9.23317 9.18642 9.56666C9.43541 9.90016 9.56583 10.3073 9.55697 10.7234L9.51153 12.8018"
+        {...common}
+      />
+      <Path d="M9.2591 4.656L9.23634 2.57196" {...common} strokeLinejoin={undefined} />
+      <Path d="M12.2594 4.99506L13.8625 3.66324" {...common} strokeLinejoin={undefined} />
+      <Path d="M6.23573 5.25336L4.63261 3.92154" {...common} strokeLinejoin={undefined} />
+    </Svg>
+  );
+}

--- a/components/SocialFeed/views/ChannelView.tsx
+++ b/components/SocialFeed/views/ChannelView.tsx
@@ -346,7 +346,7 @@ export function ChannelView({
           </TouchableOpacity>
           <View style={staticStyles.actionButton}>
             <IconSymbol
-              name={cast.viewerContext?.recast ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+              name="arrow.triangle.2.circlepath"
               color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
               size={16}
             />

--- a/components/SocialFeed/views/HegemonyGovernanceView.tsx
+++ b/components/SocialFeed/views/HegemonyGovernanceView.tsx
@@ -293,7 +293,7 @@ export function HegemonyGovernanceView({ theme, token }: { theme: AppTheme; toke
             {/* Counts */}
             <View style={{ flexDirection: 'row', gap: Skin.space(14), marginTop: Skin.space(10) }}>
               <Count icon="heart" value={c.likes} theme={theme} />
-              <Count icon="arrowshape.turn.up.right" value={c.recasts} theme={theme} />
+              <Count icon="arrow.triangle.2.circlepath" value={c.recasts} theme={theme} />
               <Count icon="bubble.left" value={c.replies} theme={theme} />
             </View>
           </View>

--- a/components/SocialFeed/views/ProfileView.tsx
+++ b/components/SocialFeed/views/ProfileView.tsx
@@ -358,7 +358,7 @@ export function ProfileView({
           </TouchableOpacity>
           <View style={staticStyles.actionButton}>
             <IconSymbol
-              name={cast.viewerContext?.recast ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+              name="arrow.triangle.2.circlepath"
               color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
               size={16}
             />

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -8,8 +8,10 @@ import { LiveSpacesStrip } from '@/components/SocialFeed/content/LiveSpacesStrip
 import { FarcasterTokenEmbed } from '@/components/SocialFeed/content/FarcasterTokenEmbed';
 import { LikeIcon, getLikeIconType } from '@/components/SocialFeed/content/LikeIcon';
 import { SnapIcon } from '@/components/SocialFeed/content/SnapIcon';
+import { SnapIconOutline, SnapIconFilled } from '@/components/SocialFeed/content/SnapIconVariants';
 import TipModal, { type TipTarget } from '@/components/wallet/TipModal';
 import { ActionSheet, type ActionRowItem } from '@/components/shared/ActionSheet';
+import { ActionRow, ActionRowGroup } from '@/components/shared/ActionRow';
 import { useMiniappManifest } from '@/hooks/useMiniappManifest';
 import { useOgMetadata } from '@/hooks/useOgMetadata';
 import { SnapEmbed, useSnapDetection } from '@/components/SocialFeed/content/SnapEmbed';
@@ -473,6 +475,42 @@ interface ShareToChatModalProps {
   onSent: () => void;
 }
 
+// Styles for the ShareToChat row lists. Color-dependent entries are functions
+// of theme; the rest are static. Rows themselves come from the shared ActionRow
+// primitive — only the section header, group spacing, and avatar chrome live here.
+const shareToChatStyles = {
+  sectionHeader: (theme: AppTheme) => ({
+    fontSize: Skin.font(13),
+    fontWeight: '600' as const,
+    color: theme.colors.textMuted,
+    paddingHorizontal: Skin.space(16),
+    paddingTop: Skin.space(16),
+    paddingBottom: Skin.space(8),
+  }),
+  group: {
+    marginHorizontal: Skin.space(12),
+    marginBottom: Skin.space(4),
+  },
+  dmAvatar: (theme: AppTheme) => ({
+    width: 40,
+    height: 40,
+    borderRadius: Skin.radius(20),
+    backgroundColor: theme.colors.surface3,
+    alignItems: 'center' as const,
+    justifyContent: 'center' as const,
+  }),
+  dmAvatarImage: {
+    width: 40,
+    height: 40,
+    borderRadius: Skin.radius(20),
+  },
+  farcasterBadge: {
+    width: 18,
+    height: 18,
+    opacity: 0.7,
+  },
+};
+
 function ShareToChatModal({
   visible,
   castUrl,
@@ -636,113 +674,68 @@ function ShareToChatModal({
               {/* Spaces Section */}
               {spaces.length > 0 && (
                 <>
-                  <Text
-                    style={{
-                      fontSize: Skin.font(13),
-                      fontWeight: '600',
-                      color: theme.colors.textMuted,
-                      paddingHorizontal: Skin.space(16),
-                      paddingTop: Skin.space(16),
-                      paddingBottom: Skin.space(8),
-                    }}
-                  >
-                    SPACES
-                  </Text>
-                  {spaces.map((space) => (
-                    <TouchableOpacity
-                      key={space.spaceId}
-                      style={{
-                        flexDirection: 'row',
-                        alignItems: 'center',
-                        paddingHorizontal: Skin.space(16),
-                        paddingVertical: Skin.space(12),
-                        gap: Skin.space(12),
-                      }}
-                      onPress={() => setSelectedSpace(space)}
-                    >
-                      <SpaceIcon
-                        name={space.spaceName}
-                        size={40}
-                        style={{ borderRadius: Skin.radius(8) }}
+                  <Text style={shareToChatStyles.sectionHeader(theme)}>SPACES</Text>
+                  <ActionRowGroup style={shareToChatStyles.group}>
+                    {spaces.map((space) => (
+                      <ActionRow
+                        key={space.spaceId}
+                        leading={
+                          <SpaceIcon
+                            name={space.spaceName}
+                            size={40}
+                            style={{ borderRadius: Skin.radius(8) }}
+                          />
+                        }
+                        label={space.spaceName}
+                        sublabel={`${space.groups?.reduce((acc, g) => acc + (g.channels?.length ?? 0), 0) ?? 0} channels`}
+                        trailing="chevron"
+                        onPress={() => setSelectedSpace(space)}
                       />
-                      <View style={{ flex: 1 }}>
-                        <Text style={{ fontSize: Skin.font(15), fontWeight: '500', color: theme.colors.textMain }}>
-                          {space.spaceName}
-                        </Text>
-                        <Text style={{ fontSize: Skin.font(13), color: theme.colors.textMuted }}>
-                          {space.groups?.reduce((acc, g) => acc + (g.channels?.length ?? 0), 0) ?? 0} channels
-                        </Text>
-                      </View>
-                      <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
-                    </TouchableOpacity>
-                  ))}
+                    ))}
+                  </ActionRowGroup>
                 </>
               )}
 
               {/* DMs Section - Merged and sorted by timestamp */}
               {allDMs.length > 0 && (
                 <>
-                  <Text
-                    style={{
-                      fontSize: Skin.font(13),
-                      fontWeight: '600',
-                      color: theme.colors.textMuted,
-                      paddingHorizontal: Skin.space(16),
-                      paddingTop: Skin.space(16),
-                      paddingBottom: Skin.space(8),
-                    }}
-                  >
-                    DIRECT MESSAGES
-                  </Text>
-                  {allDMs.map((conv: any) => {
-                    const isFarcaster = conv.source === 'farcaster';
-                    return (
-                      <TouchableOpacity
-                        key={conv.conversationId}
-                        style={{
-                          flexDirection: 'row',
-                          alignItems: 'center',
-                          paddingHorizontal: Skin.space(16),
-                          paddingVertical: Skin.space(12),
-                          gap: Skin.space(12),
-                        }}
-                        onPress={() => isFarcaster ? handleSelectFarcasterDM(conv) : handleSelectDM(conv)}
-                      >
-                        <View
-                          style={{
-                            width: 40,
-                            height: 40,
-                            borderRadius: Skin.radius(20),
-                            backgroundColor: theme.colors.surface3,
-                            alignItems: 'center',
-                            justifyContent: 'center',
-                          }}
-                        >
-                          {conv.icon ? (
-                            <Image source={{ uri: conv.icon }} style={{ width: 40, height: 40, borderRadius: Skin.radius(20) }} />
-                          ) : (
-                            <IconSymbol name="person.fill" size={20} color={theme.colors.textMuted} />
-                          )}
-                        </View>
-                        <View style={{ flex: 1 }}>
-                          <Text style={{ fontSize: Skin.font(15), fontWeight: '500', color: theme.colors.textMain }}>
-                            {conv.displayName || (isFarcaster ? conv.farcasterUsername : conv.address?.slice(0, 12) + '...') || 'Unknown'}
-                          </Text>
-                          {isFarcaster && conv.farcasterUsername && conv.displayName !== conv.farcasterUsername && (
-                            <Text style={{ fontSize: Skin.font(13), color: theme.colors.textMuted }}>
-                              @{conv.farcasterUsername}
-                            </Text>
-                          )}
-                        </View>
-                        {isFarcaster && (
-                          <Image
-                            source={require('../assets/images/farcaster.png')}
-                            style={{ width: 18, height: 18, opacity: 0.7 }}
-                          />
-                        )}
-                      </TouchableOpacity>
-                    );
-                  })}
+                  <Text style={shareToChatStyles.sectionHeader(theme)}>DIRECT MESSAGES</Text>
+                  <ActionRowGroup style={shareToChatStyles.group}>
+                    {allDMs.map((conv: any) => {
+                      const isFarcaster = conv.source === 'farcaster';
+                      const showHandle =
+                        isFarcaster && conv.farcasterUsername && conv.displayName !== conv.farcasterUsername;
+                      return (
+                        <ActionRow
+                          key={conv.conversationId}
+                          leading={
+                            <View style={shareToChatStyles.dmAvatar(theme)}>
+                              {conv.icon ? (
+                                <Image source={{ uri: conv.icon }} style={shareToChatStyles.dmAvatarImage} />
+                              ) : (
+                                <IconSymbol name="person.fill" size={20} color={theme.colors.textMuted} />
+                              )}
+                            </View>
+                          }
+                          label={
+                            conv.displayName ||
+                            (isFarcaster ? conv.farcasterUsername : conv.address?.slice(0, 12) + '...') ||
+                            'Unknown'
+                          }
+                          sublabel={showHandle ? `@${conv.farcasterUsername}` : undefined}
+                          trailing={
+                            isFarcaster ? (
+                              <Image
+                                source={require('../assets/images/farcaster.png')}
+                                style={shareToChatStyles.farcasterBadge}
+                              />
+                            ) : undefined
+                          }
+                          onPress={() => (isFarcaster ? handleSelectFarcasterDM(conv) : handleSelectDM(conv))}
+                        />
+                      );
+                    })}
+                  </ActionRowGroup>
                 </>
               )}
 
@@ -759,24 +752,16 @@ function ShareToChatModal({
           {/* Channel list when space is selected */}
           {!isSending && selectedSpace && (
             <ScrollView style={{ flex: 1 }}>
-              {channels.map((channel) => (
-                <TouchableOpacity
-                  key={channel.channelId}
-                  style={{
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    paddingHorizontal: Skin.space(16),
-                    paddingVertical: Skin.space(12),
-                    gap: Skin.space(12),
-                  }}
-                  onPress={() => handleSelectChannel(channel)}
-                >
-                  <IconSymbol name="number" size={20} color={theme.colors.textMuted} />
-                  <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>
-                    {channel.channelName}
-                  </Text>
-                </TouchableOpacity>
-              ))}
+              <ActionRowGroup style={shareToChatStyles.group}>
+                {channels.map((channel) => (
+                  <ActionRow
+                    key={channel.channelId}
+                    icon="number"
+                    label={channel.channelName}
+                    onPress={() => handleSelectChannel(channel)}
+                  />
+                ))}
+              </ActionRowGroup>
               {channels.length === 0 && (
                 <View style={{ padding: Skin.space(40), alignItems: 'center' }}>
                   <Text style={{ color: theme.colors.textMuted }}>No channels in this space</Text>
@@ -5196,7 +5181,12 @@ const FeedPostCard = React.memo(function FeedPostCard({
               authorDisplayName: post.authorName,
             })}
           >
-            <SnapIcon color={theme.colors.textMuted} size={16} />
+            {/* TEMP compare row: current | outline | filled. Pick one, then revert. */}
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(8) }}>
+              <SnapIcon color={theme.colors.textMuted} size={16} />
+              <SnapIconOutline color={theme.colors.textMuted} size={16} />
+              <SnapIconFilled color={theme.colors.textMuted} size={16} />
+            </View>
           </TouchableOpacity>
         )}
       </View>

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -444,7 +444,7 @@ function ShareActionSheet({
 
   const actions = [
     {
-      icon: isRecasted ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right',
+      icon: 'arrow.triangle.2.circlepath',
       label: isRecasted ? 'Undo recast' : 'Recast',
       color: isRecasted ? theme.colors.success : theme.colors.textMain,
       onPress: onRecast,
@@ -546,29 +546,6 @@ function ShareActionSheet({
               </Text>
             </TouchableOpacity>
           ))}
-
-          {/* Cancel button */}
-          <TouchableOpacity
-            style={{
-              marginTop: Skin.space(8),
-              marginHorizontal: Skin.space(16),
-              paddingVertical: Skin.space(14),
-              backgroundColor: theme.colors.surface2,
-              borderRadius: Skin.radius(12),
-              alignItems: 'center',
-            }}
-            onPress={onClose}
-          >
-            <Text
-              style={{
-                fontSize: Skin.font(16),
-                fontWeight: '600',
-                color: theme.colors.textMain,
-              }}
-            >
-              Cancel
-            </Text>
-          </TouchableOpacity>
         </View>
       </Pressable>
     </Modal>
@@ -3069,7 +3046,7 @@ function ThreadDetailView({
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               >
                 <IconSymbol
-                  name={isRecasted ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+                  name="arrow.triangle.2.circlepath"
                   color={isRecasted ? theme.colors.success : theme.colors.textMuted}
                   size={16}
                 />
@@ -4009,7 +3986,7 @@ export function ProfileView({
               </TouchableOpacity>
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(6) }}>
                 <IconSymbol
-                  name={cast.viewerContext?.recast ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+                  name="arrow.triangle.2.circlepath"
                   color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
                   size={16}
                 />
@@ -4612,7 +4589,7 @@ function ChannelView({
               </TouchableOpacity>
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(6) }}>
                 <IconSymbol
-                  name={cast.viewerContext?.recast ? 'arrowshape.turn.up.right.fill' : 'arrowshape.turn.up.right'}
+                  name="arrow.triangle.2.circlepath"
                   color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
                   size={16}
                 />
@@ -5290,7 +5267,7 @@ const FeedPostCard = React.memo(function FeedPostCard({
           onPress={() => onOpenShareSheet(post.hash, post.username ?? '', post.content ?? '', isRecasted, recastCount, post.authorFid)}
         >
           <IconSymbol
-            name={isRecasted ? "arrowshape.turn.up.right.fill" : "arrowshape.turn.up.right"}
+            name="arrow.triangle.2.circlepath"
             color={isRecasted ? theme.colors.success : theme.colors.textMuted}
             size={16}
           />

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -9,6 +9,7 @@ import { FarcasterTokenEmbed } from '@/components/SocialFeed/content/FarcasterTo
 import { LikeIcon, getLikeIconType } from '@/components/SocialFeed/content/LikeIcon';
 import { SnapIcon } from '@/components/SocialFeed/content/SnapIcon';
 import TipModal, { type TipTarget } from '@/components/wallet/TipModal';
+import { ActionSheet, type ActionRowItem } from '@/components/shared/ActionSheet';
 import { useMiniappManifest } from '@/hooks/useMiniappManifest';
 import { useOgMetadata } from '@/hooks/useOgMetadata';
 import { SnapEmbed, useSnapDetection } from '@/components/SocialFeed/content/SnapEmbed';
@@ -416,8 +417,6 @@ interface ShareActionSheetProps {
   isRecasted: boolean;
   recastCount: number;
   token?: string;
-  theme: AppTheme;
-  bottomInset: number;
   onClose: () => void;
   onRecast: () => void;
   onQuote: () => void;
@@ -427,129 +426,41 @@ interface ShareActionSheetProps {
 
 function ShareActionSheet({
   visible,
-  castHash,
-  castAuthor,
   isRecasted,
-  recastCount,
   token,
-  theme,
-  bottomInset,
   onClose,
   onRecast,
   onQuote,
   onShareToChat,
   onNativeShare,
 }: ShareActionSheetProps) {
-  if (!visible) return null;
-
-  const actions = [
+  const actions: ActionRowItem[] = [
     {
       icon: 'arrow.triangle.2.circlepath',
       label: isRecasted ? 'Undo recast' : 'Recast',
-      color: isRecasted ? theme.colors.success : theme.colors.textMain,
+      active: isRecasted,
       onPress: onRecast,
       disabled: !token,
     },
     {
       icon: 'quote.bubble',
       label: 'Quote',
-      color: theme.colors.textMain,
       onPress: onQuote,
       disabled: !token,
     },
     {
       icon: 'paperplane',
       label: 'Share to chat',
-      color: theme.colors.textMain,
       onPress: onShareToChat,
-      disabled: false,
     },
     {
       icon: 'square.and.arrow.up',
       label: 'Share',
-      color: theme.colors.textMain,
       onPress: onNativeShare,
-      disabled: false,
     },
   ];
 
-  return (
-    <Modal
-      visible={visible}
-      transparent
-      animationType="fade"
-      onRequestClose={onClose}
-    >
-      <Pressable
-        style={{
-          flex: 1,
-          backgroundColor: 'rgba(0,0,0,0.5)',
-          justifyContent: 'flex-end',
-        }}
-        onPress={onClose}
-      >
-        <View
-          style={{
-            backgroundColor: theme.colors.surface1,
-            borderTopLeftRadius: Skin.radius(16),
-            borderTopRightRadius: Skin.radius(16),
-            paddingTop: Skin.space(12),
-            paddingBottom: bottomInset + 12,
-          }}
-        >
-          {/* Handle bar */}
-          <View
-            style={{
-              width: 36,
-              height: 4,
-              backgroundColor: theme.colors.surface4,
-              borderRadius: Skin.radius(2),
-              alignSelf: 'center',
-              marginBottom: Skin.space(16),
-            }}
-          />
-
-          {actions.map((action, index) => (
-            <TouchableOpacity
-              key={index}
-              style={{
-                flexDirection: 'row',
-                alignItems: 'center',
-                paddingVertical: Skin.space(14),
-                paddingHorizontal: Skin.space(20),
-                opacity: action.disabled ? 0.5 : 1,
-              }}
-              onPress={async () => {
-                if (!action.disabled) {
-                  onClose();
-                  // Small delay to allow modal to close before showing native share
-                  await new Promise(resolve => setTimeout(resolve, 100));
-                  action.onPress();
-                }
-              }}
-              disabled={action.disabled}
-            >
-              <IconSymbol
-                name={action.icon as IconSymbolName}
-                size={22}
-                color={action.color}
-              />
-              <Text
-                style={{
-                  marginLeft: Skin.space(16),
-                  fontSize: Skin.font(16),
-                  color: action.color,
-                  fontWeight: '500',
-                }}
-              >
-                {action.label}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      </Pressable>
-    </Modal>
-  );
+  return <ActionSheet visible={visible} onClose={onClose} actions={actions} />;
 }
 
 // Share to chat modal - lets user pick a space/channel or DM to share the cast link
@@ -3426,8 +3337,6 @@ function ThreadDetailView({
         isRecasted={shareSheetCast?.isRecasted ?? false}
         recastCount={shareSheetCast?.recastCount ?? 0}
         token={token}
-        theme={theme}
-        bottomInset={bottomInset}
         onClose={() => setShareSheetCast(null)}
         onRecast={() => {
           if (shareSheetCast) {
@@ -7373,8 +7282,6 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
             isRecasted={feedShareSheet?.isRecasted ?? false}
             recastCount={feedShareSheet?.recastCount ?? 0}
             token={token}
-            theme={theme}
-            bottomInset={insets.bottom}
             onClose={() => setFeedShareSheet(null)}
             onRecast={() => {
               if (feedShareSheet) {

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -8,7 +8,8 @@ import { LiveSpacesStrip } from '@/components/SocialFeed/content/LiveSpacesStrip
 import { FarcasterTokenEmbed } from '@/components/SocialFeed/content/FarcasterTokenEmbed';
 import { LikeIcon, getLikeIconType } from '@/components/SocialFeed/content/LikeIcon';
 import { SnapIcon } from '@/components/SocialFeed/content/SnapIcon';
-import { SnapIconOutline, SnapIconFilled } from '@/components/SocialFeed/content/SnapIconVariants';
+// Outline snap-icon candidate, kept for a future swap (see SnapIconVariants).
+// import { SnapIconOutline } from '@/components/SocialFeed/content/SnapIconVariants';
 import TipModal, { type TipTarget } from '@/components/wallet/TipModal';
 import { ActionSheet, type ActionRowItem } from '@/components/shared/ActionSheet';
 import { ActionRow, ActionRowGroup } from '@/components/shared/ActionRow';
@@ -2911,7 +2912,7 @@ function ThreadDetailView({
                   isLiked={isLiked}
                   color={theme.colors.textMuted}
                   activeColor={theme.colors.danger}
-                  size={16}
+                  size={20}
                 />
                 {likeCount > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{likeCount}</Text>
@@ -2922,7 +2923,7 @@ function ThreadDetailView({
                 onPress={() => onOpenThread(cast.author.username, cast.hash.slice(0, 10), cast)}
                 hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
               >
-                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={16} />
+                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={20} />
                 {(cast.replies?.count ?? 0) > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{cast.replies?.count}</Text>
                 )}
@@ -2944,7 +2945,7 @@ function ThreadDetailView({
                 <IconSymbol
                   name="arrow.triangle.2.circlepath"
                   color={isRecasted ? theme.colors.success : theme.colors.textMuted}
-                  size={16}
+                  size={20}
                 />
                 {recastCount > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{recastCount}</Text>
@@ -2962,7 +2963,7 @@ function ThreadDetailView({
                   })}
                   hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
                 >
-                  <SnapIcon color={theme.colors.textMuted} size={16} />
+                  <SnapIcon color={theme.colors.textMuted} size={24} />
                 </TouchableOpacity>
               )}
             </View>
@@ -3863,7 +3864,7 @@ export function ProfileView({
                   isLiked={isLiked}
                   color={theme.colors.textMuted}
                   activeColor={theme.colors.danger}
-                  size={16}
+                  size={20}
                 />
                 {likeCount > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{likeCount}</Text>
@@ -3873,7 +3874,7 @@ export function ProfileView({
                 style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(6) }}
                 onPress={navigateToThread}
               >
-                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={16} />
+                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={20} />
                 {(cast.replies?.count ?? 0) > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{cast.replies?.count}</Text>
                 )}
@@ -3882,7 +3883,7 @@ export function ProfileView({
                 <IconSymbol
                   name="arrow.triangle.2.circlepath"
                   color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
-                  size={16}
+                  size={20}
                 />
                 {(cast.recasts?.count ?? 0) > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{cast.recasts?.count}</Text>
@@ -3900,7 +3901,7 @@ export function ProfileView({
                   })}
                   hitSlop={12}
                 >
-                  <SnapIcon color={theme.colors.textMuted} size={16} />
+                  <SnapIcon color={theme.colors.textMuted} size={24} />
                 </TouchableOpacity>
               )}
             </View>
@@ -4466,7 +4467,7 @@ function ChannelView({
                   isLiked={isLiked}
                   color={theme.colors.textMuted}
                   activeColor={theme.colors.danger}
-                  size={16}
+                  size={20}
                 />
                 {likeCount > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{likeCount}</Text>
@@ -4476,7 +4477,7 @@ function ChannelView({
                 style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(6) }}
                 onPress={navigateToThread}
               >
-                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={16} />
+                <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={20} />
                 {(cast.replies?.count ?? 0) > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{cast.replies?.count}</Text>
                 )}
@@ -4485,7 +4486,7 @@ function ChannelView({
                 <IconSymbol
                   name="arrow.triangle.2.circlepath"
                   color={cast.viewerContext?.recast ? theme.colors.success : theme.colors.textMuted}
-                  size={16}
+                  size={20}
                 />
                 {(cast.recasts?.count ?? 0) > 0 && (
                   <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13) }}>{cast.recasts?.count}</Text>
@@ -4503,7 +4504,7 @@ function ChannelView({
                   })}
                   hitSlop={12}
                 >
-                  <SnapIcon color={theme.colors.textMuted} size={16} />
+                  <SnapIcon color={theme.colors.textMuted} size={24} />
                 </TouchableOpacity>
               )}
             </View>
@@ -5139,7 +5140,7 @@ const FeedPostCard = React.memo(function FeedPostCard({
             isLiked={isLiked}
             color={theme.colors.textMuted}
             activeColor={theme.colors.danger}
-            size={16}
+            size={20}
           />
           {likeCount > 0 && (
             <Text style={styles.statText}>{likeCount}</Text>
@@ -5150,7 +5151,7 @@ const FeedPostCard = React.memo(function FeedPostCard({
           onPress={navigateToReply}
           hitSlop={12}
         >
-          <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={16} />
+          <IconSymbol name="bubble.left" color={theme.colors.textMuted} size={20} />
           {post.stats.replies !== '0' && (
             <Text style={styles.statText}>{post.stats.replies}</Text>
           )}
@@ -5163,7 +5164,7 @@ const FeedPostCard = React.memo(function FeedPostCard({
           <IconSymbol
             name="arrow.triangle.2.circlepath"
             color={isRecasted ? theme.colors.success : theme.colors.textMuted}
-            size={16}
+            size={20}
           />
           {recastCount > 0 && (
             <Text style={styles.statText}>{recastCount}</Text>
@@ -5181,12 +5182,7 @@ const FeedPostCard = React.memo(function FeedPostCard({
               authorDisplayName: post.authorName,
             })}
           >
-            {/* TEMP compare row: current | outline | filled. Pick one, then revert. */}
-            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(8) }}>
-              <SnapIcon color={theme.colors.textMuted} size={16} />
-              <SnapIconOutline color={theme.colors.textMuted} size={16} />
-              <SnapIconFilled color={theme.colors.textMuted} size={16} />
-            </View>
+            <SnapIcon color={theme.colors.textMuted} size={24} />
           </TouchableOpacity>
         )}
       </View>

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -1,4 +1,4 @@
-import { BaseModal } from '@/components/shared';
+import { BaseModal, ActionRow, ActionRowGroup } from '@/components/shared';
 import { KickUserModal } from '@/components/KickUserModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
@@ -313,55 +313,37 @@ export default function UserProfileModal({
         {/* Actions - styled as tappable rows */}
         {((onStartDM && !isSelf) || (onMuteUser && !isSelf) || canKick) && (
           <View style={styles.actionsContainer}>
-            {onStartDM && !isSelf && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity
-                  style={styles.actionRow}
+            <ActionRowGroup>
+              {onStartDM && !isSelf && (
+                <ActionRow
+                  icon="bubble.left"
+                  label="Message"
                   onPress={() => {
                     onStartDM(user.userId);
                     onClose();
                   }}
-                >
-                  <IconSymbol name="bubble.left" size={20} color={theme.colors.textMain} />
-                  <Text style={styles.actionRowText}>Message</Text>
-                </TouchableOpacity>
-              </>
-            )}
-            {onMuteUser && !isSelf && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity
-                  style={styles.actionRow}
+                />
+              )}
+              {onMuteUser && !isSelf && (
+                <ActionRow
+                  icon={isUserMuted ? 'bell' : 'bell.slash'}
+                  label={isUserMuted ? 'Unmute' : 'Mute'}
                   onPress={() => {
                     onMuteUser(user.userId);
                     onClose();
                   }}
-                >
-                  <IconSymbol
-                    name={isUserMuted ? 'bell' : 'bell.slash'}
-                    size={20}
-                    color={theme.colors.textMain}
-                  />
-                  <Text style={styles.actionRowText}>
-                    {isUserMuted ? 'Unmute' : 'Mute'}
-                  </Text>
-                </TouchableOpacity>
-              </>
-            )}
-            {/* Kick (space owners only) - destructive row */}
-            {canKick && (
-              <>
-                <View style={styles.divider} />
-                <TouchableOpacity
-                  style={styles.actionRow}
+                />
+              )}
+              {/* Kick (space owners only) - destructive row */}
+              {canKick && (
+                <ActionRow
+                  icon="person.crop.circle.badge.exclamationmark"
+                  label="Kick from Space"
+                  destructive
                   onPress={() => setKickVisible(true)}
-                >
-                  <IconSymbol name="person.crop.circle.badge.exclamationmark" size={20} color={theme.colors.danger} />
-                  <Text style={[styles.actionRowText, styles.dangerText]}>Kick from Space</Text>
-                </TouchableOpacity>
-              </>
-            )}
+                />
+              )}
+            </ActionRowGroup>
           </View>
         )}
       </ScrollView>
@@ -504,23 +486,5 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
     },
     actionsContainer: {
       marginBottom: Skin.space(24),
-    },
-    divider: {
-      height: 1,
-      backgroundColor: theme.colors.border ?? theme.colors.surface3,
-    },
-    actionRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(14),
-      gap: Skin.space(12),
-    },
-    actionRowText: {
-      fontSize: Skin.font(16),
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.regular.fontFamily,
-    },
-    dangerText: {
-      color: theme.colors.danger,
     },
   });

--- a/components/shared/ActionRow.tsx
+++ b/components/shared/ActionRow.tsx
@@ -1,0 +1,170 @@
+/**
+ * ActionRow — the canonical "icon-left + label-right" tappable row.
+ *
+ * Single source of truth for the row visual used across every modal/drawer/
+ * sheet and embedded option list. Use it directly inside any container (a
+ * ScrollView profile modal, a centered dialog, a bottom sheet) when the shared
+ * `ActionSheet` shell doesn't fit — e.g. surfaces that also need Switch rows,
+ * a confirm dialog hosted on top, an emoji strip, or a search field.
+ *
+ * For a standard bottom-sheet menu, prefer `ActionSheet`, which composes these.
+ *
+ * `ActionRowGroup` wraps rows in the standardized rounded card with 1px
+ * dividers between them (and none after the last). Pass plain `<ActionRow>`
+ * children; the group handles the card + divider chrome.
+ *
+ * See .agents/reports/2026-06-15-modal-link-row-audit-and-unified-component.md
+ *
+ * @example
+ *   <ActionRowGroup>
+ *     <ActionRow icon="bubble.left" label="Message" onPress={onMessage} />
+ *     <ActionRow icon="bell.slash" label="Mute" onPress={onMute} />
+ *     <ActionRow icon="trash" label="Delete" destructive onPress={onDelete} />
+ *   </ActionRowGroup>
+ */
+
+import React from 'react';
+import { StyleSheet, Text, View, type ViewStyle } from 'react-native';
+import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { useTheme, type AppTheme } from '@/theme';
+import * as Skin from '@/theme/skins/geometry';
+
+export interface ActionRowProps {
+  label: string;
+  /** IconSymbol name. Omit to leave an aligned spacer, or use `leading`. */
+  icon?: string;
+  onPress?: () => void;
+  destructive?: boolean;
+  disabled?: boolean;
+  /** Optional secondary line under the label. */
+  sublabel?: string;
+  /** Trailing affordance: a chevron, or any custom node (toggle, send icon…). */
+  trailing?: 'chevron' | React.ReactNode;
+  /** Success-tinted active state (e.g. selected / recasted). */
+  active?: boolean;
+  /** Custom leading element (avatar, SpaceIcon) rendered instead of `icon`. */
+  leading?: React.ReactNode;
+  /** Internal — set by ActionRowGroup to drop the divider on the last row. */
+  isLast?: boolean;
+  style?: ViewStyle;
+}
+
+/** Resolve the label/icon tint from the row's state. */
+function rowColor(theme: AppTheme, props: ActionRowProps): string {
+  if (props.disabled) return theme.colors.textMuted;
+  if (props.destructive) return theme.colors.danger;
+  if (props.active) return theme.colors.success;
+  return theme.colors.textMain;
+}
+
+export function ActionRow(props: ActionRowProps) {
+  const { theme } = useTheme();
+  const styles = createRowStyles(theme);
+  const color = rowColor(theme, props);
+
+  const interactive = !!props.onPress && !props.disabled;
+
+  return (
+    <TouchableOpacity
+      style={[styles.row, props.isLast && styles.rowLast, props.style]}
+      onPress={props.onPress}
+      activeOpacity={interactive ? 0.6 : 1}
+      disabled={!interactive}
+      accessibilityRole="button"
+      accessibilityLabel={props.label}
+      accessibilityState={{ disabled: !!props.disabled }}
+    >
+      {props.leading ? (
+        props.leading
+      ) : props.icon ? (
+        // icon name is validated by IconSymbol's mapping at runtime; the strict
+        // union type is too narrow for a generic wrapper.
+        <IconSymbol name={props.icon as IconSymbolName} size={20} color={color} />
+      ) : (
+        <View style={styles.iconSpacer} />
+      )}
+
+      <View style={styles.labelColumn}>
+        <Text style={[styles.label, { color }]}>{props.label}</Text>
+        {props.sublabel ? (
+          <Text style={styles.sublabel} numberOfLines={1}>
+            {props.sublabel}
+          </Text>
+        ) : null}
+      </View>
+
+      {props.trailing === 'chevron' ? (
+        <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+      ) : props.trailing ? (
+        props.trailing
+      ) : null}
+    </TouchableOpacity>
+  );
+}
+
+export interface ActionRowGroupProps {
+  children: React.ReactNode;
+  style?: ViewStyle;
+}
+
+/**
+ * Wraps ActionRow children in the standardized rounded card and stamps the
+ * `isLast` flag so the trailing divider is dropped on the final row.
+ */
+export function ActionRowGroup({ children, style }: ActionRowGroupProps) {
+  const { theme } = useTheme();
+  const styles = createRowStyles(theme);
+
+  const rows = React.Children.toArray(children);
+  return (
+    <View style={[styles.group, style]}>
+      {rows.map((child, index) =>
+        React.isValidElement<ActionRowProps>(child)
+          ? React.cloneElement(child, { isLast: index === rows.length - 1 })
+          : child,
+      )}
+    </View>
+  );
+}
+
+const createRowStyles = (theme: AppTheme) =>
+  StyleSheet.create({
+    group: {
+      // surface2 card after the down-one-step shift (sheet sits at surface0).
+      backgroundColor: theme.colors.surface2,
+      borderRadius: Skin.radius(14),
+      overflow: 'hidden',
+    },
+    row: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Skin.space(12),
+      paddingHorizontal: Skin.space(16),
+      paddingVertical: Skin.space(14),
+      minHeight: 44,
+      // Full 1px (not hairlineWidth ~0.5px, which read as barely visible).
+      // surface4 against the surface2 card.
+      borderBottomWidth: Skin.border(1),
+      borderBottomColor: theme.colors.surface4,
+    },
+    rowLast: {
+      borderBottomWidth: 0,
+    },
+    iconSpacer: {
+      width: 20,
+    },
+    labelColumn: {
+      flex: 1,
+    },
+    label: {
+      ...theme.textStyles.callout,
+    },
+    sublabel: {
+      ...theme.textStyles.footnote,
+      color: theme.colors.textMuted,
+      marginTop: Skin.space(1),
+    },
+  });
+
+export default ActionRow;

--- a/components/shared/ActionSheet.tsx
+++ b/components/shared/ActionSheet.tsx
@@ -4,13 +4,18 @@
  * Drop-in replacement for ActionSheetIOS / Alert.alert that:
  *   - Matches the app's dark/light theme
  *   - Renders consistently on iOS and Android
- *   - Supports an optional icon per action
+ *   - Supports an optional icon (or custom leading element) per action
  *   - Marks destructive actions in red
+ *   - Supports flat lists (`actions`) OR grouped sections (`sections`)
  *
  * Dismissed by tapping the backdrop or swiping down (inherited from BaseModal);
  * there is no separate Cancel row, matching the rest of the app's sheets.
  *
- * @example
+ * This is the single source of truth for the "icon-left + label-right" row used
+ * across every modal/drawer/sheet. See
+ * .agents/reports/2026-06-15-modal-link-row-audit-and-unified-component.md
+ *
+ * @example flat list
  *   <ActionSheet
  *     visible={visible}
  *     onClose={() => setVisible(false)}
@@ -21,6 +26,16 @@
  *       { label: 'Delete', icon: 'trash', onPress: handleDelete, destructive: true },
  *     ]}
  *   />
+ *
+ * @example grouped sections
+ *   <ActionSheet
+ *     visible={visible}
+ *     onClose={onClose}
+ *     sections={[
+ *       { title: 'Spaces', items: spaceRows },
+ *       { title: 'Direct messages', items: dmRows },
+ *     ]}
+ *   />
  */
 
 import React, { useCallback } from 'react';
@@ -28,28 +43,107 @@ import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { BaseModal } from '@/components/shared/BaseModal';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
-import { textStyles, useTheme, type AppTheme } from '@/theme';
+import { useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
 import * as Skin from '@/theme/skins/geometry';
 
-export interface ActionSheetAction {
+export interface ActionRowItem {
   label: string;
+  /** IconSymbol name. Omit to leave an aligned spacer, or use `leading`. */
   icon?: string;
-  /** Runs after the sheet animates closed */
+  /** Runs after the sheet animates closed. */
   onPress: () => void;
   destructive?: boolean;
   disabled?: boolean;
+  /** Optional secondary line under the label. */
+  sublabel?: string;
+  /** Trailing affordance: a chevron, or any custom node (toggle, send icon…). */
+  trailing?: 'chevron' | React.ReactNode;
+  /** Success-tinted active state (e.g. selected / recasted). */
+  active?: boolean;
+  /** Custom leading element (avatar, SpaceIcon) rendered instead of `icon`. */
+  leading?: React.ReactNode;
+}
+
+export interface ActionSheetSection {
+  /** Optional uppercase header shown above the group. */
+  title?: string;
+  items: ActionRowItem[];
 }
 
 interface ActionSheetProps {
   visible: boolean;
   onClose: () => void;
-  /** Optional title shown at the top in bold */
+  /** Optional title shown at the top in bold. */
   title?: string;
-  /** Optional secondary message under the title */
+  /** Optional secondary message under the title. */
   message?: string;
-  /** List of tappable actions — rendered vertically */
-  actions: ActionSheetAction[];
+  /** Flat list of actions (back-compat). Provide this OR `sections`. */
+  actions?: ActionRowItem[];
+  /** Grouped sections. Provide this OR `actions`. */
+  sections?: ActionSheetSection[];
+}
+
+/** Back-compat alias — old call sites typed against `ActionSheetAction`. */
+export type ActionSheetAction = ActionRowItem;
+
+function ActionRow({
+  item,
+  isLast,
+  onPress,
+  theme,
+  styles,
+}: {
+  item: ActionRowItem;
+  isLast: boolean;
+  onPress: (item: ActionRowItem) => void;
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  const color = item.disabled
+    ? theme.colors.textMuted
+    : item.destructive
+      ? theme.colors.danger
+      : item.active
+        ? theme.colors.success
+        : theme.colors.textMain;
+
+  return (
+    <TouchableOpacity
+      style={[styles.actionRow, isLast && styles.actionRowLast]}
+      onPress={() => onPress(item)}
+      activeOpacity={0.6}
+      disabled={item.disabled}
+      accessibilityRole="button"
+      accessibilityLabel={item.label}
+      accessibilityState={{ disabled: !!item.disabled }}
+    >
+      {item.leading ? (
+        item.leading
+      ) : item.icon ? (
+        // icon name is validated by IconSymbol's mapping at runtime; the strict
+        // union type is too narrow for a generic wrapper.
+        <IconSymbol name={item.icon as IconSymbolName} size={20} color={color} />
+      ) : (
+        <View style={styles.iconSpacer} />
+      )}
+
+      <View style={styles.labelColumn}>
+        <Text style={[styles.actionLabel, { color }]}>{item.label}</Text>
+        {item.sublabel ? (
+          <Text style={styles.actionSublabel} numberOfLines={1}>
+            {item.sublabel}
+          </Text>
+        ) : null}
+      </View>
+
+      {item.trailing === 'chevron' ? (
+        <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+      ) : item.trailing ? (
+        item.trailing
+      ) : null}
+    </TouchableOpacity>
+  );
 }
 
 export function ActionSheet({
@@ -58,19 +152,24 @@ export function ActionSheet({
   title,
   message,
   actions,
+  sections,
 }: ActionSheetProps) {
   const { theme } = useTheme();
   const styles = createStyles(theme);
 
+  // Normalize flat `actions` into a single unnamed section.
+  const resolvedSections: ActionSheetSection[] =
+    sections ?? (actions ? [{ items: actions }] : []);
+
   const handleActionPress = useCallback(
-    (action: ActionSheetAction) => {
-      if (action.disabled) return;
+    (item: ActionRowItem) => {
+      if (item.disabled) return;
       haptics.selection();
-      // Close first so the user sees the sheet dismiss, then run the action
-      // on next tick. Prevents visual awkwardness when the action opens
-      // another modal.
+      // Close first so the user sees the sheet dismiss, then run the action on
+      // next tick. Prevents visual awkwardness when the action opens another
+      // modal.
       onClose();
-      setTimeout(() => action.onPress(), 120);
+      setTimeout(() => item.onPress(), 120);
     },
     [onClose],
   );
@@ -85,36 +184,25 @@ export function ActionSheet({
           </View>
         )}
 
-        <View style={styles.actions}>
-          {actions.map((action, index) => {
-            const isLast = index === actions.length - 1;
-            const color = action.disabled
-              ? theme.colors.textMuted
-              : action.destructive
-                ? theme.colors.danger
-                : theme.colors.textMain;
-            return (
-              <TouchableOpacity
-                key={`${action.label}-${index}`}
-                style={[styles.actionRow, isLast && styles.actionRowLast]}
-                onPress={() => handleActionPress(action)}
-                activeOpacity={0.6}
-                disabled={action.disabled}
-              >
-                {action.icon ? (
-                  // icon name is validated by IconSymbol's mapping at runtime;
-                  // the strict union type is too narrow for a generic wrapper.
-                  <IconSymbol name={action.icon as IconSymbolName} size={20} color={color} />
-                ) : (
-                  <View style={styles.iconSpacer} />
-                )}
-                <Text style={[styles.actionLabel, { color }]}>
-                  {action.label}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-        </View>
+        {resolvedSections.map((section, sIndex) => (
+          <View key={`section-${sIndex}`} style={styles.section}>
+            {section.title ? (
+              <Text style={styles.sectionTitle}>{section.title}</Text>
+            ) : null}
+            <View style={styles.group}>
+              {section.items.map((item, iIndex) => (
+                <ActionRow
+                  key={`${item.label}-${iIndex}`}
+                  item={item}
+                  isLast={iIndex === section.items.length - 1}
+                  onPress={handleActionPress}
+                  theme={theme}
+                  styles={styles}
+                />
+              ))}
+            </View>
+          </View>
+        ))}
       </View>
     </BaseModal>
   );
@@ -143,7 +231,19 @@ const createStyles = (theme: AppTheme) =>
       textAlign: 'center',
       marginTop: Skin.space(2),
     },
-    actions: {
+    section: {
+      marginBottom: Skin.space(12),
+    },
+    sectionTitle: {
+      ...theme.textStyles.footnote,
+      color: theme.colors.textMuted,
+      textTransform: 'uppercase',
+      letterSpacing: 0.5,
+      marginTop: Skin.space(4),
+      marginBottom: Skin.space(8),
+      marginHorizontal: Skin.space(8),
+    },
+    group: {
       backgroundColor: theme.colors.surface2,
       borderRadius: Skin.radius(14),
       overflow: 'hidden',
@@ -151,9 +251,10 @@ const createStyles = (theme: AppTheme) =>
     actionRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: Skin.space(14),
+      gap: Skin.space(12),
       paddingHorizontal: Skin.space(16),
       paddingVertical: Skin.space(14),
+      minHeight: 44,
       borderBottomWidth: StyleSheet.hairlineWidth,
       borderBottomColor: theme.colors.surface4,
     },
@@ -163,8 +264,15 @@ const createStyles = (theme: AppTheme) =>
     iconSpacer: {
       width: 20,
     },
-    actionLabel: {
-      ...theme.textStyles.body,
+    labelColumn: {
       flex: 1,
+    },
+    actionLabel: {
+      ...theme.textStyles.callout,
+    },
+    actionSublabel: {
+      ...theme.textStyles.footnote,
+      color: theme.colors.textMuted,
+      marginTop: Skin.space(1),
     },
   });

--- a/components/shared/ActionSheet.tsx
+++ b/components/shared/ActionSheet.tsx
@@ -11,9 +11,12 @@
  * Dismissed by tapping the backdrop or swiping down (inherited from BaseModal);
  * there is no separate Cancel row, matching the rest of the app's sheets.
  *
- * This is the single source of truth for the "icon-left + label-right" row used
- * across every modal/drawer/sheet. See
- * .agents/reports/2026-06-15-modal-link-row-audit-and-unified-component.md
+ * Rows are rendered via the shared `ActionRow` / `ActionRowGroup` primitives —
+ * the single source of truth for the "icon-left + label-right" row. Surfaces
+ * that can't use this bottom-sheet shell (embedded scroll lists, sheets with
+ * Switch rows or a confirm dialog on top) import those primitives directly.
+ *
+ * See .agents/reports/2026-06-15-modal-link-row-audit-and-unified-component.md
  *
  * @example flat list
  *   <ActionSheet
@@ -40,29 +43,15 @@
 
 import React, { useCallback } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { BaseModal } from '@/components/shared/BaseModal';
-import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { ActionRow, ActionRowGroup, type ActionRowProps } from '@/components/shared/ActionRow';
 import { useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
 import * as Skin from '@/theme/skins/geometry';
 
-export interface ActionRowItem {
-  label: string;
-  /** IconSymbol name. Omit to leave an aligned spacer, or use `leading`. */
-  icon?: string;
-  /** Runs after the sheet animates closed. */
+/** A single action. `onPress` is required (the sheet runs it after closing). */
+export interface ActionRowItem extends Omit<ActionRowProps, 'onPress' | 'isLast' | 'style'> {
   onPress: () => void;
-  destructive?: boolean;
-  disabled?: boolean;
-  /** Optional secondary line under the label. */
-  sublabel?: string;
-  /** Trailing affordance: a chevron, or any custom node (toggle, send icon…). */
-  trailing?: 'chevron' | React.ReactNode;
-  /** Success-tinted active state (e.g. selected / recasted). */
-  active?: boolean;
-  /** Custom leading element (avatar, SpaceIcon) rendered instead of `icon`. */
-  leading?: React.ReactNode;
 }
 
 export interface ActionSheetSection {
@@ -86,65 +75,6 @@ interface ActionSheetProps {
 
 /** Back-compat alias — old call sites typed against `ActionSheetAction`. */
 export type ActionSheetAction = ActionRowItem;
-
-function ActionRow({
-  item,
-  isLast,
-  onPress,
-  theme,
-  styles,
-}: {
-  item: ActionRowItem;
-  isLast: boolean;
-  onPress: (item: ActionRowItem) => void;
-  theme: AppTheme;
-  styles: ReturnType<typeof createStyles>;
-}) {
-  const color = item.disabled
-    ? theme.colors.textMuted
-    : item.destructive
-      ? theme.colors.danger
-      : item.active
-        ? theme.colors.success
-        : theme.colors.textMain;
-
-  return (
-    <TouchableOpacity
-      style={[styles.actionRow, isLast && styles.actionRowLast]}
-      onPress={() => onPress(item)}
-      activeOpacity={0.6}
-      disabled={item.disabled}
-      accessibilityRole="button"
-      accessibilityLabel={item.label}
-      accessibilityState={{ disabled: !!item.disabled }}
-    >
-      {item.leading ? (
-        item.leading
-      ) : item.icon ? (
-        // icon name is validated by IconSymbol's mapping at runtime; the strict
-        // union type is too narrow for a generic wrapper.
-        <IconSymbol name={item.icon as IconSymbolName} size={20} color={color} />
-      ) : (
-        <View style={styles.iconSpacer} />
-      )}
-
-      <View style={styles.labelColumn}>
-        <Text style={[styles.actionLabel, { color }]}>{item.label}</Text>
-        {item.sublabel ? (
-          <Text style={styles.actionSublabel} numberOfLines={1}>
-            {item.sublabel}
-          </Text>
-        ) : null}
-      </View>
-
-      {item.trailing === 'chevron' ? (
-        <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
-      ) : item.trailing ? (
-        item.trailing
-      ) : null}
-    </TouchableOpacity>
-  );
-}
 
 export function ActionSheet({
   visible,
@@ -194,18 +124,15 @@ export function ActionSheet({
             {section.title ? (
               <Text style={styles.sectionTitle}>{section.title}</Text>
             ) : null}
-            <View style={styles.group}>
+            <ActionRowGroup>
               {section.items.map((item, iIndex) => (
                 <ActionRow
                   key={`${item.label}-${iIndex}`}
-                  item={item}
-                  isLast={iIndex === section.items.length - 1}
-                  onPress={handleActionPress}
-                  theme={theme}
-                  styles={styles}
+                  {...item}
+                  onPress={() => handleActionPress(item)}
                 />
               ))}
-            </View>
+            </ActionRowGroup>
           </View>
         ))}
       </View>
@@ -250,42 +177,5 @@ const createStyles = (theme: AppTheme) =>
       marginTop: Skin.space(4),
       marginBottom: Skin.space(8),
       marginHorizontal: Skin.space(8),
-    },
-    group: {
-      // Whole stack shifted down one ramp step: sheet surface0, card surface2,
-      // divider surface4 — keeps the relative spacing but darkens the overall
-      // menu. (Sheet bg set via BaseModal's backgroundColor prop above.)
-      backgroundColor: theme.colors.surface2,
-      borderRadius: Skin.radius(14),
-      overflow: 'hidden',
-    },
-    actionRow: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: Skin.space(12),
-      paddingHorizontal: Skin.space(16),
-      paddingVertical: Skin.space(14),
-      minHeight: 44,
-      // Full 1px (not hairlineWidth ~0.5px, which was barely visible). surface4
-      // against the surface2 card after the down-one-step shift.
-      borderBottomWidth: Skin.border(1),
-      borderBottomColor: theme.colors.surface4,
-    },
-    actionRowLast: {
-      borderBottomWidth: 0,
-    },
-    iconSpacer: {
-      width: 20,
-    },
-    labelColumn: {
-      flex: 1,
-    },
-    actionLabel: {
-      ...theme.textStyles.callout,
-    },
-    actionSublabel: {
-      ...theme.textStyles.footnote,
-      color: theme.colors.textMuted,
-      marginTop: Skin.space(1),
     },
   });

--- a/components/shared/ActionSheet.tsx
+++ b/components/shared/ActionSheet.tsx
@@ -175,7 +175,12 @@ export function ActionSheet({
   );
 
   return (
-    <BaseModal visible={visible} onClose={onClose} showHandle>
+    <BaseModal
+      visible={visible}
+      onClose={onClose}
+      showHandle
+      backgroundColor={theme.colors.surface0}
+    >
       <View style={styles.container}>
         {(title || message) && (
           <View style={styles.header}>
@@ -212,6 +217,9 @@ const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
     container: {
       paddingHorizontal: Skin.space(12),
+      // Breathing room below the handle bar before the first group, so the menu
+      // doesn't crowd the top edge of the sheet.
+      paddingTop: Skin.space(12),
       paddingBottom: Skin.space(8),
     },
     header: {
@@ -244,6 +252,9 @@ const createStyles = (theme: AppTheme) =>
       marginHorizontal: Skin.space(8),
     },
     group: {
+      // Whole stack shifted down one ramp step: sheet surface0, card surface2,
+      // divider surface4 — keeps the relative spacing but darkens the overall
+      // menu. (Sheet bg set via BaseModal's backgroundColor prop above.)
       backgroundColor: theme.colors.surface2,
       borderRadius: Skin.radius(14),
       overflow: 'hidden',
@@ -255,7 +266,9 @@ const createStyles = (theme: AppTheme) =>
       paddingHorizontal: Skin.space(16),
       paddingVertical: Skin.space(14),
       minHeight: 44,
-      borderBottomWidth: StyleSheet.hairlineWidth,
+      // Full 1px (not hairlineWidth ~0.5px, which was barely visible). surface4
+      // against the surface2 card after the down-one-step shift.
+      borderBottomWidth: Skin.border(1),
       borderBottomColor: theme.colors.surface4,
     },
     actionRowLast: {

--- a/components/shared/BaseModal.tsx
+++ b/components/shared/BaseModal.tsx
@@ -26,6 +26,8 @@ export interface BaseModalProps {
   fillHeight?: boolean;
   /** Fraction of screen height (0-1) */
   minHeight?: number;
+  /** Sheet background color. Defaults to surface1. */
+  backgroundColor?: string;
 }
 
 /**
@@ -52,6 +54,7 @@ export function BaseModal({
   avoidKeyboard = false,
   fillHeight = false,
   minHeight,
+  backgroundColor,
 }: BaseModalProps) {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
@@ -87,7 +90,7 @@ export function BaseModal({
     };
   }, [avoidKeyboard]);
 
-  const styles = createStyles(theme, insets, height, backdropDarkness, fillHeight, minHeight);
+  const styles = createStyles(theme, insets, height, backdropDarkness, fillHeight, minHeight, backgroundColor);
 
   // Calculate bottom offset and max height when keyboard is visible
   const keyboardVisible = avoidKeyboard && keyboardHeight > 0;
@@ -165,7 +168,8 @@ const createStyles = (
   height: number,
   backdropDarkness: number,
   fillHeight: boolean,
-  minHeight?: number
+  minHeight?: number,
+  backgroundColor?: string
 ) =>
   StyleSheet.create({
     container: {
@@ -183,7 +187,7 @@ const createStyles = (
       // Sheet sits a step above the page background so it reads as a distinct
       // floating panel rather than blending into the dimmed backdrop — most
       // noticeable in dark mode, where the page background is near-black.
-      backgroundColor: theme.colors.surface1,
+      backgroundColor: backgroundColor ?? theme.colors.surface1,
       borderTopLeftRadius: Skin.radius(20),
       borderTopRightRadius: Skin.radius(20),
       // Soft elevation so the rounded top edge reads above the backdrop.

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -1,7 +1,9 @@
 export { BaseModal } from './BaseModal';
 export type { BaseModalProps } from './BaseModal';
 export { ActionSheet } from './ActionSheet';
-export type { ActionSheetAction } from './ActionSheet';
+export type { ActionSheetAction, ActionRowItem, ActionSheetSection } from './ActionSheet';
+export { ActionRow, ActionRowGroup } from './ActionRow';
+export type { ActionRowProps, ActionRowGroupProps } from './ActionRow';
 export { CenterModal } from './CenterModal';
 export type { CenterModalProps } from './CenterModal';
 export { ConfirmDialog } from './ConfirmDialog';

--- a/components/wallet/TipModal.tsx
+++ b/components/wallet/TipModal.tsx
@@ -438,7 +438,7 @@ export default function TipModal({
     <BaseModal visible={visible} onClose={onClose} height={0.75} avoidKeyboard>
       <View style={styles.header}>
         <View style={styles.titleRow}>
-          <SnapIcon color={theme.colors.textMain} size={20} />
+          <SnapIcon color={theme.colors.textMain} size={26} />
           <Text style={styles.title}>Tip</Text>
         </View>
         <TouchableOpacity onPress={onClose}>

--- a/theme/fonts.ts
+++ b/theme/fonts.ts
@@ -12,8 +12,13 @@
  * always the same body text.
  */
 
-/** The bundled default font family. */
-export const DEFAULT_FONT_FAMILY = 'AtAero';
+/**
+ * The default font family. `'System'` is React Native's sentinel for the
+ * platform's native UI font: San Francisco on iOS, and Roboto / the user's
+ * chosen system font on Android (RN falls back to the device default for an
+ * unrecognized family). No bundled font is used unless a skin overrides this.
+ */
+export const DEFAULT_FONT_FAMILY = 'System';
 
 /**
  * Build the weight→{family,weight} map for a given font family. A skin swaps

--- a/theme/skins/mergeSkin.ts
+++ b/theme/skins/mergeSkin.ts
@@ -10,7 +10,8 @@ import type { SkinOverride } from './types';
  * The actual font family the theme uses (and the loader registers) when a skin
  * ships an embedded font. Namespaced by skin id so it never collides with the
  * bundled `AtAero` or a system font; the author's `font.family` is just a
- * display label. Returns null when the skin has no embedded font.
+ * display label. Returns null when the skin has no embedded font, in which case
+ * the theme uses the platform's native system font (see DEFAULT_FONT_FAMILY).
  */
 export function skinFontFamily(skin?: SkinOverride | null): string | null {
   return skin?.font ? `skin-${skin.id || 'local'}` : null;


### PR DESCRIPTION
- Use repeat icon for recast and remove redundant Cancel from share sheet
- Use the device's native system font by default
- Add grouping and row affordances to shared ActionSheet
- Migrate share sheet to shared ActionSheet and improve menu contrast
- Use Quorum send arrow in a circular button on the message composer
- Extract shared ActionRow primitive and adopt it in profile and DM settings sheets
- Adopt shared ActionRow in message actions, share-to-chat, and invite sheets
- Remove divider below emoji row in message action sheet
- Tune cast action + tip icon sizes; add outline snap-icon candidate
- Enlarge tap targets for DM and channel header icons
- Add hitSlop and explicit close button to emoji picker search row