### PR TITLE
feat: skins improvements

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -65,7 +65,7 @@ import { retryPushPrefsSyncIfDirty } from '@/services/notifications/pushPrefsSyn
 import { registerBackgroundNotificationTask } from '@/services/notifications/pushReceivedTask';
 import { CustomThemeProvider, useTheme } from '@/theme';
 import { AppBackground } from '@/components/ui/AppBackground';
-import { getActiveSkin } from '@/services/theme/skinPrefs';
+import { getActiveSkin, getAppearancePref } from '@/services/theme/skinPrefs';
 import { ensureSkinFontLoaded } from '@/theme/skins/fontLoader';
 import { setSkinGeometry } from '@/theme/skins/geometry';
 import { bumpStyleVersion } from '@/theme/skins/skinnableStyleSheet';
@@ -267,6 +267,9 @@ export default function RootLayout() {
     bumpStyleVersion();
     return skin;
   }, []);
+  // Appearance pref is a synchronous MMKV read — available before first paint,
+  // same as the skin tokens, so a manual light/dark choice never flashes.
+  const bootAppearance = React.useMemo(() => getAppearancePref(), []);
   const [skinReady, setSkinReady] = React.useState(false);
   React.useEffect(() => {
     let cancelled = false;
@@ -290,7 +293,7 @@ export default function RootLayout() {
         maxAge: 24 * 60 * 60 * 1000, // 24 hours
       }}
     >
-      <CustomThemeProvider defaultAccentColor="blue" defaultSkin={bootSkin}>
+      <CustomThemeProvider defaultAccentColor="blue" defaultSkin={bootSkin} defaultAppearance={bootAppearance}>
         <StorageProvider>
           <AuthProvider>
             <AuthAwareApiProvider>

--- a/components/skins/SkinSwatch.tsx
+++ b/components/skins/SkinSwatch.tsx
@@ -1,0 +1,55 @@
+/**
+ * SkinSwatch — a tiny palette+geometry preview chip for a skin row.
+ *
+ * A rounded square split diagonally: the top-left triangle is the skin's
+ * accent, the rest is the skin's background. The swatch's OWN corner radius
+ * reflects the skin's geometry (square for a square-corner skin, rounder for a
+ * roomy one), so a color-less skin still previews its shape. Purely
+ * presentational and synchronous — no font loading, no global theme mutation.
+ */
+
+import React from 'react';
+import { View } from 'react-native';
+import { useTheme } from '@/theme';
+
+export function SkinSwatch({
+  accent,
+  background,
+  cornerRadius,
+  size = 40,
+  theme,
+}: {
+  accent: string;
+  background: string;
+  cornerRadius: number;
+  size?: number;
+  theme: ReturnType<typeof useTheme>['theme'];
+}) {
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        borderRadius: cornerRadius,
+        overflow: 'hidden',
+        backgroundColor: background,
+        borderWidth: 1,
+        borderColor: theme.colors.surface5,
+      }}
+    >
+      {/* Oversized square rotated 45° so its straight edge becomes the
+          diagonal; positioned to cover the top-left triangle with the accent. */}
+      <View
+        style={{
+          position: 'absolute',
+          width: size * 1.5,
+          height: size * 1.5,
+          left: -size * 0.75,
+          top: -size * 0.75,
+          backgroundColor: accent,
+          transform: [{ rotate: '45deg' }],
+        }}
+      />
+    </View>
+  );
+}

--- a/components/skins/SkinsModal.tsx
+++ b/components/skins/SkinsModal.tsx
@@ -30,8 +30,47 @@ import {
   type SkinSummary,
 } from '@/services/skins/skinsClient';
 import { SkinEditor } from '@/components/skins/SkinEditor';
+import { SkinSwatch } from '@/components/skins/SkinSwatch';
+import { LightTheme, DarkTheme } from '@/theme';
 import { logger } from '@quilibrium/quorum-shared';
 import * as Skin from '@/theme/skins/geometry';
+
+/** Swatch preview (accent + background + own corner radius) for a skin row. */
+interface SwatchSpec {
+  accent: string;
+  background: string;
+  cornerRadius: number;
+}
+
+/**
+ * Resolve a skin's preview swatch WITHOUT applying it.
+ *
+ * - Colors: the skin's own `accent`/`surface1` for its base; a color-less skin
+ *   (Brutalist/Roomy — geometry only) falls back to the UNSKINNED base theme's
+ *   real accent/surface1, NOT a grey placeholder. That fallback is fixed per
+ *   `base` (light vs dark) so the chip never shifts with the app's live
+ *   appearance toggle — a skin pins its own base.
+ * - Corner radius: mirrors `geometry.ts:radius()`, scaled by the SKIN's OWN
+ *   `deriveGeometry`. The base multiplier is the unskinned `LightTheme.radii.md`
+ *   — using the LIVE `theme.radii.md` was the bug that made every swatch turn
+ *   square whenever a square-corner skin (Brutalist) was the active one.
+ */
+function swatchForSkin(skin: SkinOverride): SwatchSpec {
+  const baseTheme = skin.base === 'dark' ? DarkTheme : LightTheme;
+  const tokens = skin.colors?.[skin.base];
+  const { radiusScale, radiusSet } = Skin.deriveGeometry(skin);
+  const cornerRadius =
+    radiusSet !== undefined
+      ? radiusSet === 0
+        ? 0
+        : radiusSet
+      : Math.round(baseTheme.radii.md * radiusScale);
+  return {
+    accent: tokens?.accent ?? baseTheme.colors.accent,
+    background: tokens?.surface1 ?? baseTheme.colors.surface1,
+    cornerRadius,
+  };
+}
 
 export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: () => void }) {
   const { theme, activeSkin, setActiveSkin, appearance, setAppearance } = useTheme();
@@ -245,6 +284,16 @@ export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: ()
               description="The built-in Quorum theme"
               active={!activeSkin}
               onPress={() => apply(null)}
+              // Default = the built-in unskinned theme, so ALL of its swatch
+              // (accent, background, radius) must come from the base theme, not
+              // the live `theme` — otherwise an active skin (e.g. Midnight Neon)
+              // bleeds its purple accent / square corners into the Default chip.
+              // Tracks light/dark via `theme.dark`, which is correct.
+              swatch={{
+                accent: (theme.dark ? DarkTheme : LightTheme).colors.accent,
+                background: (theme.dark ? DarkTheme : LightTheme).colors.surface1,
+                cornerRadius: (theme.dark ? DarkTheme : LightTheme).radii.md,
+              }}
               footer={
                 !activeSkin ? (
                   <AppearanceSegments value={appearance} onChange={setAppearance} theme={theme} />
@@ -263,6 +312,7 @@ export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: ()
                   onPress={() => apply(skin)}
                   onLongPress={isSample ? undefined : () => confirmDelete(skin)}
                   onDelete={isSample ? undefined : () => confirmDelete(skin)}
+                  swatch={swatchForSkin(skin)}
                   theme={theme}
                 />
               );
@@ -289,6 +339,10 @@ export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: ()
                 description={`${entry.authorName ? `by ${entry.authorName} · ` : ''}${entry.installs} install${entry.installs === 1 ? '' : 's'}`}
                 active={activeSkin?.id === entry.id}
                 onPress={() => installFromGallery(entry, true)}
+                // No swatch here on purpose: gallery summaries carry no color
+                // data, so a chip would be a misleading all-grey fake-preview
+                // identical for every skin. Real per-skin gallery previews are
+                // deferred — see .agents/tasks/2026-06-15-skin-gallery-real-color-swatches.md.
                 theme={theme}
               />
             ))}
@@ -307,6 +361,7 @@ function SkinRow({
   onPress,
   onLongPress,
   onDelete,
+  swatch,
   footer,
   theme,
 }: {
@@ -316,6 +371,7 @@ function SkinRow({
   onPress: () => void;
   onLongPress?: () => void;
   onDelete?: () => void;
+  swatch?: SwatchSpec;
   footer?: React.ReactNode;
   theme: ReturnType<typeof useTheme>['theme'];
 }) {
@@ -345,6 +401,14 @@ function SkinRow({
           backgroundColor: active && !footer ? theme.colors.surface3 : 'transparent',
         }}
       >
+        {swatch && (
+          <SkinSwatch
+            accent={swatch.accent}
+            background={swatch.background}
+            cornerRadius={swatch.cornerRadius}
+            theme={theme}
+          />
+        )}
         <View style={{ flex: 1 }}>
           <Text style={{ color: theme.colors.textMain, fontWeight: '600', fontSize: Skin.font(15) }}>{label}</Text>
           <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13), marginTop: Skin.space(2) }}>{description}</Text>
@@ -378,6 +442,7 @@ function AppearanceSegments({
 }) {
   return (
     <View
+      accessibilityRole="radiogroup"
       style={{
         flexDirection: 'row',
         gap: Skin.space(8),
@@ -391,9 +456,9 @@ function AppearanceSegments({
           <TouchableOpacity
             key={seg.key}
             onPress={() => onChange(seg.key)}
-            accessibilityRole="button"
-            accessibilityState={{ selected: active }}
-            accessibilityLabel={`Appearance: ${seg.label}`}
+            accessibilityRole="radio"
+            accessibilityState={{ checked: active }}
+            accessibilityLabel={`${seg.label} appearance`}
             style={{
               paddingHorizontal: Skin.space(14),
               paddingVertical: Skin.space(7),

--- a/components/skins/SkinsModal.tsx
+++ b/components/skins/SkinsModal.tsx
@@ -18,7 +18,7 @@ import { BaseModal } from '@/components/shared';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useTheme } from '@/theme';
 import { useAuth } from '@/context/AuthContext';
-import { deleteSkin, listSkins, saveSkin } from '@/services/theme/skinPrefs';
+import { deleteSkin, listSkins, saveSkin, type AppearancePref } from '@/services/theme/skinPrefs';
 import { validateSkin } from '@/theme/skins/validate';
 import { SAMPLE_SKINS } from '@/theme/skins/samples';
 import type { SkinOverride } from '@/theme/skins/types';
@@ -34,7 +34,7 @@ import { logger } from '@quilibrium/quorum-shared';
 import * as Skin from '@/theme/skins/geometry';
 
 export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: () => void }) {
-  const { theme, activeSkin, setActiveSkin } = useTheme();
+  const { theme, activeSkin, setActiveSkin, appearance, setAppearance } = useTheme();
   const { user } = useAuth();
   const address = user?.address;
   const [refresh, setRefresh] = React.useState(0);
@@ -245,6 +245,11 @@ export function SkinsModal({ visible, onClose }: { visible: boolean; onClose: ()
               description="The built-in Quorum theme"
               active={!activeSkin}
               onPress={() => apply(null)}
+              footer={
+                !activeSkin ? (
+                  <AppearanceSegments value={appearance} onChange={setAppearance} theme={theme} />
+                ) : undefined
+              }
               theme={theme}
             />
             {skins.map((skin) => {
@@ -302,6 +307,7 @@ function SkinRow({
   onPress,
   onLongPress,
   onDelete,
+  footer,
   theme,
 }: {
   label: string;
@@ -310,35 +316,95 @@ function SkinRow({
   onPress: () => void;
   onLongPress?: () => void;
   onDelete?: () => void;
+  footer?: React.ReactNode;
   theme: ReturnType<typeof useTheme>['theme'];
 }) {
   return (
-    <TouchableOpacity
-      onPress={onPress}
-      onLongPress={onLongPress}
+    <View>
+      <TouchableOpacity
+        onPress={onPress}
+        onLongPress={onLongPress}
+        style={{
+          flexDirection: 'row',
+          alignItems: 'center',
+          gap: Skin.space(12),
+          paddingVertical: Skin.space(14),
+          paddingHorizontal: Skin.space(16),
+          borderRadius: theme.radii.md,
+          backgroundColor: active ? theme.colors.surface3 : 'transparent',
+          marginHorizontal: Skin.space(12),
+          marginBottom: Skin.space(4),
+        }}
+      >
+        <View style={{ flex: 1 }}>
+          <Text style={{ color: theme.colors.textMain, fontWeight: '600', fontSize: Skin.font(15) }}>{label}</Text>
+          <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13), marginTop: Skin.space(2) }}>{description}</Text>
+        </View>
+        {active && <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.accent} />}
+        {onDelete && (
+          <TouchableOpacity onPress={onDelete} hitSlop={10} style={{ padding: Skin.space(4) }}>
+            <IconSymbol name="trash" size={18} color={theme.colors.textMuted} />
+          </TouchableOpacity>
+        )}
+      </TouchableOpacity>
+      {footer}
+    </View>
+  );
+}
+
+const APPEARANCE_SEGMENTS: { key: AppearancePref; label: string }[] = [
+  { key: 'system', label: 'System' },
+  { key: 'light', label: 'Light' },
+  { key: 'dark', label: 'Dark' },
+];
+
+function AppearanceSegments({
+  value,
+  onChange,
+  theme,
+}: {
+  value: AppearancePref;
+  onChange: (pref: AppearancePref) => void;
+  theme: ReturnType<typeof useTheme>['theme'];
+}) {
+  return (
+    <View
       style={{
         flexDirection: 'row',
-        alignItems: 'center',
-        gap: Skin.space(12),
-        paddingVertical: Skin.space(14),
+        gap: Skin.space(8),
         paddingHorizontal: Skin.space(16),
-        borderRadius: theme.radii.md,
-        backgroundColor: active ? theme.colors.surface3 : 'transparent',
-        marginHorizontal: Skin.space(12),
-        marginBottom: Skin.space(4),
+        paddingBottom: Skin.space(8),
       }}
     >
-      <View style={{ flex: 1 }}>
-        <Text style={{ color: theme.colors.textMain, fontWeight: '600', fontSize: Skin.font(15) }}>{label}</Text>
-        <Text style={{ color: theme.colors.textMuted, fontSize: Skin.font(13), marginTop: Skin.space(2) }}>{description}</Text>
-      </View>
-      {active && <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.accent} />}
-      {onDelete && (
-        <TouchableOpacity onPress={onDelete} hitSlop={10} style={{ padding: Skin.space(4) }}>
-          <IconSymbol name="trash" size={18} color={theme.colors.textMuted} />
-        </TouchableOpacity>
-      )}
-    </TouchableOpacity>
+      {APPEARANCE_SEGMENTS.map((seg) => {
+        const active = value === seg.key;
+        return (
+          <TouchableOpacity
+            key={seg.key}
+            onPress={() => onChange(seg.key)}
+            accessibilityRole="button"
+            accessibilityState={{ selected: active }}
+            accessibilityLabel={`Appearance: ${seg.label}`}
+            style={{
+              paddingHorizontal: Skin.space(14),
+              paddingVertical: Skin.space(7),
+              borderRadius: theme.radii.pill,
+              backgroundColor: active ? theme.colors.surface3 : 'transparent',
+            }}
+          >
+            <Text
+              style={{
+                color: active ? theme.colors.textMain : theme.colors.textMuted,
+                fontWeight: '600',
+                fontSize: Skin.font(13),
+              }}
+            >
+              {seg.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      })}
+    </View>
   );
 }
 

--- a/components/skins/SkinsModal.tsx
+++ b/components/skins/SkinsModal.tsx
@@ -319,8 +319,19 @@ function SkinRow({
   footer?: React.ReactNode;
   theme: ReturnType<typeof useTheme>['theme'];
 }) {
+  // When a footer is present (the Default row), the highlighted card wraps BOTH
+  // the tappable label and the footer so the pills sit inside the same rounded
+  // container. Without a footer, the highlight stays on the touchable itself so
+  // every other row looks exactly as before.
   return (
-    <View>
+    <View
+      style={{
+        borderRadius: theme.radii.md,
+        backgroundColor: active && footer ? theme.colors.surface3 : 'transparent',
+        marginHorizontal: Skin.space(12),
+        marginBottom: Skin.space(4),
+      }}
+    >
       <TouchableOpacity
         onPress={onPress}
         onLongPress={onLongPress}
@@ -331,9 +342,7 @@ function SkinRow({
           paddingVertical: Skin.space(14),
           paddingHorizontal: Skin.space(16),
           borderRadius: theme.radii.md,
-          backgroundColor: active ? theme.colors.surface3 : 'transparent',
-          marginHorizontal: Skin.space(12),
-          marginBottom: Skin.space(4),
+          backgroundColor: active && !footer ? theme.colors.surface3 : 'transparent',
         }}
       >
         <View style={{ flex: 1 }}>
@@ -373,7 +382,7 @@ function AppearanceSegments({
         flexDirection: 'row',
         gap: Skin.space(8),
         paddingHorizontal: Skin.space(16),
-        paddingBottom: Skin.space(8),
+        paddingBottom: Skin.space(12),
       }}
     >
       {APPEARANCE_SEGMENTS.map((seg) => {

--- a/services/theme/skinPrefs.ts
+++ b/services/theme/skinPrefs.ts
@@ -83,3 +83,22 @@ export function getActiveSkin(): SkinOverride | null {
   const id = getActiveSkinId();
   return id ? getSkin(id) : null;
 }
+
+/** User's manual appearance choice for the BUILT-IN theme. Has no effect while
+ *  a custom skin is active (skins pin their own base). Stored independently of
+ *  the active skin so it survives switching to a skin and back. */
+export type AppearancePref = 'system' | 'light' | 'dark';
+
+const K_APPEARANCE = 'appearancePref';
+
+/** Manual appearance choice; 'system' (follow device) when unset or invalid. */
+export function getAppearancePref(): AppearancePref {
+  const raw = skinPrefsStore.getString(K_APPEARANCE);
+  return raw === 'light' || raw === 'dark' ? raw : 'system';
+}
+
+export function setAppearancePref(pref: AppearancePref): void {
+  // Store only an explicit override; 'system' is the absence of a key.
+  if (pref === 'system') skinPrefsStore.remove(K_APPEARANCE);
+  else skinPrefsStore.set(K_APPEARANCE, pref);
+}

--- a/theme/ThemeProvider.tsx
+++ b/theme/ThemeProvider.tsx
@@ -5,7 +5,12 @@ import type { SkinOverride } from './skins/types';
 import { ensureSkinFontLoaded } from './skins/fontLoader';
 import { setSkinGeometry } from './skins/geometry';
 import { bumpStyleVersion } from './skins/skinnableStyleSheet';
-import { saveSkin, setActiveSkinId } from '@/services/theme/skinPrefs';
+import {
+  saveSkin,
+  setActiveSkinId,
+  setAppearancePref,
+  type AppearancePref,
+} from '@/services/theme/skinPrefs';
 
 type ThemeContextType = {
   theme: ReturnType<typeof createTheme>;
@@ -14,6 +19,11 @@ type ThemeContextType = {
   /** The applied custom skin, or null for the built-in theme. */
   activeSkin: SkinOverride | null;
   setIsDark: (isDark: boolean) => void;
+  /** Manual appearance choice for the built-in theme: system | light | dark. */
+  appearance: AppearancePref;
+  /** Set + persist the appearance choice. Canonical entry point for the UI —
+   *  use this instead of setIsDark so the choice survives restarts. */
+  setAppearance: (pref: AppearancePref) => void;
   setAccentColor: (color: AccentColor) => void;
   toggleTheme: () => void;
   /** Apply (or clear) a skin. Loads its embedded font before switching so
@@ -42,6 +52,8 @@ type ThemeProviderProps = {
   children: ReactNode;
   defaultAccentColor?: AccentColor;
   forceTheme?: 'light' | 'dark' | null;
+  /** Appearance pref restored from storage at boot (see app/_layout.tsx). */
+  defaultAppearance?: AppearancePref;
   /** Skin resolved + font-preloaded at boot (see app/_layout.tsx). */
   defaultSkin?: SkinOverride | null;
 };
@@ -50,10 +62,13 @@ export const CustomThemeProvider: React.FC<ThemeProviderProps> = ({
   children,
   defaultAccentColor = 'blue',
   forceTheme = null,
+  defaultAppearance = 'system',
   defaultSkin = null,
 }) => {
   const deviceColorScheme = useDeviceColorScheme();
-  const [isDarkOverride, setIsDarkOverride] = useState<boolean | null>(null);
+  const [isDarkOverride, setIsDarkOverride] = useState<boolean | null>(
+    defaultAppearance === 'system' ? null : defaultAppearance === 'dark',
+  );
   const [accentColor, setAccentColor] = useState<AccentColor>(defaultAccentColor);
   const [skin, setSkin] = useState<SkinOverride | null>(defaultSkin);
 
@@ -75,6 +90,14 @@ export const CustomThemeProvider: React.FC<ThemeProviderProps> = ({
   const setIsDarkCb = useCallback((dark: boolean) => {
     setIsDarkOverride(dark);
   }, []);
+
+  const setAppearance = useCallback((pref: AppearancePref) => {
+    setAppearancePref(pref); // persist first
+    setIsDarkOverride(pref === 'system' ? null : pref === 'dark');
+  }, []);
+
+  const appearance: AppearancePref =
+    isDarkOverride === null ? 'system' : isDarkOverride ? 'dark' : 'light';
 
   const setActiveSkin = useCallback(async (next: SkinOverride | null) => {
     if (next) {
@@ -101,12 +124,14 @@ export const CustomThemeProvider: React.FC<ThemeProviderProps> = ({
     isDark,
     accentColor,
     activeSkin: skin,
+    appearance,
     setIsDark: setIsDarkCb,
+    setAppearance,
     setAccentColor,
     toggleTheme,
     setActiveSkin,
     previewSkin,
-  }), [theme, isDark, accentColor, skin, setIsDarkCb, setAccentColor, toggleTheme, setActiveSkin, previewSkin]);
+  }), [theme, isDark, accentColor, skin, appearance, setIsDarkCb, setAppearance, setAccentColor, toggleTheme, setActiveSkin, previewSkin]);
 
   return (
     <ThemeContext.Provider value={value}>


### PR DESCRIPTION
- Add persisted appearance preference (light/dark/system)
- Seed and expose appearance preference in theme provider
- Restore appearance preference at boot
- Add Light/Dark/System appearance control to Default theme row
- Nest appearance pills inside the Default theme card
- style: add per-skin color swatches to the skins list