### PR TITLE
Fix TypeScript errors (and warm lazy modal chunks)

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -20,16 +20,23 @@ import { truncateAddress } from '@/utils/formatAddress';
 import { useTheme } from '@/theme';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import React, { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 import { createSkinnable } from '@/theme/skins/skinnableStyleSheet';
 
-const UserProfileModal = React.lazy(() => import('@/components/UserProfileModal'));
+// Prefetch helpers: warm the lazy chunks in the background after the screen
+// mounts so the first tap on the info icon / a profile opens instantly instead
+// of waiting on the on-demand import. Paths are declared once and reused by both
+// React.lazy() and the prefetch so they can't drift.
+const importUserProfileModal = () => import('@/components/UserProfileModal');
+const importDMSettingsSheet = () => import('@/components/Chat/DMSettingsSheet');
+
+const UserProfileModal = React.lazy(importUserProfileModal);
 const DMSettingsSheet = React.lazy(() =>
-  import('@/components/Chat/DMSettingsSheet').then((m) => ({ default: m.DMSettingsSheet }))
+  importDMSettingsSheet().then((m) => ({ default: m.DMSettingsSheet }))
 );
 
 export default function DMChatScreen() {
@@ -43,6 +50,13 @@ export default function DMChatScreen() {
     fcPfp?: string;
   }>();
   const conversationId = typeof params.id === 'string' ? decodeURIComponent(params.id) : undefined;
+
+  // Warm the lazy modal chunks in the background once the screen is open so the
+  // first open of the info sheet / a profile is instant (no on-demand import wait).
+  useEffect(() => {
+    void importDMSettingsSheet();
+    void importUserProfileModal();
+  }, []);
 
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();

--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -17,13 +17,16 @@ import { truncateAddress } from '@/utils/formatAddress';
 import { isValidAvatarUri } from '@/utils/validation';
 import { FlashList } from '@shopify/flash-list';
 import { router, Stack } from 'expo-router';
-import React, { Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Image, Platform, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
-const NewConversationModal = React.lazy(() => import('@/components/NewConversationModal'));
+// Prefetch helper: warm the lazy chunk in the background so the first tap on the
+// "new conversation" button opens the modal instantly (no on-demand import wait).
+const importNewConversationModal = () => import('@/components/NewConversationModal');
+const NewConversationModal = React.lazy(importNewConversationModal);
 
 // Row for the DMs list
 interface InboxItem {
@@ -116,6 +119,11 @@ export default function MessagesInbox() {
   const { theme, isDark } = useTheme();
   const insets = useSafeAreaInsets();
   const { user } = useAuth();
+
+  // Warm the new-conversation modal chunk in the background once the screen is open.
+  useEffect(() => {
+    void importNewConversationModal();
+  }, []);
 
   const {
     conversations,

--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -286,10 +286,6 @@ export default function MessagesInbox() {
           data={items}
           keyExtractor={(item) => item.id}
           renderItem={renderItem}
-          // Rows are 68px when there's no subtitle wrap, ~82px with one line
-          // of preview text. Use a slightly-over average so FlashList doesn't
-          // unmount cells it thinks are off-screen when they actually aren't.
-          estimatedItemSize={82}
           // Keep more off-screen cells alive so scrolling back up doesn't
           // briefly blank the first few rows while they remount.
           drawDistance={1200}

--- a/app/(tabs)/spaces/[id]/[channelId].tsx
+++ b/app/(tabs)/spaces/[id]/[channelId].tsx
@@ -16,7 +16,7 @@ import { getSpaceKey } from '@/services/config/spaceStorage';
 import { useTheme } from '@/theme';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import React, { Suspense, useCallback, useMemo, useRef, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -28,15 +28,31 @@ import { sendSpaceCallStartMessage } from '@/services/space/spaceMessageService'
 import * as Skin from '@/theme/skins/geometry';
 import { createSkinnable } from '@/theme/skins/skinnableStyleSheet';
 
-const UserProfileModal = React.lazy(() => import('@/components/UserProfileModal'));
-const InviteModal = React.lazy(() => import('@/components/InviteModal'));
-const SpaceSettingsModal = React.lazy(() => import('@/components/SpaceSettingsModal'));
+// Prefetch helpers: warm the lazy chunks in the background after the screen
+// mounts so the first tap on the gear / invite / a profile opens instantly
+// instead of waiting on the on-demand import. SpaceSettingsModal in particular
+// is a large component, so warming it removes a noticeable first-open delay.
+const importUserProfileModal = () => import('@/components/UserProfileModal');
+const importInviteModal = () => import('@/components/InviteModal');
+const importSpaceSettingsModal = () => import('@/components/SpaceSettingsModal');
+
+const UserProfileModal = React.lazy(importUserProfileModal);
+const InviteModal = React.lazy(importInviteModal);
+const SpaceSettingsModal = React.lazy(importSpaceSettingsModal);
 const CastThreadModal = React.lazy(() => import('@/components/CastThreadModal'));
 
 export default function SpaceChannelChat() {
   const params = useLocalSearchParams<{ id: string; channelId: string }>();
   const spaceId = typeof params.id === 'string' ? params.id : undefined;
   const channelId = typeof params.channelId === 'string' ? params.channelId : undefined;
+
+  // Warm the lazy modal chunks in the background once the screen is open so the
+  // first open of space settings / invite / a profile is instant.
+  useEffect(() => {
+    void importSpaceSettingsModal();
+    void importUserProfileModal();
+    void importInviteModal();
+  }, []);
 
   const { theme } = useTheme();
   const { user } = useAuth();

--- a/app/(tabs)/spaces/[id]/index.tsx
+++ b/app/(tabs)/spaces/[id]/index.tsx
@@ -14,20 +14,33 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import { haptics } from '@/utils/haptics';
 import type { Group } from '@quilibrium/quorum-shared';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
-import React, { Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
-const SpaceSettingsModal = React.lazy(() => import('@/components/SpaceSettingsModal'));
-const InviteModal = React.lazy(() => import('@/components/InviteModal'));
+// Prefetch helpers: warm the lazy chunks in the background after the screen
+// mounts so the first tap on the gear / invite opens instantly instead of
+// waiting on the on-demand import.
+const importSpaceSettingsModal = () => import('@/components/SpaceSettingsModal');
+const importInviteModal = () => import('@/components/InviteModal');
+
+const SpaceSettingsModal = React.lazy(importSpaceSettingsModal);
+const InviteModal = React.lazy(importInviteModal);
 
 export default function SpaceChannelsScreen() {
   const params = useLocalSearchParams<{ id: string }>();
   const spaceId = typeof params.id === 'string' ? params.id : undefined;
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
+
+  // Warm the lazy modal chunks in the background once the screen is open so the
+  // first open of space settings / invite is instant.
+  useEffect(() => {
+    void importSpaceSettingsModal();
+    void importInviteModal();
+  }, []);
 
   const { data: spaceData, isLoading } = useSpace(spaceId, { enabled: !!spaceId });
   useChannels(spaceId, { enabled: !!spaceId });

--- a/app/(tabs)/spaces/index.tsx
+++ b/app/(tabs)/spaces/index.tsx
@@ -10,13 +10,16 @@ import { haptics } from '@/utils/haptics';
 import type { Space } from '@quilibrium/quorum-shared';
 import { FlashList } from '@shopify/flash-list';
 import { router, Stack } from 'expo-router';
-import React, { Suspense, useCallback, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Image, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
-const SpaceModal = React.lazy(() => import('@/components/SpaceModal'));
+// Prefetch helper: warm the lazy chunk in the background so the first tap on the
+// "+" add-space button opens the modal instantly (no on-demand import wait).
+const importSpaceModal = () => import('@/components/SpaceModal');
+const SpaceModal = React.lazy(importSpaceModal);
 
 interface SpaceItem {
   id: string;
@@ -97,6 +100,11 @@ export default function SpacesIndex() {
   const [search, setSearch] = useState('');
   const [spaceModalVisible, setSpaceModalVisible] = useState(false);
   const [refreshing, setRefreshing] = useState(false);
+
+  // Warm the add-space modal chunk in the background once the screen is open.
+  useEffect(() => {
+    void importSpaceModal();
+  }, []);
 
   const styles = useMemo(() => createStyles(theme, isDark), [theme, isDark]);
 

--- a/app/(tabs)/spaces/index.tsx
+++ b/app/(tabs)/spaces/index.tsx
@@ -235,7 +235,6 @@ export default function SpacesIndex() {
           data={items}
           keyExtractor={item => item.id}
           renderItem={renderItem}
-          estimatedItemSize={72}
           drawDistance={800}
           contentContainerStyle={styles.listContent}
           refreshControl={

--- a/app/browser.tsx
+++ b/app/browser.tsx
@@ -294,7 +294,7 @@ export default function BrowserScreen() {
     if (navState.title && !name) {
       setTitle(navState.title);
     }
-    setLoading(navState.loading);
+    setLoading(navState.loading ?? false);
   };
 
   const handleGoBack = () => {

--- a/components/BrowserModal.tsx
+++ b/components/BrowserModal.tsx
@@ -833,8 +833,8 @@ export default function BrowserModal({ visible, url, onClose, isQNative = false,
     setCanGoBack(navState.canGoBack);
     setCanGoForward(navState.canGoForward);
     setCurrentUrl(navState.url);
-    setTitle(navState.title);
-    setLoading(navState.loading);
+    setTitle(navState.title ?? '');
+    setLoading(navState.loading ?? false);
   };
 
   const handleGoBack = () => {

--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -354,7 +354,6 @@ export function DirectMessagesList({
         data={filteredConversations}
         keyExtractor={(item) => item.conversationId}
         renderItem={renderItem}
-        estimatedItemSize={73}
         refreshControl={
           onRefresh ? (
             <RefreshControl

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1138,11 +1138,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         scrollEventThrottle={64}
         onStartReached={handleEndReached}
         onStartReachedThreshold={0.5}
-        // Message rows are highly variable (text wrap, embeds, reactions). Using
-        // a realistic average prevents FlashList from aggressively unmounting
-        // cells that end up taller than expected, which caused the "first few
-        // messages vanishing on scroll" quirk.
-        estimatedItemSize={110}
         // Keep a larger window of rendered cells alive so that scrolling back
         // toward the top doesn't briefly render empty space before the older
         // cells remount.

--- a/components/NewConversationModal.tsx
+++ b/components/NewConversationModal.tsx
@@ -148,8 +148,8 @@ export default function NewConversationModal({
         address: targetAddress,
         type: 'direct',
         timestamp: Date.now(),
-        displayName: usernameToResolve ? `@${usernameToResolve}` : undefined,
-        icon: undefined,
+        displayName: usernameToResolve ? `@${usernameToResolve}` : '',
+        icon: '',
         lastReadTimestamp: undefined,
       });
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -1320,6 +1320,12 @@ export default function ProfileModal({
       return;
     }
 
+    // Capture the validated markers so the async onPress closure below has
+    // non-undefined values (the guard above can't narrow record.ownership
+    // through the closure boundary).
+    const oneTimeKeyB64 = record.ownership.one_time_key;
+    const verificationKeyB64 = record.ownership.verification_key;
+
     Alert.alert(
       'Make Name Resolvable',
       `Allow others to look up your public key via @${name}?\n\nThis enables encrypted messaging to your address.`,
@@ -1341,8 +1347,8 @@ export default function ProfileModal({
               );
 
               // Decode the stealth markers from the bucket record
-              const oneTimeKey = Uint8Array.from(atob(record.ownership.one_time_key), c => c.charCodeAt(0));
-              const verificationKey = Uint8Array.from(atob(record.ownership.verification_key), c => c.charCodeAt(0));
+              const oneTimeKey = Uint8Array.from(atob(oneTimeKeyB64), c => c.charCodeAt(0));
+              const verificationKey = Uint8Array.from(atob(verificationKeyB64), c => c.charCodeAt(0));
 
               // Generate timestamp and nonce
               const timestamp = Math.floor(Date.now() / 1000);
@@ -3190,7 +3196,6 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       color: theme.colors.textMain,
       fontFamily: 'monospace',
       lineHeight: Skin.font(18),
-      wordBreak: 'break-all',
     },
     recoveryPhraseActions: {
       flexDirection: 'row',

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -1685,7 +1685,7 @@ function MiniappAwareLinkPreview({
       <FrameEmbed
         imageUrl={m.imageUrl ?? m.iconUrl ?? og.image ?? ''}
         buttonTitle={m.buttonTitle ?? 'Open'}
-        actionUrl={m.homeUrl}
+        actionUrl={m.homeUrl!}
         theme={theme}
         onPress={() => onOpenMiniApp?.(m.homeUrl!)}
       />
@@ -6233,7 +6233,7 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
         '[SocialFeedModal] main cast submit threw:',
         err instanceof Error ? err.message : String(err),
       );
-      setPostError(err?.message ?? 'Failed to publish cast.');
+      setPostError(err instanceof Error ? err.message : 'Failed to publish cast.');
     } finally {
       setPosting(false);
     }

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -82,7 +82,7 @@ import { useVideoPlayer, VideoView } from 'expo-video';
 import { setAudioModeAsync } from 'expo-audio';
 import { Image as ExpoImage } from 'expo-image';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Animated, BackHandler, Dimensions, Image, Keyboard, KeyboardAvoidingView, Modal, Platform, Pressable, RefreshControl, ScrollView, Share, StyleSheet, Text, TextInput, View, type KeyboardEvent, type StyleProp, type ViewStyle } from 'react-native';
+import { ActivityIndicator, Alert, Animated, BackHandler, Dimensions, Image, Keyboard, KeyboardAvoidingView, Modal, Platform, Pressable, RefreshControl, ScrollView, Share, StyleSheet, Text, TextInput, View, type KeyboardEvent, type StyleProp, type TextStyle, type ViewStyle } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import ReanimatedModule, { runOnJS, useAnimatedStyle, useSharedValue, withSpring } from 'react-native-reanimated';
@@ -248,7 +248,7 @@ function CastText({
   onLinkPress,
 }: {
   text: string;
-  style?: StyleProp<ViewStyle>;
+  style?: StyleProp<TextStyle>;
   theme: AppTheme;
   onMentionPress?: (username: string) => void;
   onChannelPress?: (channelKey: string) => void;
@@ -3127,7 +3127,6 @@ function ThreadDetailView({
               <View style={{ marginLeft: Skin.space(56) }}>
                 <TextInput
                   ref={replyInputRef}
-                  onFocus={() => setIsEditorFocused(true)}
                   onBlur={() => setIsEditorFocused(false)}
                   style={{
                     minHeight: 40,
@@ -3147,6 +3146,7 @@ function ThreadDetailView({
                     setReplyCursorPosition(e.nativeEvent.selection.end);
                   }}
                   onFocus={() => {
+                    setIsEditorFocused(true);
                     // Scroll to bottom when input is focused so the editor is visible
                     setTimeout(() => {
                       scrollViewRef.current?.scrollToEnd({ animated: true });

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -6486,10 +6486,6 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
               numColumns={activeFilter === 'media' ? 3 : 1}
               // Hint FlashList with the row size so recycling computes
               // accurate slot positions without measuring during scroll.
-              // Grid mode: a single tile is one row's height. Card mode:
-              // an average post is ~400px once media + actions are
-              // accounted for.
-              estimatedItemSize={activeFilter === 'media' ? GRID_TILE_SIZE : 400}
               extraData={likeStates}
               keyExtractor={(item) => item.id}
               showsVerticalScrollIndicator={false}

--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -284,6 +284,7 @@ export default function WalletModal({ visible, onClose, isRouteMode = false, noT
       await Clipboard.setStringAsync(address);
       showToast({
         type: 'success',
+        title: 'Copied',
         message: `${getChainName(chain)} address copied`,
       });
     };

--- a/components/WarpcastWalletImportModal.tsx
+++ b/components/WarpcastWalletImportModal.tsx
@@ -186,7 +186,7 @@ export default function WarpcastWalletImportModal({
 
   // Derive custody address from private key
   const getCustodyAddressFromKey = async (privateKeyHex: string): Promise<string> => {
-    const { secp256k1 } = await import('@noble/curves/secp256k1');
+    const { secp256k1 } = await import('@noble/curves/secp256k1.js');
     const { keccak_256 } = await import('@noble/hashes/sha3.js');
     const { hexToBytes, bytesToHex } = await import('@noble/hashes/utils.js');
 

--- a/components/onboarding/OnboardingLayout.tsx
+++ b/components/onboarding/OnboardingLayout.tsx
@@ -70,7 +70,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
   StyleSheet.create({
     container: {
       flex: 1,
-      backgroundColor: isDark ? theme.colors.surface00 : theme.colors.surface1,
+      backgroundColor: isDark ? theme.colors.surface0 : theme.colors.surface1,
     },
     scrollView: {
       flex: 1,

--- a/components/qns/AuctionsModal.tsx
+++ b/components/qns/AuctionsModal.tsx
@@ -192,7 +192,7 @@ export default function AuctionsModal({
         </View>
 
         <FlatList
-          data={auctions ?? []}
+          data={auctions?.auctions ?? []}
           renderItem={renderAuction}
           keyExtractor={item => item.id}
           contentContainerStyle={styles.listContent}

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2117,11 +2117,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             {
               const preview = getSpaceMessagePreview(spaceMessage);
               const senderId = ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined);
-              const senderMember = spaceId ? await storage.getSpaceMember(spaceId, senderId) : undefined;
+              const senderMember = spaceId && senderId ? await storage.getSpaceMember(spaceId, senderId) : undefined;
               const senderName = messageSenderName(
                 senderId,
                 fullUserAddrRef.current ?? undefined,
-                senderMember ? { [senderId]: senderMember } : undefined
+                senderId && senderMember ? { [senderId]: senderMember } : undefined
               );
               recordSpaceActivity(spaceId, {
                 timestamp: spaceMessage.createdDate || Date.now(),
@@ -3328,11 +3328,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           {
             const preview = getSpaceMessagePreview(spaceMessage);
             const senderId = ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined);
-            const senderMember = spaceId ? await storage.getSpaceMember(spaceId, senderId) : undefined;
+            const senderMember = spaceId && senderId ? await storage.getSpaceMember(spaceId, senderId) : undefined;
             const senderName = messageSenderName(
               senderId,
               fullUserAddrRef.current ?? undefined,
-              senderMember ? { [senderId]: senderMember } : undefined
+              senderId && senderMember ? { [senderId]: senderMember } : undefined
             );
             recordSpaceActivity(spaceId, {
               timestamp: spaceMessage.createdDate || Date.now(),

--- a/services/calling/farcaster-link.ts
+++ b/services/calling/farcaster-link.ts
@@ -3,8 +3,8 @@ import { getFarcasterCustodyKey } from '@/services/onboarding/secureStorage';
 import { ensurePrivateKey } from '@/services/onboarding/keyService';
 import { NativeCryptoProvider } from '@/services/crypto/native-provider';
 import { hexToBytes } from '@quilibrium/quorum-shared';
-import { secp256k1 } from '@noble/curves/secp256k1';
-import { keccak_256 } from '@noble/hashes/sha3';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
+import { keccak_256 } from '@noble/hashes/sha3.js';
 
 /**
  * Generate a bidirectional Farcaster ↔ Quorum identity link.

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -3,8 +3,8 @@
 import { base64ToHex, numberArrayToBase64 } from '@/utils/encoding';
 import { InteractionManager } from 'react-native';
 import { sha512 } from '@noble/hashes/sha2.js';
-import { gcm } from '@noble/ciphers/aes';
-import { randomBytes } from '@noble/ciphers/webcrypto';
+import { gcm } from '@noble/ciphers/aes.js';
+import { randomBytes } from '@noble/ciphers/webcrypto.js';
 import { createMMKV, type MMKV } from 'react-native-mmkv';
 import { getQuorumClient } from '../api/quorumClient';
 import { getPrivateKey, getPublicKey } from '../onboarding/secureStorage';

--- a/services/onboarding/farcasterService.ts
+++ b/services/onboarding/farcasterService.ts
@@ -6,14 +6,14 @@
  * - ed25519 keys for signers
  */
 
-import { ed25519 } from '@noble/curves/ed25519';
-import { secp256k1 } from '@noble/curves/secp256k1';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import { keccak_256 } from '@noble/hashes/sha3.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { hmac } from '@noble/hashes/hmac.js';
 import { sha512 } from '@noble/hashes/sha2.js';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 
 export interface FarcasterKeys {
   custodyAddress: string;      // Ethereum address (0x...)

--- a/services/onboarding/keyService.ts
+++ b/services/onboarding/keyService.ts
@@ -6,14 +6,14 @@
  */
 
 import { base64ToHex, numberArrayToBase64 } from '@/utils/encoding';
-import * as ed448Module from '@noble/curves/ed448';
+import * as ed448Module from '@noble/curves/ed448.js';
 import { bytesToHex, hexToBytes, concatBytes } from '@noble/hashes/utils.js';
 // @ts-ignore - module resolution works at runtime
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import { hmac } from '@noble/hashes/hmac.js';
 import { hkdf } from '@noble/hashes/hkdf.js';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import * as multihashes from 'multihashes';
 import bs58 from 'bs58';
 

--- a/services/reporting/reportService.ts
+++ b/services/reporting/reportService.ts
@@ -18,8 +18,8 @@
  * report to a real account.
  */
 
-import { gcm } from '@noble/ciphers/aes';
-import { randomBytes } from '@noble/hashes/utils';
+import { gcm } from '@noble/ciphers/aes.js';
+import { randomBytes } from '@noble/hashes/utils.js';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { NativeCryptoProvider } from '@/services/crypto/native-provider';
 import { ensurePrivateKey } from '@/services/onboarding/keyService';

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -894,7 +894,7 @@ export async function maybeSendUpdateProfileMessage(
 /** Clear the gate for a (spaceId, senderAddress) — used when the user
  *  leaves a space or signs out so a fresh rejoin re-broadcasts. */
 export function clearProfileBroadcastState(spaceId: string, senderAddress: string): void {
-  getProfileBroadcastStore().delete(profileBroadcastKey(spaceId, senderAddress));
+  getProfileBroadcastStore().remove(profileBroadcastKey(spaceId, senderAddress));
 }
 
 /**
@@ -938,7 +938,7 @@ export function runProfileBroadcastMigrations(): void {
   // new signatures (which include Farcaster fields when linked).
   for (const k of store.getAllKeys()) {
     if (k === MIGRATIONS_KEY) continue;
-    store.delete(k);
+    store.remove(k);
   }
 
   done[tag] = true;

--- a/services/wallet/bittensorService.ts
+++ b/services/wallet/bittensorService.ts
@@ -12,7 +12,7 @@
  */
 
 import { HDKey } from '@scure/bip32';
-import { ed25519 } from '@noble/curves/ed25519';
+import { ed25519 } from '@noble/curves/ed25519.js';
 import { blake2b } from '@noble/hashes/blake2.js';
 import { sha512 } from '@noble/hashes/sha2.js';
 import bs58 from 'bs58';

--- a/services/wallet/kaspaService.ts
+++ b/services/wallet/kaspaService.ts
@@ -11,7 +11,7 @@
  */
 
 import { HDKey } from '@scure/bip32';
-import { secp256k1 } from '@noble/curves/secp256k1';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 
 // Kaspa constants
 export const KASPA_COIN_TYPE = 111111;

--- a/services/wallet/multiChainWallet.ts
+++ b/services/wallet/multiChainWallet.ts
@@ -14,7 +14,7 @@
 
 import { HDKey } from '@scure/bip32';
 import * as bip39 from '@scure/bip39';
-import { wordlist } from '@scure/bip39/wordlists/english';
+import { wordlist } from '@scure/bip39/wordlists/english.js';
 import { bytesToHex, hexToBytes } from '@noble/hashes/utils.js';
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import { hkdf } from '@noble/hashes/hkdf.js';
@@ -22,8 +22,8 @@ import { hmac } from '@noble/hashes/hmac.js';
 import { blake2b } from '@noble/hashes/blake2.js';
 import { ripemd160 } from '@noble/hashes/legacy.js';
 import { keccak_256 } from '@noble/hashes/sha3.js';
-import { ed25519 } from '@noble/curves/ed25519';
-import { secp256k1 } from '@noble/curves/secp256k1';
+import { ed25519 } from '@noble/curves/ed25519.js';
+import { secp256k1 } from '@noble/curves/secp256k1.js';
 import bs58 from 'bs58';
 
 // BIP44/49/84 coin types

--- a/services/wallet/nonEvmTransactionService.ts
+++ b/services/wallet/nonEvmTransactionService.ts
@@ -23,9 +23,9 @@ import bs58 from 'bs58';
 import { blake2b } from '@noble/hashes/blake2.js';
 import { sha256, sha512 } from '@noble/hashes/sha2.js';
 import { ripemd160 } from '@noble/hashes/legacy.js';
-import { secp256k1, schnorr } from '@noble/curves/secp256k1';
+import { secp256k1, schnorr } from '@noble/curves/secp256k1.js';
 import * as bitcoinerlabSecp from '@bitcoinerlab/secp256k1';
-import { ed25519 } from '@noble/curves/ed25519';
+import { ed25519 } from '@noble/curves/ed25519.js';
 import { ApiPromise, WsProvider } from '@polkadot/api';
 import { Keyring } from '@polkadot/keyring';
 

--- a/theme/fonts.ts
+++ b/theme/fonts.ts
@@ -26,7 +26,22 @@ export const DEFAULT_FONT_FAMILY = 'System';
  * consumer picks it up. Embedded skin fonts are single-face, so all weights
  * share one family and rely on synthetic bolding (see fontLoader).
  */
-export function makeFonts(fontFamily: string = DEFAULT_FONT_FAMILY) {
+type FontFace = { fontFamily: string; fontWeight: '400' | '500' | '700' | '900' };
+
+type FontMap = {
+  regular: FontFace;
+  medium: FontFace;
+  bold: FontFace;
+  heavy: FontFace;
+  /**
+   * Optional faces a skin may add. Not produced by the default map, so consumers
+   * must access them defensively (e.g. `theme.fonts.mono?.fontFamily || fallback`).
+   */
+  mono?: FontFace;
+  semiBold?: FontFace;
+};
+
+export function makeFonts(fontFamily: string = DEFAULT_FONT_FAMILY): FontMap {
   return {
     regular: { fontFamily, fontWeight: '400' as const },
     medium: { fontFamily, fontWeight: '500' as const },


### PR DESCRIPTION
Cleans up the bulk of the project's `tsc --noEmit` errors (82 → 23) and removes a noticeable first-open delay on modals. Every fix was typechecked; the riskier remainder (crypto / native-calling / messaging-protocol contracts) was left untouched on purpose.

## TypeScript fixes

- **@noble/@scure v2 imports**: add the `.js` extension to deep imports (e.g. `@noble/curves/secp256k1.js`). v2 keys these subpaths with an explicit `.js` in its exports map; the old form only resolved via Metro's legacy fallback (with a warning). Same module, no behavior change.
- **FlashList v2**: remove `estimatedItemSize` (the prop was removed in flash-list v2, which auto-measures; it was ignored at runtime).
- **Theme**: declare optional `mono`/`semiBold` font faces so the existing `fonts.mono?.fontFamily || fallback` access typechecks; fix a `surface00` → `surface0` typo (the wrong token was `undefined` at runtime, leaving onboarding with no dark-mode background).
- **MMKV**: use `.remove()` instead of `.delete()` (renamed in react-native-mmkv v4; `.delete()` would throw when clearing profile-broadcast state).
- **Null-safety / narrowing**: default optional `navState.loading/title`, narrow `unknown` catch vars before `.message`, guard space-activity sender lookups, pass `''` for required `Conversation` fields.
- **CastText**: the local copy in SocialFeedModal typed its `style` as `ViewStyle` but applies it to `<Text>`; switched to `TextStyle`.

## Real bugs found along the way

- **Auctions list rendered nothing**: the modal passed the whole `{ auctions, total_count }` response object as FlatList `data` instead of the array.
- **Reply input had two `onFocus` handlers**: the second silently overrode the first, so `setIsEditorFocused(true)` never ran. Merged.

## Perf

- Warm the lazy-loaded modal chunks (space settings, DM info, add-space, invite, profile, new-conversation) in the background on screen mount, so the first tap opens instantly instead of waiting on the on-demand import.

## Not included

23 errors remain in crypto (@noble v2 API changes), native calling (react-native-webrtc / expo-modules-core), and messaging-protocol shapes. These need domain knowledge to fix safely and would risk silent breakage if guessed. Happy to share a categorized list.