### PR TITLE
Render Farcaster like logos as crisp SVGs instead of raster PNGs

### DIFF
--- a/components/SocialFeed/content/LikeIcon.tsx
+++ b/components/SocialFeed/content/LikeIcon.tsx
@@ -6,11 +6,9 @@
 
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
-
-// Logo images
-const QuilibriumLogo = require('@/assets/images/qlogo.png');
-const QuorumLogo = require('@/assets/images/icon.png');
+import { StyleSheet, Text, View } from 'react-native';
+import { QuilibriumLogoIcon } from './QuilibriumLogoIcon';
+import { QuorumLogoIcon } from './QuorumLogoIcon';
 
 export enum LikeIconType {
   Standard = 'standard',
@@ -91,30 +89,10 @@ export function LikeIcon({ type, isLiked, color, activeColor, size }: LikeIconPr
 
   switch (type) {
     case LikeIconType.Quilibrium:
-      return (
-        <Image
-          source={QuilibriumLogo}
-          style={{
-            width: size,
-            height: size,
-            borderRadius: size / 2,
-            opacity: isLiked ? 1 : 0.6,
-          }}
-        />
-      );
+      return <QuilibriumLogoIcon size={size} opacity={isLiked ? 1 : 0.6} />;
 
     case LikeIconType.Quorum:
-      return (
-        <Image
-          source={QuorumLogo}
-          style={{
-            width: size,
-            height: size,
-            borderRadius: size / 2,
-            opacity: isLiked ? 1 : 0.6,
-          }}
-        />
-      );
+      return <QuorumLogoIcon size={size} opacity={isLiked ? 1 : 0.6} />;
 
     case LikeIconType.GM:
       return <BoldText text="GM" color={displayColor} size={size} />;

--- a/components/SocialFeed/content/QuilibriumLogoIcon.tsx
+++ b/components/SocialFeed/content/QuilibriumLogoIcon.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface QuilibriumLogoIconProps {
+  /** Render size in px (square). Defaults to 20 to match the like-row icons. */
+  size?: number;
+  /** Opacity, used to mirror the like icon's not-liked (0.6) / liked (1) states. */
+  opacity?: number;
+}
+
+/**
+ * Quilibrium brand mark, used as the like icon for casts mentioning
+ * "quilibrium". Vector source (single color #FF056D) replaces the former
+ * raster `qlogo.png`, so it stays crisp at any size. Tint is fixed to the
+ * brand color; the liked/not-liked distinction is expressed via `opacity`,
+ * exactly as the raster version did.
+ *
+ * The viewBox is cropped to the artwork's exact geometry bounds (the disc
+ * occupies x/y 95–405 of the source 500x500 box). Cropping out that ~19%
+ * internal padding makes the logo fill its `size`-px box like the heart and
+ * other action icons beside it, rather than reading visibly smaller.
+ */
+export function QuilibriumLogoIcon({ size = 20, opacity = 1 }: QuilibriumLogoIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="95 95 310 310" fill="none" opacity={opacity}>
+      <Path
+        d="M296.112 353.244C281.983 359.54 266.395 363.15 249.962 363.15C233.529 363.15 217.94 359.617 203.811 353.244C201.431 352.169 199.05 351.017 196.746 349.788C194.289 348.483 191.909 346.947 189.528 345.488C178.317 338.347 168.488 329.362 160.425 318.842C155.203 312.084 150.749 304.789 147.217 296.957C146.065 294.423 145.067 291.735 144.069 289.048C139.538 276.838 136.85 263.707 136.85 249.962C136.85 187.532 187.608 136.774 250.038 136.774C312.468 136.774 363.226 187.532 363.226 249.962C363.226 263.784 360.539 276.838 356.008 289.048L386.34 323.065C398.089 301.257 405 276.377 405 249.962C404.923 164.495 335.352 95 249.962 95C164.571 95 95 164.495 95 249.962C95 335.429 164.495 404.923 249.962 404.923C277.145 404.923 302.563 397.705 324.755 385.342L296.112 353.244Z"
+        fill="#FF056D"
+      />
+      <Path
+        d="M249.961 235.986C264.889 235.986 276.991 223.885 276.991 208.956C276.991 194.028 264.889 181.926 249.961 181.926C235.033 181.926 222.931 194.028 222.931 208.956C222.931 223.885 235.033 235.986 249.961 235.986Z"
+        fill="#FF056D"
+      />
+      <Path
+        d="M401.161 373.977L369.293 401.007L249.962 267.239L200.279 322.912C188.607 314.926 178.855 304.252 172.097 291.735L212.949 245.969C222.241 254.953 234.834 260.559 248.81 260.559C262.786 260.559 276.454 254.492 285.823 244.817L401.084 374.054L401.161 373.977Z"
+        fill="#FF056D"
+      />
+    </Svg>
+  );
+}
+
+export default QuilibriumLogoIcon;

--- a/components/SocialFeed/content/QuorumLogoIcon.tsx
+++ b/components/SocialFeed/content/QuorumLogoIcon.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface QuorumLogoIconProps {
+  /** Render size in px (square). Defaults to 20 to match the like-row icons. */
+  size?: number;
+  /** Opacity, used to mirror the like icon's not-liked (0.6) / liked (1) states. */
+  opacity?: number;
+}
+
+/**
+ * Quorum brand mark, used as the like icon for casts mentioning "quorum".
+ * Vector source (single color #0287F2) replaces the former raster
+ * `icon.png`, so it stays crisp at any size. Tint is fixed to the brand
+ * color; the liked/not-liked distinction is expressed via `opacity`, exactly
+ * as the raster version did.
+ *
+ * The viewBox is cropped to the artwork's exact geometry bounds (the disc
+ * occupies x/y 95–405 of the source 500x500 box). Cropping out that ~19%
+ * internal padding makes the logo fill its `size`-px box like the heart and
+ * other action icons beside it, rather than reading visibly smaller.
+ */
+export function QuorumLogoIcon({ size = 20, opacity = 1 }: QuorumLogoIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="95 96 308 308" fill="none" opacity={opacity}>
+      <Path
+        d="M263.872 264.817L179.722 262.817L392.243 398.246L401.868 388.341L258.821 180.817L263.872 264.817Z"
+        fill="#0287F2"
+      />
+      <Path
+        d="M249.101 97C164.093 97 95 166.143 95 251C95 335.857 164.188 405 249.101 405C276.167 405 301.422 397.857 323.531 385.571L326.962 383.762L285.506 357.286C274.07 361.19 261.872 363.476 249.101 363.476C232.71 363.476 217.271 359.952 203.166 353.667C200.784 352.619 198.401 351.476 196.114 350.238C193.636 348.905 191.254 347.476 188.967 345.952C177.816 338.905 168 329.952 159.995 319.476C154.849 312.81 150.37 305.476 146.844 297.762C145.7 295.19 144.747 292.524 143.699 289.952C140.458 281.381 138.267 272.333 137.218 262.905C136.742 259 136.456 255.095 136.456 251C136.456 246.905 136.742 242.81 137.123 238.81C142.65 187.667 182.677 146.81 233.377 139.762C238.523 139 243.765 138.524 249.006 138.524C251.96 138.524 254.82 138.714 257.679 139C315.717 143.476 361.556 191.952 361.556 251.095C361.556 262.143 359.746 272.714 356.696 282.81L384.715 323.476C396.341 301.857 403.108 277.286 403.108 251.095C403.108 166.143 333.919 97.0953 249.006 97.0953L249.101 97Z"
+        fill="#0287F2"
+      />
+    </Svg>
+  );
+}
+
+export default QuorumLogoIcon;


### PR DESCRIPTION
## What

The like icon in the Farcaster feed is content-driven: when a cast's text mentions **quilibrium** it shows the Quilibrium logo, and **quorum** shows the Quorum logo (otherwise it's the heart). These two logo variants previously rendered from raster PNGs (`qlogo.png` / `icon.png`) clipped to a circle.

This PR replaces them with `react-native-svg` components built from the brand vector art, so they stay sharp at any size.

## Details

- New components `QuilibriumLogoIcon` and `QuorumLogoIcon` next to `LikeIcon.tsx`.
- Each `viewBox` is cropped to the logo's exact geometry bounds (the art occupies x/y 95-405 of the source 500x500 box). Removing that ~19% internal padding makes the mark fill its box like the heart and other action icons beside it, instead of reading visibly smaller.
- Rendered at 1.0x (no scale fudge needed once cropped).
- Liked / not-liked is still expressed via `opacity` (1 / 0.6), identical to the old raster behavior. Brand color is fixed.
- The PNG assets are left in place; they're still used elsewhere (app icon in `app.json`, `WalletModal`, mock data).

## Testing

- `npx tsc --noEmit` clean for the changed files.
- Visual behavior unchanged apart from crispness and the size match to neighboring icons.