### PR TITLE
feat: unified message composer

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,6 +29,7 @@ import * as SystemUI from 'expo-system-ui';
 import React from 'react';
 import { ActivityIndicator, AppState, Platform, View } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import 'react-native-reanimated';
 
 // Prevent the splash screen from auto-hiding (guarded for Fast Refresh)
@@ -318,7 +319,9 @@ export default function RootLayout() {
 
   return (
     <GestureHandlerRootView style={{ flex: 1 }}>
-      <ErrorBoundary>{content}</ErrorBoundary>
+      <KeyboardProvider>
+        <ErrorBoundary>{content}</ErrorBoundary>
+      </KeyboardProvider>
     </GestureHandlerRootView>
   );
 }

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -484,6 +484,7 @@ export const DMChatArea = React.memo(function DMChatArea({
         pendingAttachment={pendingAttachment}
         onClearAttachment={handleClearAttachment}
         bottomInset={0}
+        bottomChromeHeight={tabBarHeight}
         replyTo={replyToMessage}
         onDismissReply={handleDismissReply}
         editingMessage={editingMessage}

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -8,7 +8,7 @@
 
 import type { AppTheme } from '@/theme';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Keyboard, KeyboardAvoidingView, Platform, StyleSheet, View } from 'react-native';
+import { Platform, StyleSheet, View } from 'react-native';
 import { useHeaderHeight } from '@react-navigation/elements';
 
 import {
@@ -427,26 +427,12 @@ export const DMChatArea = React.memo(function DMChatArea({
     }
   }, [isBookmarked, bookmarks, addBookmark, removeBookmark, conversationId, conversationData]);
 
-  const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
-  useEffect(() => {
-    if (Platform.OS !== 'android') return;
-    const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
-      setAndroidKeyboardHeight(e.endCoordinates.height);
-    });
-    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
-      setAndroidKeyboardHeight(0);
-    });
-    return () => { showSub.remove(); hideSub.remove(); };
-  }, []);
-
   const styles = useMemo(() => createStyles(theme), [theme]);
 
+  // Keyboard avoidance is owned by the composer itself (it grows an animated
+  // spacer that follows the keyboard), so the chat area is a plain flex column.
   return (
-    <KeyboardAvoidingView
-      style={[styles.chatArea, Platform.OS === 'android' && androidKeyboardHeight > 0 && { paddingBottom: androidKeyboardHeight - tabBarHeight / 2 - 10 }]}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
+    <View style={styles.chatArea}>
       {dmSearch.isSearchOpen && (
         <SearchBar
           query={dmSearch.query}
@@ -522,7 +508,7 @@ export const DMChatArea = React.memo(function DMChatArea({
         onClose={() => setReportTarget(null)}
         target={reportTarget}
       />
-    </KeyboardAvoidingView>
+    </View>
   );
 });
 

--- a/components/Chat/DirectMessageView.tsx
+++ b/components/Chat/DirectMessageView.tsx
@@ -124,6 +124,7 @@ export function DirectMessageView({
           channelName={displayName}
           theme={theme}
           isSending={isSending}
+          bottomInset={insets.bottom}
         />
       </View>
     </View>
@@ -176,7 +177,8 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       flex: 1,
     },
     inputContainer: {
-      paddingBottom: insets.bottom,
+      // The composer owns its own bottom safe-area gap (passed as bottomInset),
+      // so the wrapper adds no padding to avoid double-counting it.
     },
   });
 

--- a/components/Chat/DirectMessageView.tsx
+++ b/components/Chat/DirectMessageView.tsx
@@ -5,7 +5,7 @@
 import type { AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import React, { useCallback, useMemo, useState } from 'react';
-import { View, Text, Image, StyleSheet, KeyboardAvoidingView, Platform } from 'react-native';
+import { View, Text, Image, StyleSheet } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -71,12 +71,10 @@ export function DirectMessageView({
     setMessageText('');
   }, [messageText, onSendMessage]);
 
+  // Keyboard avoidance is owned by the composer itself (it grows an animated
+  // spacer that follows the keyboard), so the container is a plain flex column.
   return (
-    <KeyboardAvoidingView
-      style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
+    <View style={styles.container}>
       {/* Header */}
       <View style={styles.header}>
         <TouchableOpacity style={styles.backButton} onPress={onBack}>
@@ -128,7 +126,7 @@ export function DirectMessageView({
           isSending={isSending}
         />
       </View>
-    </KeyboardAvoidingView>
+    </View>
   );
 }
 

--- a/components/Chat/FarcasterDirectMessageView.tsx
+++ b/components/Chat/FarcasterDirectMessageView.tsx
@@ -290,6 +290,7 @@ export function FarcasterDirectMessageView({
         pendingAttachment={pendingAttachment}
         onClearAttachment={handleClearAttachment}
         bottomInset={bottomInset}
+        bottomChromeHeight={tabBarHeight}
       />
     </View>
   );

--- a/components/Chat/FarcasterDirectMessageView.tsx
+++ b/components/Chat/FarcasterDirectMessageView.tsx
@@ -4,7 +4,7 @@
  */
 
 import type { AppTheme } from '@/theme';
-import React, { useCallback, useEffect, useMemo, useState, useRef } from 'react';
+import React, { useCallback, useMemo, useState, useRef } from 'react';
 import {
   View,
   Text,
@@ -12,9 +12,6 @@ import {
   Image,
   Dimensions,
   Alert,
-  Keyboard,
-  KeyboardAvoidingView,
-  Platform,
 } from 'react-native';
 import { DMChatHeader } from './DMChatHeader';
 import { MessagesList } from './MessagesList';
@@ -250,33 +247,10 @@ export function FarcasterDirectMessageView({
   const displayName = conversation.displayName ||
     (conversation.farcasterUsername ? `@${conversation.farcasterUsername}` : 'Unknown');
 
-  // Android KeyboardAvoidingView's `padding` behavior is unreliable when the
-  // screen sits inside a parent that already has paddingBottom (the tab bar
-  // inset on the DM screen). Subscribe to the keyboard directly and pad the
-  // bottom ourselves — matching DMChatArea's tuned offset.
-  const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
-  useEffect(() => {
-    if (Platform.OS !== 'android') return;
-    const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
-      setAndroidKeyboardHeight(e.endCoordinates.height);
-    });
-    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
-      setAndroidKeyboardHeight(0);
-    });
-    return () => { showSub.remove(); hideSub.remove(); };
-  }, []);
-
+  // Keyboard avoidance is owned by the composer itself (it grows an animated
+  // spacer that follows the keyboard), so the container is a plain flex column.
   return (
-    <KeyboardAvoidingView
-      style={[
-        styles.container,
-        Platform.OS === 'android' && androidKeyboardHeight > 0 && {
-          paddingBottom: androidKeyboardHeight - tabBarHeight / 2 - 10,
-        },
-      ]}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
+    <View style={styles.container}>
       {/* Security warning banner */}
       <View style={styles.warningBanner}>
         <Image source={FarcasterLogo} style={styles.warningIcon} />
@@ -317,7 +291,7 @@ export function FarcasterDirectMessageView({
         onClearAttachment={handleClearAttachment}
         bottomInset={bottomInset}
       />
-    </KeyboardAvoidingView>
+    </View>
   );
 }
 

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -1070,6 +1070,10 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   emojiPanelInner: {
     flex: 1,
     backgroundColor: theme.colors.surface4,
+    borderTopLeftRadius: Skin.radius(16),
+    borderTopRightRadius: Skin.radius(16),
+    // Clip the search bar / category band to the rounded top corners.
+    overflow: 'hidden',
   },
   searchContainer: {
     flexDirection: 'row',

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -839,7 +839,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
               <IconSymbol
                 name="plus"
                 color={disabled ? theme.colors.textMuted : theme.colors.textSubtle}
-                size={24}
+                size={27}
               />
             </TouchableOpacity>
           )}
@@ -853,7 +853,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             <IconSymbol
               name={showEmojiPicker ? 'keyboard' : 'face.smiling'}
               color={showEmojiPicker ? theme.colors.primary : (disabled ? theme.colors.textMuted : theme.colors.textSubtle)}
-              size={24}
+              size={27}
             />
           </TouchableOpacity>
         </View>
@@ -912,7 +912,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
 const createStyles = (theme: AppTheme) => StyleSheet.create({
   container: {
-    backgroundColor: theme.colors.surface3,
+    // Match the messages page so the composer bar blends with the chat
+    // background; the pill sits on top as the distinct surface.
+    backgroundColor: theme.colors.surface1,
     paddingHorizontal: Skin.space(12),
     paddingTop: Skin.space(8),
     // paddingBottom and width depend on insets/screen width and are
@@ -1027,7 +1029,8 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     borderRadius: Skin.radius(22),
     paddingVertical: Skin.space(4),
     paddingLeft: Skin.space(4),
-    paddingRight: Skin.space(4),
+    // Keep the send circle hugging the pill's right edge (~1px gap).
+    paddingRight: 1,
     minHeight: 44,
     // A small breathing gap between the pill and whatever sits below it
     // (the keyboard or the emoji panel), so the pill never touches them.

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -895,7 +895,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             {isSending ? (
               <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <SendIcon color="#fff" size={18} />
+              <SendIcon color="#fff" size={20} />
             )}
           </TouchableOpacity>
         </View>
@@ -1026,15 +1026,19 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   // the last line; for a single line everything lands on the same baseline.
   pill: {
     flexDirection: 'row',
-    alignItems: 'flex-end',
+    // Self-sizing: the row height is defined by its tallest child (the 36px
+    // controls), and `center` keeps the text and controls on one baseline on
+    // every device instead of relying on per-device text metrics. No fixed
+    // pill height — it adapts to the font/line-height the device renders.
+    alignItems: 'center',
     backgroundColor: theme.colors.surface5,
     // Large radius => the short ends are always perfect semicircles regardless
-    // of the pill's current height (single line vs wrapped).
+    // of the pill's resolved height (single line vs wrapped).
     borderRadius: 999,
-    paddingVertical: Skin.space(4),
-    paddingLeft: Skin.space(4),
-    // Keep the send circle hugging the pill's right edge (~1px gap).
-    paddingRight: 1,
+    // Uniform inner padding on all four sides: the send circle then has the
+    // same gap to the right edge as it does to the top/bottom, so it reads as
+    // evenly inset (snug but balanced) rather than cramped against one side.
+    padding: Skin.space(4),
     // A small breathing gap between the pill and whatever sits below it
     // (the keyboard or the emoji panel), so the pill never touches them.
     marginBottom: Skin.space(8),
@@ -1052,26 +1056,27 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     flex: 1,
     color: theme.colors.textMain,
     paddingHorizontal: Skin.space(8),
-    // Zero vertical padding: the 36px line box (minHeight) plus the pill's own
-    // 4px vertical padding gives a ~44px single-line pill. textAlignVertical
-    // centers the glyphs so they don't sit low.
-    paddingTop: 0,
-    paddingBottom: 0,
+    // No vertical padding and no minHeight: the input's height is its own
+    // line-height (single line) and grows naturally up to maxHeight when
+    // wrapped. The parent's `alignItems: center` + the 36px controls keep a
+    // single line vertically centered without device-specific magic numbers.
+    paddingVertical: 0,
     fontFamily: theme.fonts.regular.fontFamily,
     fontSize: Skin.font(16),
     lineHeight: Skin.font(22),
     maxHeight: 120,
-    // Match the 36px send/button height so a single line is vertically centered
-    // against them and the pill resolves to ~44px tall.
-    minHeight: 36,
+    // Android adds extra font padding above/below the glyphs that throws off
+    // vertical centering in a flex row; disabling it makes the text box equal
+    // its lineHeight so it centers cleanly. (No-op / ignored on iOS.)
+    includeFontPadding: false,
   },
   inputIconButton: {
     padding: Skin.space(6),
   },
   sendButton: {
-    width: 36,
-    height: 36,
-    borderRadius: 18,
+    width: 40,
+    height: 40,
+    borderRadius: 20,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -886,10 +886,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           <TouchableOpacity
             style={[
               styles.sendButton,
-              // Disabled: a clearly lighter muted-gray circle (surface8) so it
-              // stays an obvious affordance against the surface4 pill, with a
-              // dark arrow on top for contrast. Active: accent fill, white arrow.
-              { backgroundColor: canSend ? theme.colors.accent : theme.colors.surface8 },
+              {
+                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
+                opacity: canSend ? 1 : 0.6,
+              },
             ]}
             onPress={handleSend}
             disabled={!canSend}
@@ -899,7 +899,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             {isSending ? (
               <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <SendIcon color={canSend ? '#fff' : theme.colors.surface2} size={20} />
+              <SendIcon color="#fff" size={20} />
             )}
           </TouchableOpacity>
         </View>

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -8,7 +8,7 @@ import type { Channel, Emoji, SpaceMember, Sticker } from '@quilibrium/quorum-sh
 import { searchEmojis } from '@/data/emojiData';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Image, useWindowDimensions, NativeSyntheticEvent, Platform, ScrollView, StyleSheet, Text, TextInput, TextInputSubmitEditingEventData, View } from 'react-native';
-import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
+import Reanimated, { LinearTransition, useAnimatedStyle } from 'react-native-reanimated';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useComposerPanel } from '@/hooks/useComposerPanel';
 import * as Skin from '@/theme/skins/geometry';
@@ -845,10 +845,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
       {/* The composer pill — one rounded container with the emoji toggle on the
           left, the growing text input, then the attach + send buttons on the
-          right. Single line: a fully-rounded stadium with controls centered.
-          Multi-line: a moderate-radius box with controls pinned to the bottom
-          (last line), like a grown text area. */}
-      <View style={[styles.pill, isMultiline && styles.pillMultiline]}>
+          right. Controls are bottom-anchored in both states (single line is one
+          row tall, so it still reads centered) — avoiding a center<->flex-end
+          flip removes the icon jump at the 1->2 line boundary. Only the corner
+          radius changes when wrapped (stadium -> box). LinearTransition
+          animates the height change so growth/shrink is smooth, not abrupt. */}
+      <Reanimated.View
+        layout={LinearTransition.duration(140)}
+        style={[styles.pill, isMultiline && styles.pillMultiline]}
+      >
         <View style={styles.leftButtons}>
           <TouchableOpacity
             style={styles.inputIconButton}
@@ -924,7 +929,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             )}
           </TouchableOpacity>
         </View>
-      </View>
+      </Reanimated.View>
 
       {/* Animated spacer beneath the pill. Closed: it follows the keyboard so
           the pill rides up (keyboard avoidance). Open: it holds the keyboard
@@ -1051,16 +1056,15 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   // the last line; for a single line everything lands on the same baseline.
   pill: {
     flexDirection: 'row',
-    // Self-sizing: the row height is defined by its tallest child (the 36px
-    // controls), and `center` keeps the text and controls on one baseline on
-    // every device instead of relying on per-device text metrics. No fixed
-    // pill height — it adapts to the font/line-height the device renders.
-    alignItems: 'center',
+    // Bottom-anchor the controls ALWAYS. Single line is one control-row tall so
+    // this reads identical to centered; multi-line keeps the controls on the
+    // last line. Anchoring in both states (rather than flipping center<->
+    // flex-end on wrap) is what removes the icon jump at the 1->2 line boundary.
+    alignItems: 'flex-end',
     // Same shade as the emoji panel so the pill and the panel read as one
     // continuous surface.
     backgroundColor: theme.colors.surface4,
-    // Large radius => the short ends are always perfect semicircles regardless
-    // of the pill's resolved height (single line vs wrapped).
+    // Large radius => the short ends are perfect semicircles while single-line.
     borderRadius: 999,
     // Uniform inner padding on all four sides: the send circle then has the
     // same gap to the right edge as it does to the top/bottom, so it reads as
@@ -1071,10 +1075,9 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     marginBottom: Skin.space(8),
   },
   pillMultiline: {
-    // Grown box: pin controls to the bottom (last line) and drop the stadium
-    // radius to a moderate corner so the short ends don't bulge into big
-    // semicircles on a tall pill.
-    alignItems: 'flex-end',
+    // Grown box: drop the stadium radius to a moderate corner so the short ends
+    // don't bulge into big semicircles on a tall pill. (Controls are already
+    // bottom-anchored by the base style.)
     borderRadius: Skin.radius(20),
   },
   leftButtons: {

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -882,10 +882,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           <TouchableOpacity
             style={[
               styles.sendButton,
-              // Disabled: keep the circle at full opacity (no whole-button fade)
-              // on the lightest surface so it stays a clearly visible affordance
-              // against the pill; the muted arrow signals the inactive state.
-              { backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6 },
+              // Disabled: a clearly lighter muted-gray circle (surface8) so it
+              // stays an obvious affordance against the surface4 pill, with a
+              // dark arrow on top for contrast. Active: accent fill, white arrow.
+              { backgroundColor: canSend ? theme.colors.accent : theme.colors.surface8 },
             ]}
             onPress={handleSend}
             disabled={!canSend}
@@ -895,7 +895,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             {isSending ? (
               <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <SendIcon color={canSend ? '#fff' : theme.colors.textMuted} size={20} />
+              <SendIcon color={canSend ? '#fff' : theme.colors.surface2} size={20} />
             )}
           </TouchableOpacity>
         </View>

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -845,9 +845,12 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
       {/* The composer pill — one rounded container with the emoji toggle on the
           left, the growing text input, then the attach + send buttons on the
-          right. Single line: a fully-rounded stadium with controls centered.
-          Multi-line: a moderate-radius box with controls pinned to the bottom
-          (last line), like a grown text area. */}
+          right. Single line: a fully-rounded stadium, text centered. Multi-line:
+          a moderate-radius box with controls on the last line. The controls are
+          bottom-pinned in BOTH states (button containers, not the pill, own the
+          vertical align) so growing a line never moves them. No layout
+          animation here — it raced the height growth and shoved the icons out
+          of the pill for a frame before they snapped back. */}
       <View style={[styles.pill, isMultiline && styles.pillMultiline]}>
         <View style={styles.leftButtons}>
           <TouchableOpacity
@@ -880,7 +883,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           blurOnSubmit={false}
           multiline
           scrollEnabled
-          textAlignVertical={isMultiline ? 'top' : 'center'}
+          // Always 'center' — flipping this on the multi-line boundary was
+          // unreliable on Android (the text sometimes stayed top-aligned after
+          // shrinking back to one line). Centering the text block reads fine in
+          // both states and is deterministic.
+          textAlignVertical="center"
           onFocus={() => {
             composerPanel.onInputFocus();
             setSearchQuery('');
@@ -1051,16 +1058,16 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   // the last line; for a single line everything lands on the same baseline.
   pill: {
     flexDirection: 'row',
-    // Self-sizing: the row height is defined by its tallest child (the 36px
-    // controls), and `center` keeps the text and controls on one baseline on
-    // every device instead of relying on per-device text metrics. No fixed
-    // pill height — it adapts to the font/line-height the device renders.
-    alignItems: 'center',
+    // `stretch` (not center/flex-end) so children fill the pill's height and we
+    // NEVER flip alignItems on the 1->2 line boundary — that flip was what made
+    // the emoji icon jump. Button position is controlled inside the button
+    // containers (justifyContent: flex-end) and text position by the input's
+    // own textAlignVertical, so neither depends on the pill's vertical align.
+    alignItems: 'stretch',
     // Same shade as the emoji panel so the pill and the panel read as one
     // continuous surface.
     backgroundColor: theme.colors.surface4,
-    // Large radius => the short ends are always perfect semicircles regardless
-    // of the pill's resolved height (single line vs wrapped).
+    // Large radius => the short ends are perfect semicircles while single-line.
     borderRadius: 999,
     // Uniform inner padding on all four sides: the send circle then has the
     // same gap to the right edge as it does to the top/bottom, so it reads as
@@ -1071,19 +1078,21 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     marginBottom: Skin.space(8),
   },
   pillMultiline: {
-    // Grown box: pin controls to the bottom (last line) and drop the stadium
-    // radius to a moderate corner so the short ends don't bulge into big
-    // semicircles on a tall pill.
-    alignItems: 'flex-end',
+    // Grown box: only the corner radius changes (down from the stadium) so the
+    // short ends don't bulge on a tall pill. Controls stay bottom-pinned via
+    // the button containers — no alignItems flip here.
     borderRadius: Skin.radius(20),
   },
+  // Button containers fill the pill height (stretch) and bottom-pin their
+  // button. Single line: container is one row tall, so "bottom" reads centered.
+  // Multi-line: button sits on the last line. Same rule both states -> no jump.
   leftButtons: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-end',
   },
   rightButtons: {
     flexDirection: 'row',
-    alignItems: 'center',
+    alignItems: 'flex-end',
     gap: Skin.space(2),
   },
   input: {

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -227,8 +227,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const containerDynamicStyle = useMemo(() => ({
     width: screenWidth,
   }), [screenWidth]);
-  const availableWidth = screenWidth - 180;
-  const maxPlaceholderNameLength = Math.max(8, Math.min(Math.floor(availableWidth / 8.5), 24));
   const inputRef = useRef<TextInput>(null);
   const valueRef = useRef(value);
   const onChangeTextRef = useRef(onChangeText);
@@ -823,26 +821,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
         </View>
       )}
 
-      {/* The composer pill — one rounded container holding the left-side
-          buttons, the growing text input, and the circular send button. */}
+      {/* The composer pill — one rounded container with the emoji toggle on the
+          left, the growing text input, then the attach + send buttons on the
+          right. */}
       <View style={styles.pill}>
         <View style={styles.leftButtons}>
-          {/* Attach (+) hides while composing to give the text room. */}
-          {!isComposing && (
-            <TouchableOpacity
-              style={styles.inputIconButton}
-              onPress={onAttachmentPress}
-              disabled={disabled}
-              accessibilityRole="button"
-              accessibilityLabel="Attach image"
-            >
-              <IconSymbol
-                name="plus"
-                color={disabled ? theme.colors.textMuted : theme.colors.textSubtle}
-                size={27}
-              />
-            </TouchableOpacity>
-          )}
           <TouchableOpacity
             style={styles.inputIconButton}
             onPress={handleToggleEmojiPicker}
@@ -863,7 +846,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           value={value}
           onChangeText={handleTextChange}
           onSelectionChange={handleSelectionChange}
-          placeholder={editingMessage ? 'Edit message...' : isDM ? `Message ${channelName.length > maxPlaceholderNameLength ? channelName.slice(0, maxPlaceholderNameLength) + '…' : channelName}` : `Message #${channelName}`}
+          placeholder={editingMessage ? 'Edit message...' : 'Message...'}
           placeholderTextColor={theme.colors.textMuted}
           style={styles.input}
           editable={!disabled}
@@ -879,25 +862,43 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           }}
         />
 
-        <TouchableOpacity
-          style={[
-            styles.sendButton,
-            {
-              backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
-              opacity: canSend ? 1 : 0.6,
-            },
-          ]}
-          onPress={handleSend}
-          disabled={!canSend}
-          accessibilityRole="button"
-          accessibilityLabel="Send message"
-        >
-          {isSending ? (
-            <ActivityIndicator size="small" color="#fff" />
-          ) : (
-            <SendIcon color="#fff" size={18} />
+        <View style={styles.rightButtons}>
+          {/* Attach hides while composing to give the text room. */}
+          {!isComposing && (
+            <TouchableOpacity
+              style={styles.inputIconButton}
+              onPress={onAttachmentPress}
+              disabled={disabled}
+              accessibilityRole="button"
+              accessibilityLabel="Attach image"
+            >
+              <IconSymbol
+                name="paperclip"
+                color={disabled ? theme.colors.textMuted : theme.colors.textSubtle}
+                size={27}
+              />
+            </TouchableOpacity>
           )}
-        </TouchableOpacity>
+          <TouchableOpacity
+            style={[
+              styles.sendButton,
+              {
+                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
+                opacity: canSend ? 1 : 0.6,
+              },
+            ]}
+            onPress={handleSend}
+            disabled={!canSend}
+            accessibilityRole="button"
+            accessibilityLabel="Send message"
+          >
+            {isSending ? (
+              <ActivityIndicator size="small" color="#fff" />
+            ) : (
+              <SendIcon color="#fff" size={18} />
+            )}
+          </TouchableOpacity>
+        </View>
       </View>
 
       {/* Animated spacer beneath the pill. Closed: it follows the keyboard so
@@ -1020,18 +1021,20 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontWeight: 'bold',
   },
   // The single pill: rounded container holding left buttons, the growing
-  // input, and the circular send button. Bottom-aligned so the send button
-  // and buttons stay anchored as the multiline input grows upward.
+  // input, and the circular send button. Children are bottom-aligned so that
+  // when the input wraps to multiple lines the buttons + send stay anchored to
+  // the last line; for a single line everything lands on the same baseline.
   pill: {
     flexDirection: 'row',
     alignItems: 'flex-end',
     backgroundColor: theme.colors.surface5,
-    borderRadius: Skin.radius(22),
+    // Large radius => the short ends are always perfect semicircles regardless
+    // of the pill's current height (single line vs wrapped).
+    borderRadius: 999,
     paddingVertical: Skin.space(4),
     paddingLeft: Skin.space(4),
     // Keep the send circle hugging the pill's right edge (~1px gap).
     paddingRight: 1,
-    minHeight: 44,
     // A small breathing gap between the pill and whatever sits below it
     // (the keyboard or the emoji panel), so the pill never touches them.
     marginBottom: Skin.space(8),
@@ -1039,21 +1042,27 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   leftButtons: {
     flexDirection: 'row',
     alignItems: 'center',
-    // Pin to the bottom of the pill so buttons align with the last input line.
-    alignSelf: 'flex-end',
-    paddingBottom: Skin.space(2),
+  },
+  rightButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Skin.space(2),
   },
   input: {
     flex: 1,
     color: theme.colors.textMain,
     paddingHorizontal: Skin.space(8),
-    paddingTop: Platform.OS === 'ios' ? Skin.space(8) : Skin.space(4),
-    paddingBottom: Platform.OS === 'ios' ? Skin.space(8) : Skin.space(4),
+    // Zero vertical padding: the 36px line box (minHeight) plus the pill's own
+    // 4px vertical padding gives a ~44px single-line pill. textAlignVertical
+    // centers the glyphs so they don't sit low.
+    paddingTop: 0,
+    paddingBottom: 0,
     fontFamily: theme.fonts.regular.fontFamily,
     fontSize: Skin.font(16),
     lineHeight: Skin.font(22),
     maxHeight: 120,
-    // Vertically center a single line within the pill's min height.
+    // Match the 36px send/button height so a single line is vertically centered
+    // against them and the pill resolves to ~44px tall.
     minHeight: 36,
   },
   inputIconButton: {
@@ -1065,7 +1074,6 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
-    alignSelf: 'flex-end',
   },
   emojiPanelInner: {
     flex: 1,

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -7,8 +7,10 @@ import type { ProcessedAttachment } from '@/services/media/imageAttachment';
 import type { Channel, Emoji, SpaceMember, Sticker } from '@quilibrium/quorum-shared';
 import { searchEmojis } from '@/data/emojiData';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Image, useWindowDimensions, Keyboard, NativeSyntheticEvent, Platform, ScrollView, StyleSheet, Text, TextInput, TextInputSubmitEditingEventData, View } from 'react-native';
+import { ActivityIndicator, Image, useWindowDimensions, NativeSyntheticEvent, Platform, ScrollView, StyleSheet, Text, TextInput, TextInputSubmitEditingEventData, View } from 'react-native';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { useComposerPanel } from '@/hooks/useComposerPanel';
 import * as Skin from '@/theme/skins/geometry';
 
 
@@ -216,9 +218,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   // Keyboard/inset/rotation-driven values applied inline so the whole
   // stylesheet isn't rebuilt every time the insets or screen width change.
   const containerDynamicStyle = useMemo(() => ({
-    paddingBottom: Skin.space(8) + bottomInset,
     width: screenWidth,
-  }), [bottomInset, screenWidth]);
+  }), [screenWidth]);
   const availableWidth = screenWidth - 180;
   const maxPlaceholderNameLength = Math.max(8, Math.min(Math.floor(availableWidth / 8.5), 24));
   const inputRef = useRef<TextInput>(null);
@@ -226,9 +227,18 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const onChangeTextRef = useRef(onChangeText);
   valueRef.current = value;
   onChangeTextRef.current = onChangeText;
-  const [showEmojiPicker, setShowEmojiPicker] = useState(false);
+  // Keyboard <-> emoji-panel choreography. The panel opens downward,
+  // replacing the keyboard in the same footprint.
+  const composerPanel = useComposerPanel({ bottomInset: Skin.space(8) + bottomInset });
+  const showEmojiPicker = composerPanel.panelOpen;
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('smileys');
   const [searchQuery, setSearchQuery] = useState('');
+
+  // Animated spacer/panel container under the pill — follows the keyboard
+  // when the panel is closed, holds the keyboard footprint when it's open.
+  const spacerAnimatedStyle = useAnimatedStyle(() => ({
+    height: composerPanel.spacerHeight.value,
+  }));
 
   // Emoji frecency tracking
   const { recentEmojis, trackEmoji, refreshRecent } = useEmojiFrecency();
@@ -287,15 +297,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   );
 
   const handleToggleEmojiPicker = useCallback(() => {
-    if (showEmojiPicker) {
-      setShowEmojiPicker(false);
-      setSearchQuery('');
-      inputRef.current?.focus();
-    } else {
-      Keyboard.dismiss();
-      setShowEmojiPicker(true);
-    }
-  }, [showEmojiPicker]);
+    setSearchQuery('');
+    composerPanel.togglePanel(() => inputRef.current?.focus());
+  }, [composerPanel]);
 
   const handleSelectEmoji = useCallback((emoji: string) => {
     const newValue = valueRef.current + emoji;
@@ -309,10 +313,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const handleSelectSticker = useCallback((stickerId: string) => {
     if (onSendSticker) {
       onSendSticker(stickerId);
-      setShowEmojiPicker(false);
+      composerPanel.closePanel();
       setSearchQuery('');
     }
-  }, [onSendSticker]);
+  }, [onSendSticker, composerPanel]);
 
   // Handle text changes and detect @mention or #channel triggers
   const handleTextChange = useCallback((newText: string) => {
@@ -468,6 +472,191 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
     return stickers.filter((s) => s.name.toLowerCase().includes(lowerQuery));
   }, [searchQuery, stickers]);
 
+  // Attach (+) hides while composing so the text has more room; it reappears
+  // when the input is empty. Emoji toggle always stays.
+  const isComposing = value.trim().length > 0;
+
+  // The emoji grid markup, rendered inside the downward panel below the pill.
+  const emojiPanelContent = (
+    <View style={styles.emojiPanelInner}>
+      {/* Search bar */}
+      <View style={styles.searchContainer}>
+        <IconSymbol name="magnifyingglass" size={16} color={theme.colors.textMuted} />
+        <TextInput
+          style={styles.searchInput}
+          placeholder="Search emoji..."
+          placeholderTextColor={theme.colors.textMuted}
+          value={searchQuery}
+          onChangeText={setSearchQuery}
+          autoCapitalize="none"
+          autoCorrect={false}
+        />
+        {searchQuery.length > 0 && (
+          <TouchableOpacity onPress={() => setSearchQuery('')} hitSlop={8}>
+            <IconSymbol name="xmark.circle.fill" size={16} color={theme.colors.textMuted} />
+          </TouchableOpacity>
+        )}
+      </View>
+
+      {/* Category tabs */}
+      {!searchQuery && (
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.categoryTabs}
+          contentContainerStyle={styles.categoryTabsContent}
+          keyboardShouldPersistTaps="always"
+        >
+          {categories.map((cat) => (
+            <TouchableOpacity
+              key={cat.key}
+              style={[
+                styles.categoryTab,
+                selectedCategory === cat.key && styles.categoryTabActive,
+              ]}
+              onPress={() => setSelectedCategory(cat.key)}
+            >
+              <Text style={styles.categoryTabEmoji}>{cat.icon}</Text>
+            </TouchableOpacity>
+          ))}
+        </ScrollView>
+      )}
+
+      {/* Emoji/Sticker grid */}
+      <ScrollView
+        style={styles.emojiGrid}
+        contentContainerStyle={styles.emojiGridContent}
+        showsVerticalScrollIndicator={false}
+        keyboardShouldPersistTaps="always"
+      >
+        {/* Show search results across all categories */}
+        {searchQuery && (
+          <>
+            {filteredCustomEmojis.length > 0 && (
+              <View style={styles.emojiSection}>
+                <Text style={styles.emojiSectionTitle}>Custom</Text>
+                <View style={styles.emojiRow}>
+                  {filteredCustomEmojis.map((emoji) => (
+                    <TouchableOpacity
+                      key={emoji.id}
+                      style={styles.emojiButton}
+                      onPress={() => handleSelectEmoji(`:${emoji.name}:`)}
+                    >
+                      <Image
+                        source={{ uri: emoji.imgUrl }}
+                        style={styles.customEmojiImage}
+                        resizeMode="contain"
+                      />
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </View>
+            )}
+            {filteredStickers.length > 0 && (
+              <View style={styles.emojiSection}>
+                <Text style={styles.emojiSectionTitle}>Stickers</Text>
+                <View style={styles.stickerRow}>
+                  {filteredStickers.map((sticker) => (
+                    <TouchableOpacity
+                      key={sticker.id}
+                      style={styles.stickerButton}
+                      onPress={() => handleSelectSticker(sticker.id)}
+                    >
+                      <Image
+                        source={{ uri: sticker.imgUrl }}
+                        style={styles.stickerImage}
+                        resizeMode="contain"
+                      />
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </View>
+            )}
+            {filteredEmojis.length > 0 && (
+              <View style={styles.emojiSection}>
+                <Text style={styles.emojiSectionTitle}>Emoji</Text>
+                <View style={styles.emojiRow}>
+                  {filteredEmojis.map((emoji, index) => (
+                    <TouchableOpacity
+                      key={`${emoji}-${index}`}
+                      style={styles.emojiButton}
+                      onPress={() => handleSelectEmoji(emoji)}
+                    >
+                      <Text style={styles.emoji}>{emoji}</Text>
+                    </TouchableOpacity>
+                  ))}
+                </View>
+              </View>
+            )}
+            {filteredEmojis.length === 0 && filteredCustomEmojis.length === 0 && filteredStickers.length === 0 && (
+              <Text style={styles.emptyText}>No results found</Text>
+            )}
+          </>
+        )}
+
+        {/* Show category content when not searching */}
+        {!searchQuery && selectedCategory === 'custom' && (
+          <View style={styles.emojiRow}>
+            {customEmojis.map((emoji) => (
+              <TouchableOpacity
+                key={emoji.id}
+                style={styles.emojiButton}
+                onPress={() => handleSelectEmoji(`:${emoji.name}:`)}
+              >
+                <Image
+                  source={{ uri: emoji.imgUrl }}
+                  style={styles.customEmojiImage}
+                  resizeMode="contain"
+                />
+              </TouchableOpacity>
+            ))}
+            {customEmojis.length === 0 && (
+              <Text style={styles.emptyText}>No custom emoji</Text>
+            )}
+          </View>
+        )}
+
+        {!searchQuery && selectedCategory === 'stickers' && (
+          <View style={styles.stickerRow}>
+            {stickers.map((sticker) => (
+              <TouchableOpacity
+                key={sticker.id}
+                style={styles.stickerButton}
+                onPress={() => handleSelectSticker(sticker.id)}
+              >
+                <Image
+                  source={{ uri: sticker.imgUrl }}
+                  style={styles.stickerImage}
+                  resizeMode="contain"
+                />
+              </TouchableOpacity>
+            ))}
+            {stickers.length === 0 && (
+              <Text style={styles.emptyText}>No stickers</Text>
+            )}
+          </View>
+        )}
+
+        {!searchQuery && selectedCategory !== 'custom' && selectedCategory !== 'stickers' && (
+          <View style={styles.emojiRow}>
+            {displayEmojis.map((emoji, index) => (
+              <TouchableOpacity
+                key={`${emoji}-${index}`}
+                style={styles.emojiButton}
+                onPress={() => handleSelectEmoji(emoji)}
+              >
+                <Text style={styles.emoji}>{emoji}</Text>
+              </TouchableOpacity>
+            ))}
+            {selectedCategory === 'recent' && displayEmojis.length === 0 && (
+              <Text style={styles.emptyText}>No recent emojis</Text>
+            )}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+
   return (
     <View style={[styles.container, containerDynamicStyle]}>
       {/* Edit mode preview */}
@@ -561,298 +750,127 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
         </View>
       )}
 
-      {/* Inline emoji/sticker picker */}
-      {showEmojiPicker && (
-        <View style={styles.emojiPickerContainer}>
-          {/* Search bar */}
-          <View style={styles.searchContainer}>
-            <IconSymbol name="magnifyingglass" size={16} color={theme.colors.textMuted} />
-            <TextInput
-              style={styles.searchInput}
-              placeholder="Search emoji..."
-              placeholderTextColor={theme.colors.textMuted}
-              value={searchQuery}
-              onChangeText={setSearchQuery}
-              autoCapitalize="none"
-              autoCorrect={false}
-            />
-            {searchQuery.length > 0 && (
-              <TouchableOpacity onPress={() => setSearchQuery('')} hitSlop={8}>
-                <IconSymbol name="xmark.circle.fill" size={16} color={theme.colors.textMuted} />
-              </TouchableOpacity>
-            )}
-            {/* Close the picker. The composer also dismisses it on text input,
-                but an explicit control is clearer. */}
-            <TouchableOpacity
-              onPress={handleToggleEmojiPicker}
-              hitSlop={8}
-              style={styles.emojiCloseButton}
-              accessibilityRole="button"
-              accessibilityLabel="Close emoji picker"
-            >
-              <IconSymbol name="xmark" size={18} color={theme.colors.textMuted} />
-            </TouchableOpacity>
-          </View>
-
-          {/* Category tabs */}
-          {!searchQuery && (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
-              style={styles.categoryTabs}
-              contentContainerStyle={styles.categoryTabsContent}
-            >
-              {categories.map((cat) => (
-                <TouchableOpacity
-                  key={cat.key}
-                  style={[
-                    styles.categoryTab,
-                    selectedCategory === cat.key && styles.categoryTabActive,
-                  ]}
-                  onPress={() => setSelectedCategory(cat.key)}
-                >
-                  <Text style={styles.categoryTabEmoji}>{cat.icon}</Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
-          )}
-
-          {/* Emoji/Sticker grid */}
+      {/* Autocomplete popup — anchored above the pill */}
+      {autocompleteType && (filteredMembers.length > 0 || filteredChannels.length > 0) && (
+        <View style={styles.autocompleteContainer}>
           <ScrollView
-            style={styles.emojiGrid}
-            contentContainerStyle={styles.emojiGridContent}
+            style={styles.autocompleteList}
+            keyboardShouldPersistTaps="always"
             showsVerticalScrollIndicator={false}
           >
-            {/* Show search results across all categories */}
-            {searchQuery && (
-              <>
-                {filteredCustomEmojis.length > 0 && (
-                  <View style={styles.emojiSection}>
-                    <Text style={styles.emojiSectionTitle}>Custom</Text>
-                    <View style={styles.emojiRow}>
-                      {filteredCustomEmojis.map((emoji) => (
-                        <TouchableOpacity
-                          key={emoji.id}
-                          style={styles.emojiButton}
-                          onPress={() => handleSelectEmoji(`:${emoji.name}:`)}
-                        >
-                          <Image
-                            source={{ uri: emoji.imgUrl }}
-                            style={styles.customEmojiImage}
-                            resizeMode="contain"
-                          />
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  </View>
-                )}
-                {filteredStickers.length > 0 && (
-                  <View style={styles.emojiSection}>
-                    <Text style={styles.emojiSectionTitle}>Stickers</Text>
-                    <View style={styles.stickerRow}>
-                      {filteredStickers.map((sticker) => (
-                        <TouchableOpacity
-                          key={sticker.id}
-                          style={styles.stickerButton}
-                          onPress={() => handleSelectSticker(sticker.id)}
-                        >
-                          <Image
-                            source={{ uri: sticker.imgUrl }}
-                            style={styles.stickerImage}
-                            resizeMode="contain"
-                          />
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  </View>
-                )}
-                {filteredEmojis.length > 0 && (
-                  <View style={styles.emojiSection}>
-                    <Text style={styles.emojiSectionTitle}>Emoji</Text>
-                    <View style={styles.emojiRow}>
-                      {filteredEmojis.map((emoji, index) => (
-                        <TouchableOpacity
-                          key={`${emoji}-${index}`}
-                          style={styles.emojiButton}
-                          onPress={() => handleSelectEmoji(emoji)}
-                        >
-                          <Text style={styles.emoji}>{emoji}</Text>
-                        </TouchableOpacity>
-                      ))}
-                    </View>
-                  </View>
-                )}
-                {filteredEmojis.length === 0 && filteredCustomEmojis.length === 0 && filteredStickers.length === 0 && (
-                  <Text style={styles.emptyText}>No results found</Text>
-                )}
-              </>
-            )}
-
-            {/* Show category content when not searching */}
-            {!searchQuery && selectedCategory === 'custom' && (
-              <View style={styles.emojiRow}>
-                {customEmojis.map((emoji) => (
-                  <TouchableOpacity
-                    key={emoji.id}
-                    style={styles.emojiButton}
-                    onPress={() => handleSelectEmoji(`:${emoji.name}:`)}
-                  >
-                    <Image
-                      source={{ uri: emoji.imgUrl }}
-                      style={styles.customEmojiImage}
-                      resizeMode="contain"
-                    />
-                  </TouchableOpacity>
-                ))}
-                {customEmojis.length === 0 && (
-                  <Text style={styles.emptyText}>No custom emoji</Text>
-                )}
-              </View>
-            )}
-
-            {!searchQuery && selectedCategory === 'stickers' && (
-              <View style={styles.stickerRow}>
-                {stickers.map((sticker) => (
-                  <TouchableOpacity
-                    key={sticker.id}
-                    style={styles.stickerButton}
-                    onPress={() => handleSelectSticker(sticker.id)}
-                  >
-                    <Image
-                      source={{ uri: sticker.imgUrl }}
-                      style={styles.stickerImage}
-                      resizeMode="contain"
-                    />
-                  </TouchableOpacity>
-                ))}
-                {stickers.length === 0 && (
-                  <Text style={styles.emptyText}>No stickers</Text>
-                )}
-              </View>
-            )}
-
-            {!searchQuery && selectedCategory !== 'custom' && selectedCategory !== 'stickers' && (
-              <View style={styles.emojiRow}>
-                {displayEmojis.map((emoji, index) => (
-                  <TouchableOpacity
-                    key={`${emoji}-${index}`}
-                    style={styles.emojiButton}
-                    onPress={() => handleSelectEmoji(emoji)}
-                  >
-                    <Text style={styles.emoji}>{emoji}</Text>
-                  </TouchableOpacity>
-                ))}
-                {selectedCategory === 'recent' && displayEmojis.length === 0 && (
-                  <Text style={styles.emptyText}>No recent emojis</Text>
-                )}
-              </View>
-            )}
+            {autocompleteType === 'mention' && filteredMembers.map((member) => (
+              <TouchableOpacity
+                key={member.address}
+                style={styles.autocompleteItem}
+                onPress={() => handleSelectMention(member)}
+              >
+                <View style={styles.autocompleteAvatar}>
+                  <Text style={styles.autocompleteAvatarText}>
+                    {(member.display_name || member.name || '?')[0].toUpperCase()}
+                  </Text>
+                </View>
+                <Text style={styles.autocompleteText}>
+                  {member.display_name || member.name || member.address}
+                </Text>
+              </TouchableOpacity>
+            ))}
+            {autocompleteType === 'channel' && filteredChannels.map((channel) => (
+              <TouchableOpacity
+                key={channel.channelId}
+                style={styles.autocompleteItem}
+                onPress={() => handleSelectChannel(channel)}
+              >
+                <IconSymbol name="number" size={16} color={theme.colors.textMuted} />
+                <Text style={styles.autocompleteText}>{channel.channelName}</Text>
+              </TouchableOpacity>
+            ))}
           </ScrollView>
         </View>
       )}
 
-      <View style={styles.wrapper}>
-        <TouchableOpacity
-          style={styles.inputIconButton}
-          onPress={onAttachmentPress}
-          disabled={disabled}
-        >
-          <IconSymbol
-            name="plus.circle.fill"
-            color={disabled ? theme.colors.textMuted : theme.colors.textSubtle}
-            size={24}
-          />
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.inputIconButton}
-          onPress={handleToggleEmojiPicker}
-          disabled={disabled}
-        >
-          <IconSymbol
-            name="face.smiling"
-            color={showEmojiPicker ? theme.colors.primary : (disabled ? theme.colors.textMuted : theme.colors.textSubtle)}
-            size={24}
-          />
-        </TouchableOpacity>
-        <View style={styles.inputWrapper}>
-          {/* Autocomplete popup */}
-          {autocompleteType && (filteredMembers.length > 0 || filteredChannels.length > 0) && (
-            <View style={styles.autocompleteContainer}>
-              <ScrollView
-                style={styles.autocompleteList}
-                keyboardShouldPersistTaps="always"
-                showsVerticalScrollIndicator={false}
-              >
-                {autocompleteType === 'mention' && filteredMembers.map((member) => (
-                  <TouchableOpacity
-                    key={member.address}
-                    style={styles.autocompleteItem}
-                    onPress={() => handleSelectMention(member)}
-                  >
-                    <View style={styles.autocompleteAvatar}>
-                      <Text style={styles.autocompleteAvatarText}>
-                        {(member.display_name || member.name || '?')[0].toUpperCase()}
-                      </Text>
-                    </View>
-                    <Text style={styles.autocompleteText}>
-                      {member.display_name || member.name || member.address}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-                {autocompleteType === 'channel' && filteredChannels.map((channel) => (
-                  <TouchableOpacity
-                    key={channel.channelId}
-                    style={styles.autocompleteItem}
-                    onPress={() => handleSelectChannel(channel)}
-                  >
-                    <IconSymbol name="number" size={16} color={theme.colors.textMuted} />
-                    <Text style={styles.autocompleteText}>{channel.channelName}</Text>
-                  </TouchableOpacity>
-                ))}
-              </ScrollView>
-            </View>
+      {/* The composer pill — one rounded container holding the left-side
+          buttons, the growing text input, and the circular send button. */}
+      <View style={styles.pill}>
+        <View style={styles.leftButtons}>
+          {/* Attach (+) hides while composing to give the text room. */}
+          {!isComposing && (
+            <TouchableOpacity
+              style={styles.inputIconButton}
+              onPress={onAttachmentPress}
+              disabled={disabled}
+              accessibilityRole="button"
+              accessibilityLabel="Attach image"
+            >
+              <IconSymbol
+                name="plus"
+                color={disabled ? theme.colors.textMuted : theme.colors.textSubtle}
+                size={24}
+              />
+            </TouchableOpacity>
           )}
-          <TextInput
-            ref={inputRef}
-            value={value}
-            onChangeText={handleTextChange}
-            onSelectionChange={handleSelectionChange}
-            placeholder={editingMessage ? 'Edit message...' : isDM ? `Message ${channelName.length > maxPlaceholderNameLength ? channelName.slice(0, maxPlaceholderNameLength) + '…' : channelName}` : `Message #${channelName}`}
-            placeholderTextColor={theme.colors.textMuted}
-            style={styles.input}
-            editable={!disabled}
-            returnKeyType="send"
-            onSubmitEditing={handleSubmitEditing}
-            blurOnSubmit={false}
-            multiline
-            scrollEnabled
-            textAlignVertical="top"
-            onFocus={() => {
-              setShowEmojiPicker(false);
-              setSearchQuery('');
-            }}
-          />
-        </View>
-        <View style={styles.actions}>
           <TouchableOpacity
-            style={[
-              styles.sendButton,
-              {
-                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
-                opacity: canSend ? 1 : 0.6,
-              },
-            ]}
-            onPress={handleSend}
-            disabled={!canSend}
+            style={styles.inputIconButton}
+            onPress={handleToggleEmojiPicker}
+            disabled={disabled}
+            accessibilityRole="button"
+            accessibilityLabel={showEmojiPicker ? 'Show keyboard' : 'Open emoji panel'}
           >
-            {isSending ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <SendIcon color="#fff" size={18} />
-            )}
+            <IconSymbol
+              name={showEmojiPicker ? 'keyboard' : 'face.smiling'}
+              color={showEmojiPicker ? theme.colors.primary : (disabled ? theme.colors.textMuted : theme.colors.textSubtle)}
+              size={24}
+            />
           </TouchableOpacity>
         </View>
+
+        <TextInput
+          ref={inputRef}
+          value={value}
+          onChangeText={handleTextChange}
+          onSelectionChange={handleSelectionChange}
+          placeholder={editingMessage ? 'Edit message...' : isDM ? `Message ${channelName.length > maxPlaceholderNameLength ? channelName.slice(0, maxPlaceholderNameLength) + '…' : channelName}` : `Message #${channelName}`}
+          placeholderTextColor={theme.colors.textMuted}
+          style={styles.input}
+          editable={!disabled}
+          returnKeyType="send"
+          onSubmitEditing={handleSubmitEditing}
+          blurOnSubmit={false}
+          multiline
+          scrollEnabled
+          textAlignVertical="center"
+          onFocus={() => {
+            composerPanel.onInputFocus();
+            setSearchQuery('');
+          }}
+        />
+
+        <TouchableOpacity
+          style={[
+            styles.sendButton,
+            {
+              backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
+              opacity: canSend ? 1 : 0.6,
+            },
+          ]}
+          onPress={handleSend}
+          disabled={!canSend}
+          accessibilityRole="button"
+          accessibilityLabel="Send message"
+        >
+          {isSending ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <SendIcon color="#fff" size={18} />
+          )}
+        </TouchableOpacity>
       </View>
+
+      {/* Animated spacer beneath the pill. Closed: it follows the keyboard so
+          the pill rides up (keyboard avoidance). Open: it holds the keyboard
+          footprint and shows the emoji panel — no layout jump on swap. */}
+      <Reanimated.View style={spacerAnimatedStyle}>
+        {showEmojiPicker && emojiPanelContent}
+      </Reanimated.View>
     </View>
   );
 });
@@ -964,43 +982,53 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontSize: Skin.font(10),
     fontWeight: 'bold',
   },
-  wrapper: {
+  // The single pill: rounded container holding left buttons, the growing
+  // input, and the circular send button. Bottom-aligned so the send button
+  // and buttons stay anchored as the multiline input grows upward.
+  pill: {
     flexDirection: 'row',
     alignItems: 'flex-end',
+    backgroundColor: theme.colors.surface5,
+    borderRadius: Skin.radius(22),
+    paddingVertical: Skin.space(4),
+    paddingLeft: Skin.space(4),
+    paddingRight: Skin.space(4),
+    minHeight: 44,
+  },
+  leftButtons: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    // Pin to the bottom of the pill so buttons align with the last input line.
+    alignSelf: 'flex-end',
+    paddingBottom: Skin.space(2),
   },
   input: {
-    backgroundColor: theme.colors.surface5,
+    flex: 1,
     color: theme.colors.textMain,
-    borderRadius: Skin.radius(20),
-    paddingHorizontal: Skin.space(16),
-    paddingTop: Skin.space(8),
-    paddingBottom: Skin.space(10),
+    paddingHorizontal: Skin.space(8),
+    paddingTop: Platform.OS === 'ios' ? Skin.space(8) : Skin.space(4),
+    paddingBottom: Platform.OS === 'ios' ? Skin.space(8) : Skin.space(4),
     fontFamily: theme.fonts.regular.fontFamily,
     fontSize: Skin.font(16),
     lineHeight: Skin.font(22),
-    maxHeight: 100,
-    minHeight: 40,
-    textAlignVertical: 'top',
-  },
-  actions: {
-    flexDirection: 'row',
-    alignItems: 'center',
+    maxHeight: 120,
+    // Vertically center a single line within the pill's min height.
+    minHeight: 36,
   },
   inputIconButton: {
-    padding: Skin.space(4),
+    padding: Skin.space(6),
   },
   sendButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 36,
+    height: 36,
+    borderRadius: 18,
     alignItems: 'center',
     justifyContent: 'center',
+    alignSelf: 'flex-end',
   },
-  emojiPickerContainer: {
-    backgroundColor: theme.colors.surface5,
-    borderRadius: Skin.radius(12),
-    marginBottom: Skin.space(8),
-    height: 280,
+  emojiPanelInner: {
+    flex: 1,
+    backgroundColor: theme.colors.surface4,
   },
   searchContainer: {
     flexDirection: 'row',
@@ -1021,15 +1049,11 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontFamily: theme.fonts.regular.fontFamily,
     padding: 0,
   },
-  emojiCloseButton: {
-    marginLeft: Skin.space(4),
-  },
   categoryTabs: {
-    // A continuous band (no top/bottom separators) one shade below the panel
-    // (panel is surface5). Tall enough that the 20px emoji + pill padding
-    // aren't clipped.
+    // A continuous band (no top/bottom separators), one shade off the panel.
+    // Tall enough that the 20px emoji + pill padding aren't clipped.
     maxHeight: 48,
-    backgroundColor: theme.colors.surface4,
+    backgroundColor: theme.colors.surface3,
   },
   categoryTabsContent: {
     paddingHorizontal: Skin.space(6),
@@ -1109,20 +1133,10 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     marginTop: Skin.space(16),
     fontSize: Skin.font(14),
   },
-  inputWrapper: {
-    flex: 1,
-    flexShrink: 1,
-    position: 'relative',
-    marginHorizontal: Skin.space(8),
-  },
   autocompleteContainer: {
-    position: 'absolute',
-    bottom: '100%',
-    left: 0,
-    right: 0,
     backgroundColor: theme.colors.surface5,
     borderRadius: Skin.radius(12),
-    marginBottom: Skin.space(4),
+    marginBottom: Skin.space(8),
     maxHeight: 200,
     overflow: 'hidden',
     shadowColor: '#000',

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -887,7 +887,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             style={[
               styles.sendButton,
               {
-                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
+                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface7,
                 opacity: canSend ? 1 : 0.6,
               },
             ]}

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -8,7 +8,7 @@ import type { Channel, Emoji, SpaceMember, Sticker } from '@quilibrium/quorum-sh
 import { searchEmojis } from '@/data/emojiData';
 import React, { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Image, useWindowDimensions, NativeSyntheticEvent, Platform, ScrollView, StyleSheet, Text, TextInput, TextInputSubmitEditingEventData, View } from 'react-native';
-import Reanimated, { LinearTransition, useAnimatedStyle } from 'react-native-reanimated';
+import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useComposerPanel } from '@/hooks/useComposerPanel';
 import * as Skin from '@/theme/skins/geometry';
@@ -845,15 +845,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
       {/* The composer pill — one rounded container with the emoji toggle on the
           left, the growing text input, then the attach + send buttons on the
-          right. Controls are bottom-anchored in both states (single line is one
-          row tall, so it still reads centered) — avoiding a center<->flex-end
-          flip removes the icon jump at the 1->2 line boundary. Only the corner
-          radius changes when wrapped (stadium -> box). LinearTransition
-          animates the height change so growth/shrink is smooth, not abrupt. */}
-      <Reanimated.View
-        layout={LinearTransition.duration(140)}
-        style={[styles.pill, isMultiline && styles.pillMultiline]}
-      >
+          right. Single line: a fully-rounded stadium with controls centered.
+          Multi-line: a moderate-radius box with controls pinned to the bottom
+          (last line), like a grown text area. */}
+      <View style={[styles.pill, isMultiline && styles.pillMultiline]}>
         <View style={styles.leftButtons}>
           <TouchableOpacity
             style={styles.inputIconButton}
@@ -929,7 +924,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             )}
           </TouchableOpacity>
         </View>
-      </Reanimated.View>
+      </View>
 
       {/* Animated spacer beneath the pill. Closed: it follows the keyboard so
           the pill rides up (keyboard avoidance). Open: it holds the keyboard
@@ -1056,15 +1051,16 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   // the last line; for a single line everything lands on the same baseline.
   pill: {
     flexDirection: 'row',
-    // Bottom-anchor the controls ALWAYS. Single line is one control-row tall so
-    // this reads identical to centered; multi-line keeps the controls on the
-    // last line. Anchoring in both states (rather than flipping center<->
-    // flex-end on wrap) is what removes the icon jump at the 1->2 line boundary.
-    alignItems: 'flex-end',
+    // Self-sizing: the row height is defined by its tallest child (the 36px
+    // controls), and `center` keeps the text and controls on one baseline on
+    // every device instead of relying on per-device text metrics. No fixed
+    // pill height — it adapts to the font/line-height the device renders.
+    alignItems: 'center',
     // Same shade as the emoji panel so the pill and the panel read as one
     // continuous surface.
     backgroundColor: theme.colors.surface4,
-    // Large radius => the short ends are perfect semicircles while single-line.
+    // Large radius => the short ends are always perfect semicircles regardless
+    // of the pill's resolved height (single line vs wrapped).
     borderRadius: 999,
     // Uniform inner padding on all four sides: the send circle then has the
     // same gap to the right edge as it does to the top/bottom, so it reads as
@@ -1075,9 +1071,10 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     marginBottom: Skin.space(8),
   },
   pillMultiline: {
-    // Grown box: drop the stadium radius to a moderate corner so the short ends
-    // don't bulge into big semicircles on a tall pill. (Controls are already
-    // bottom-anchored by the base style.)
+    // Grown box: pin controls to the bottom (last line) and drop the stadium
+    // radius to a moderate corner so the short ends don't bulge into big
+    // semicircles on a tall pill.
+    alignItems: 'flex-end',
     borderRadius: Skin.radius(20),
   },
   leftButtons: {

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -882,10 +882,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           <TouchableOpacity
             style={[
               styles.sendButton,
-              {
-                backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6,
-                opacity: canSend ? 1 : 0.6,
-              },
+              // Disabled: keep the circle at full opacity (no whole-button fade)
+              // on the lightest surface so it stays a clearly visible affordance
+              // against the pill; the muted arrow signals the inactive state.
+              { backgroundColor: canSend ? theme.colors.accent : theme.colors.surface6 },
             ]}
             onPress={handleSend}
             disabled={!canSend}
@@ -895,7 +895,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
             {isSending ? (
               <ActivityIndicator size="small" color="#fff" />
             ) : (
-              <SendIcon color="#fff" size={20} />
+              <SendIcon color={canSend ? '#fff' : theme.colors.textMuted} size={20} />
             )}
           </TouchableOpacity>
         </View>

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -245,6 +245,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const showEmojiPicker = composerPanel.panelOpen;
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('smileys');
   const [searchQuery, setSearchQuery] = useState('');
+  // When the input wraps to multiple lines the pill switches from a single-line
+  // stadium (fully rounded, controls centered) to a grown box (moderate corner
+  // radius, controls pinned to the bottom/last line). Driven by the measured
+  // content height so it adapts to the device's font metrics.
+  const [isMultiline, setIsMultiline] = useState(false);
 
   // Animated spacer/panel container under the pill — follows the keyboard
   // when the panel is closed, holds the keyboard footprint when it's open.
@@ -424,6 +429,19 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const handleSelectionChange = useCallback((event: { nativeEvent: { selection: { start: number; end: number } } }) => {
     setCursorPosition(event.nativeEvent.selection.end);
   }, []);
+
+  // Detect single- vs multi-line from the measured content height so the pill
+  // can switch shape. A single line is ~one lineHeight tall; once the content
+  // exceeds ~1.5 lines it has wrapped. Using the measured height (not character
+  // counting) keeps this correct across fonts/devices and for pasted newlines.
+  const singleLineThreshold = Skin.font(22) * 1.5;
+  const handleContentSizeChange = useCallback(
+    (event: { nativeEvent: { contentSize: { height: number } } }) => {
+      const next = event.nativeEvent.contentSize.height > singleLineThreshold;
+      setIsMultiline((prev) => (prev === next ? prev : next));
+    },
+    [singleLineThreshold]
+  );
 
   // Build categories list including custom emojis, stickers, and recent if available
   const categories = useMemo(() => {
@@ -827,8 +845,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
       {/* The composer pill — one rounded container with the emoji toggle on the
           left, the growing text input, then the attach + send buttons on the
-          right. */}
-      <View style={styles.pill}>
+          right. Single line: a fully-rounded stadium with controls centered.
+          Multi-line: a moderate-radius box with controls pinned to the bottom
+          (last line), like a grown text area. */}
+      <View style={[styles.pill, isMultiline && styles.pillMultiline]}>
         <View style={styles.leftButtons}>
           <TouchableOpacity
             style={styles.inputIconButton}
@@ -850,6 +870,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           value={value}
           onChangeText={handleTextChange}
           onSelectionChange={handleSelectionChange}
+          onContentSizeChange={handleContentSizeChange}
           placeholder={editingMessage ? 'Edit message...' : 'Message...'}
           placeholderTextColor={theme.colors.textMuted}
           style={styles.input}
@@ -859,7 +880,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           blurOnSubmit={false}
           multiline
           scrollEnabled
-          textAlignVertical="center"
+          textAlignVertical={isMultiline ? 'top' : 'center'}
           onFocus={() => {
             composerPanel.onInputFocus();
             setSearchQuery('');
@@ -1048,6 +1069,13 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     // A small breathing gap between the pill and whatever sits below it
     // (the keyboard or the emoji panel), so the pill never touches them.
     marginBottom: Skin.space(8),
+  },
+  pillMultiline: {
+    // Grown box: pin controls to the bottom (last line) and drop the stadium
+    // radius to a moderate corner so the short ends don't bulge into big
+    // semicircles on a tall pill.
+    alignItems: 'flex-end',
+    borderRadius: Skin.radius(20),
   },
   leftButtons: {
     flexDirection: 'row',

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -46,6 +46,12 @@ interface MessageInputProps {
   onDismissReply?: () => void;
   /** Bottom safe area inset */
   bottomInset?: number;
+  /**
+   * Height of bottom chrome (e.g. a tab bar) the composer already sits above.
+   * The keyboard/panel footprint is reduced by this so the pill lands exactly
+   * on top of the keyboard instead of overshooting it.
+   */
+  bottomChromeHeight?: number;
   /** Custom emojis for the space */
   customEmojis?: Emoji[];
   /** Stickers for the space */
@@ -201,6 +207,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   replyTo,
   onDismissReply,
   bottomInset = 0,
+  bottomChromeHeight = 0,
   customEmojis = [],
   stickers = [],
   onSendSticker,
@@ -229,7 +236,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   onChangeTextRef.current = onChangeText;
   // Keyboard <-> emoji-panel choreography. The panel opens downward,
   // replacing the keyboard in the same footprint.
-  const composerPanel = useComposerPanel({ bottomInset: Skin.space(8) + bottomInset });
+  const composerPanel = useComposerPanel({
+    bottomInset: Skin.space(8) + bottomInset,
+    bottomChromeHeight,
+  });
   const showEmojiPicker = composerPanel.panelOpen;
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('smileys');
   const [searchQuery, setSearchQuery] = useState('');
@@ -322,6 +332,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const handleTextChange = useCallback((newText: string) => {
     onChangeText(newText);
 
+    // Typing dismisses the emoji panel. The soft-keyboard path already does
+    // this via the input's onFocus, but a hardware/Bluetooth keyboard types
+    // into an already-focused input without re-firing focus, so close here too.
+    composerPanel.closePanel();
+
     // Find the word being typed at cursor position
     const textUpToCursor = newText.slice(0, cursorPosition + (newText.length - value.length));
     const lastAtIndex = textUpToCursor.lastIndexOf('@');
@@ -355,7 +370,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
     // No trigger found
     setAutocompleteType(null);
     setAutocompleteQuery('');
-  }, [onChangeText, cursorPosition, value, channels]);
+  }, [onChangeText, cursorPosition, value, channels, composerPanel]);
 
   // Filter members for mention autocomplete - search by display name, name, or address
   const filteredMembers = useMemo(() => {
@@ -477,7 +492,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   const isComposing = value.trim().length > 0;
 
   // The emoji grid markup, rendered inside the downward panel below the pill.
-  const emojiPanelContent = (
+  // Memoized and gated on `showEmojiPicker` so the (potentially hundreds of
+  // nodes) grid isn't rebuilt on every keystroke while the panel is closed.
+  const emojiPanelContent = useMemo(() => {
+    if (!showEmojiPicker) return null;
+    return (
     <View style={styles.emojiPanelInner}>
       {/* Search bar */}
       <View style={styles.searchContainer}>
@@ -655,7 +674,23 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
         )}
       </ScrollView>
     </View>
-  );
+    );
+  }, [
+    showEmojiPicker,
+    searchQuery,
+    selectedCategory,
+    categories,
+    displayEmojis,
+    filteredEmojis,
+    filteredCustomEmojis,
+    filteredStickers,
+    customEmojis,
+    stickers,
+    handleSelectEmoji,
+    handleSelectSticker,
+    styles,
+    theme,
+  ]);
 
   return (
     <View style={[styles.container, containerDynamicStyle]}>
@@ -869,7 +904,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           the pill rides up (keyboard avoidance). Open: it holds the keyboard
           footprint and shows the emoji panel — no layout jump on swap. */}
       <Reanimated.View style={spacerAnimatedStyle}>
-        {showEmojiPicker && emojiPanelContent}
+        {emojiPanelContent}
       </Reanimated.View>
     </View>
   );

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -1029,6 +1029,9 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     paddingLeft: Skin.space(4),
     paddingRight: Skin.space(4),
     minHeight: 44,
+    // A small breathing gap between the pill and whatever sits below it
+    // (the keyboard or the emoji panel), so the pill never touches them.
+    marginBottom: Skin.space(8),
   },
   leftButtons: {
     flexDirection: 'row',

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -235,7 +235,11 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   // Keyboard <-> emoji-panel choreography. The panel opens downward,
   // replacing the keyboard in the same footprint.
   const composerPanel = useComposerPanel({
-    bottomInset: Skin.space(8) + bottomInset,
+    // Resting gap below the pill carries only a genuine safe-area inset (passed
+    // by screens with no tab bar to cover it). The small constant gap is the
+    // pill's own marginBottom, applied in BOTH states — so the no-keyboard
+    // spacing matches the tighter keyboard-up spacing instead of being larger.
+    bottomInset,
     bottomChromeHeight,
   });
   const showEmojiPicker = composerPanel.panelOpen;

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -1031,7 +1031,9 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     // every device instead of relying on per-device text metrics. No fixed
     // pill height — it adapts to the font/line-height the device renders.
     alignItems: 'center',
-    backgroundColor: theme.colors.surface5,
+    // Same shade as the emoji panel so the pill and the panel read as one
+    // continuous surface.
+    backgroundColor: theme.colors.surface4,
     // Large radius => the short ends are always perfect semicircles regardless
     // of the pill's resolved height (single line vs wrapped).
     borderRadius: 999,

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -306,7 +306,7 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
 
   const handleToggleEmojiPicker = useCallback(() => {
     setSearchQuery('');
-    composerPanel.togglePanel(() => inputRef.current?.focus());
+    composerPanel.togglePanel();
   }, [composerPanel]);
 
   const handleSelectEmoji = useCallback((emoji: string) => {

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -728,6 +728,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
             pendingAttachment={pendingAttachment}
             onClearAttachment={handleClearAttachment}
             bottomInset={0}
+            bottomChromeHeight={tabBarHeight}
             replyTo={replyToMessage}
             onDismissReply={handleDismissReply}
             castReplyAvailable={isCastReply && Boolean(farcasterAuthToken)}

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -8,7 +8,7 @@
 
 import type { AppTheme } from '@/theme';
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Keyboard, KeyboardAvoidingView, Platform, StyleSheet, Text, View } from 'react-native';
+import { Alert, Platform, StyleSheet, Text, View } from 'react-native';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useHeaderHeight } from '@react-navigation/elements';
 
@@ -626,29 +626,12 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
     }
   }, [isBookmarked, bookmarks, addBookmark, removeBookmark, spaceId, channelId, selectedConversationId, isDMsSelected]);
 
-  // On Android, track keyboard height manually since adjustResize doesn't
-  // work reliably on foldables and edge-to-edge devices.
-  const [androidKeyboardHeight, setAndroidKeyboardHeight] = useState(0);
-  useEffect(() => {
-    if (Platform.OS !== 'android') return;
-    const showSub = Keyboard.addListener('keyboardDidShow', (e) => {
-      logger.debug(`[Keyboard] height=${e.endCoordinates.height} screenY=${e.endCoordinates.screenY} screenH=${e.endCoordinates.screenX} tabBar=${tabBarHeight}`);
-      setAndroidKeyboardHeight(e.endCoordinates.height);
-    });
-    const hideSub = Keyboard.addListener('keyboardDidHide', () => {
-      setAndroidKeyboardHeight(0);
-    });
-    return () => { showSub.remove(); hideSub.remove(); };
-  }, []);
-
   const styles = useMemo(() => createStyles(theme), [theme]);
 
+  // Keyboard avoidance is owned by the composer itself (it grows an animated
+  // spacer that follows the keyboard), so the chat area is a plain flex column.
   return (
-    <KeyboardAvoidingView
-      style={[styles.chatArea, Platform.OS === 'android' && androidKeyboardHeight > 0 && { paddingBottom: androidKeyboardHeight - tabBarHeight / 2 - 10 }]}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={0}
-    >
+    <View style={styles.chatArea}>
       <View style={styles.chatAreaInner}>
         {spaceSearch.isSearchOpen && (
           <SearchBar
@@ -796,7 +779,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         onClose={() => setReportTarget(null)}
         target={reportTarget}
       />
-    </KeyboardAvoidingView>
+    </View>
   );
 });
 

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -135,6 +135,7 @@ const SF_TO_TABLER: Record<string, TablerComponentName> = {
 
   // Add / remove
   'plus': tabler('IconPlus'),
+  'keyboard': tabler('IconKeyboard'),
   'minus': tabler('IconMinus'),
   'plus.circle': tabler('IconCirclePlus'),
   'plus.circle.fill': tabler('IconCirclePlus', 'IconCirclePlusFilled'),

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -13,6 +13,14 @@ import {
 export interface ComposerPanelOptions {
   /** Bottom safe-area inset to leave below the pill when nothing is open. */
   bottomInset?: number;
+  /**
+   * Height of any chrome (e.g. a bottom tab bar) the composer already sits
+   * above. The keyboard height reported by the OS is measured from the true
+   * bottom of the screen, but the composer's layout origin is this many pixels
+   * higher, so we subtract it from the keyboard footprint to avoid overshooting
+   * the top of the keyboard.
+   */
+  bottomChromeHeight?: number;
 }
 
 /**
@@ -30,8 +38,7 @@ export interface ComposerPanelOptions {
  *     no layout jump.
  *
  * Returned `spacerHeight` is a Reanimated SharedValue to be applied as the
- * `height` of a `Reanimated.View` sitting under the pill. `panelHeight` is the
- * plain-JS pixel height to size the emoji panel's content.
+ * `height` of a `Reanimated.View` sitting under the pill.
  */
 export interface ComposerPanel {
   /** Whether the custom (emoji) panel is currently shown. */
@@ -42,8 +49,6 @@ export interface ComposerPanel {
    * that inset as the keyboard/panel takes over the space.
    */
   spacerHeight: SharedValue<number>;
-  /** Static pixel height to lay the panel content out at (last keyboard height). */
-  panelHeight: number;
   /** Show the panel: dismiss the keyboard, hold its footprint. */
   openPanel: () => void;
   /** Hide the panel (caller is responsible for refocusing the input). */
@@ -56,24 +61,36 @@ export interface ComposerPanel {
 
 // Sensible fallback before we've ever seen the keyboard (first open on a fresh
 // launch). Close to a typical Android/iOS keyboard height; it's only used for
-// the very first panel-open before a real measurement lands.
+// the very first panel-open before a real measurement lands. Cached at module
+// scope so that after the first time the keyboard is shown in a session, every
+// subsequent cold panel-open (even on a freshly mounted composer) starts from
+// the real measured height instead of this constant.
 const FALLBACK_KEYBOARD_HEIGHT = 290;
+let lastSessionKeyboardHeight = FALLBACK_KEYBOARD_HEIGHT;
 
 export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPanel {
-  const { bottomInset = 0 } = options;
+  const { bottomInset = 0, bottomChromeHeight = 0 } = options;
   const { height: keyboardHeight, progress: keyboardProgress } = useReanimatedKeyboardAnimation();
   // Last real keyboard height we've observed, kept on the UI thread for the
-  // spacer worklet and mirrored to JS state for panel content sizing.
-  const lastKeyboardHeight = useSharedValue(FALLBACK_KEYBOARD_HEIGHT);
-  const [panelHeight, setPanelHeight] = useState(FALLBACK_KEYBOARD_HEIGHT);
+  // spacer worklet. Seeded from the session cache so a panel opened before this
+  // composer ever showed the keyboard still uses a real height when available.
+  const lastKeyboardHeight = useSharedValue(lastSessionKeyboardHeight);
+  // bottomChromeHeight as a shared value so the worklet picks up changes
+  // (rotation, tab-bar show/hide) without a stale closure.
+  const chromeHeight = useSharedValue(bottomChromeHeight);
+  chromeHeight.value = bottomChromeHeight;
+  const restingInset = useSharedValue(bottomInset);
+  restingInset.value = bottomInset;
   // panelOpen as a shared value so the spacer worklet can branch without a
-  // JS round-trip; mirrored to React state for conditional rendering.
+  // JS round-trip; mirrored to React state for conditional rendering and to a
+  // ref for synchronous reads inside callbacks (avoids stale closures).
   const panelOpenSV = useSharedValue(0);
   const [panelOpen, setPanelOpen] = useState(false);
   const panelOpenRef = useRef(false);
 
   // Capture the keyboard height whenever it's meaningfully open so the panel
-  // can match it. onMove fires continuously; we only latch the peak.
+  // can match it. onMove fires continuously; we latch the height and also
+  // mirror it to the module-level session cache for future cold opens.
   useKeyboardHandler(
     {
       onMove: (e) => {
@@ -92,31 +109,41 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     []
   );
 
+  // Keep the module-level session cache in sync from JS so a future composer
+  // mount seeds from the real height. Reading a SharedValue.value from the JS
+  // thread is allowed; this runs on render, which is cheap and good enough.
+  if (lastKeyboardHeight.value > 0) {
+    lastSessionKeyboardHeight = lastKeyboardHeight.value;
+  }
+
   // The spacer height: follow the live keyboard when the panel is closed,
-  // otherwise hold the last keyboard height (panel footprint). The resting
-  // bottom safe-area inset is added on top, and fades out (via keyboard
-  // progress) as the keyboard/panel takes over so we don't double-count it.
+  // otherwise hold the last keyboard height (panel footprint). In both cases we
+  // subtract the bottom chrome the composer already sits above, so the pill
+  // lands exactly on top of the keyboard/panel rather than overshooting it. The
+  // resting bottom inset is added when nothing is open and fades out (via
+  // keyboard progress) as the keyboard/panel takes over.
   const spacerHeight = useDerivedValue(() => {
     if (panelOpenSV.value === 1) {
-      // Panel fully open: just the keyboard footprint, no resting inset.
-      return lastKeyboardHeight.value;
+      // Panel fully open: the keyboard footprint minus the chrome we sit above.
+      return Math.max(lastKeyboardHeight.value - chromeHeight.value, 0);
     }
-    const kb = Math.max(keyboardHeight.value, 0);
+    const kb = Math.max(keyboardHeight.value - chromeHeight.value, 0);
     // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
-    const restingInset = bottomInset * (1 - Math.min(Math.max(keyboardProgress.value, 0), 1));
-    return kb + restingInset;
+    const progress = Math.min(Math.max(keyboardProgress.value, 0), 1);
+    return kb + restingInset.value * (1 - progress);
   });
 
   const openPanel = useCallback(() => {
-    // Snapshot the measured height for content layout before dismissing.
-    setPanelHeight(Math.round(lastKeyboardHeight.value) || FALLBACK_KEYBOARD_HEIGHT);
     panelOpenRef.current = true;
     panelOpenSV.value = 1;
     setPanelOpen(true);
     Keyboard.dismiss();
-  }, [lastKeyboardHeight, panelOpenSV]);
+  }, [panelOpenSV]);
 
   const closePanel = useCallback(() => {
+    // Cheap to call on hot paths (e.g. every keystroke): bail if already closed
+    // so we don't write the shared value or schedule a no-op state update.
+    if (!panelOpenRef.current) return;
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
     setPanelOpen(false);
@@ -134,20 +161,14 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     [openPanel, closePanel]
   );
 
-  // When the input refocuses (keyboard comes back), make sure the panel flag
-  // is cleared so the spacer switches back to following the keyboard.
-  const onInputFocus = useCallback(() => {
-    if (panelOpenRef.current) {
-      panelOpenRef.current = false;
-      panelOpenSV.value = 0;
-      setPanelOpen(false);
-    }
-  }, [panelOpenSV]);
+  // When the input refocuses (keyboard comes back), make sure the panel is
+  // closed so the spacer switches back to following the keyboard. closePanel
+  // already no-ops when the panel isn't open.
+  const onInputFocus = closePanel;
 
   return {
     panelOpen,
     spacerHeight,
-    panelHeight,
     openPanel,
     closePanel,
     togglePanel,

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -85,21 +85,31 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   const panelOpenSV = useSharedValue(0);
   const [panelOpen, setPanelOpen] = useState(false);
   const panelOpenRef = useRef(false);
+  // Set while closing the panel BY bringing the keyboard back. During this
+  // window the spacer holds the panel footprint until the rising keyboard
+  // catches up, so the pill never drops to the bottom and bounces back up.
+  const closingSV = useSharedValue(0);
 
   // Capture the keyboard height whenever it's meaningfully open so the panel
-  // can match it. onMove fires continuously; we latch the height and also
-  // mirror it to the module-level session cache for future cold opens.
+  // can match it. We latch the height on settle and, once the keyboard is fully
+  // up, end any in-progress close hand-off.
   useKeyboardHandler(
     {
       onEnd: (e) => {
         'worklet';
         if (e.height > 0) {
           lastKeyboardHeight.value = e.height;
+          // The keyboard has finished appearing — the close hand-off is done,
+          // so the spacer can resume plainly following the live keyboard.
+          closingSV.value = 0;
           // Mirror the settled height to the JS-thread module cache so a future
           // composer mount can seed from it. Hopping to JS only on settle (not
           // every onMove frame) keeps this cheap, and avoids reading a shared
           // value during render (which Reanimated strict mode warns about).
           runOnJS(rememberSessionKeyboardHeight)(e.height);
+        } else {
+          // Keyboard fully hidden — nothing is bridging to, clear the flag.
+          closingSV.value = 0;
         }
       },
     },
@@ -113,52 +123,86 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // resting bottom inset is added when nothing is open and fades out (via
   // keyboard progress) as the keyboard/panel takes over.
   const spacerHeight = useDerivedValue(() => {
+    const panelFootprint = Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
     if (panelOpenSV.value === 1) {
       // Panel fully open: the keyboard footprint minus the chrome we sit above.
-      return Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
+      return panelFootprint;
     }
     // useReanimatedKeyboardAnimation().height is NEGATIVE-going (0 -> -kbHeight),
     // matching the library's own components which negate it. Flip the sign to
     // get the positive on-screen keyboard height.
     const liveKeyboardHeight = -keyboardHeight.value;
     const kb = Math.max(liveKeyboardHeight - bottomChromeHeight, 0);
+    if (closingSV.value === 1) {
+      // Closing the panel by summoning the keyboard back: hold the panel
+      // footprint and let the RISING keyboard meet it. Math.max means the pill
+      // stays put and the hand-off is seamless once the keyboard catches up —
+      // no drop-to-bottom-then-bounce.
+      return Math.max(kb, panelFootprint);
+    }
     // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
     const progress = Math.min(Math.max(keyboardProgress.value, 0), 1);
     return kb + bottomInset * (1 - progress);
   });
 
   const openPanel = useCallback(() => {
+    // Any prior close hand-off is moot once we're opening again.
+    closingSV.value = 0;
     panelOpenRef.current = true;
     panelOpenSV.value = 1;
     setPanelOpen(true);
     Keyboard.dismiss();
-  }, [panelOpenSV]);
+  }, [panelOpenSV, closingSV]);
 
   const closePanel = useCallback(() => {
     // Cheap to call on hot paths (e.g. every keystroke): bail if already closed
     // so we don't write the shared value or schedule a no-op state update.
     if (!panelOpenRef.current) return;
+    // Plain close (no keyboard hand-off — e.g. hardware-keyboard typing): clear
+    // any closing flag so the spacer follows the live keyboard directly.
+    closingSV.value = 0;
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
     setPanelOpen(false);
-  }, [panelOpenSV]);
+  }, [panelOpenSV, closingSV]);
+
+  // Close the panel AND bring the keyboard back, holding the pill's position
+  // throughout (no drop-and-bounce). Order matters: arm the closing hand-off
+  // and summon the keyboard BEFORE flipping panelOpen, so the spacer never
+  // sees the "panel closed, keyboard still down" state with a 0 footprint.
+  const closePanelAndRestoreKeyboard = useCallback(
+    (refocus: () => void) => {
+      if (!panelOpenRef.current) return;
+      closingSV.value = 1;
+      refocus();
+      panelOpenRef.current = false;
+      panelOpenSV.value = 0;
+      setPanelOpen(false);
+    },
+    [panelOpenSV, closingSV]
+  );
 
   const togglePanel = useCallback(
     (refocus: () => void) => {
       if (panelOpenRef.current) {
-        closePanel();
-        refocus();
+        closePanelAndRestoreKeyboard(refocus);
       } else {
         openPanel();
       }
     },
-    [openPanel, closePanel]
+    [openPanel, closePanelAndRestoreKeyboard]
   );
 
-  // When the input refocuses (keyboard comes back), make sure the panel is
-  // closed so the spacer switches back to following the keyboard. closePanel
-  // already no-ops when the panel isn't open.
-  const onInputFocus = closePanel;
+  // When the input gains focus (e.g. user taps the text field) while the panel
+  // is open, the keyboard is on its way back — arm the same closing hand-off so
+  // the pill holds position instead of dropping and bouncing.
+  const onInputFocus = useCallback(() => {
+    if (!panelOpenRef.current) return;
+    closingSV.value = 1;
+    panelOpenRef.current = false;
+    panelOpenSV.value = 0;
+    setPanelOpen(false);
+  }, [panelOpenSV, closingSV]);
 
   return {
     panelOpen,

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -117,7 +117,11 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
       // Panel fully open: the keyboard footprint minus the chrome we sit above.
       return Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
     }
-    const kb = Math.max(keyboardHeight.value - bottomChromeHeight, 0);
+    // useReanimatedKeyboardAnimation().height is NEGATIVE-going (0 -> -kbHeight),
+    // matching the library's own components which negate it. Flip the sign to
+    // get the positive on-screen keyboard height.
+    const liveKeyboardHeight = -keyboardHeight.value;
+    const kb = Math.max(liveKeyboardHeight - bottomChromeHeight, 0);
     // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
     const progress = Math.min(Math.max(keyboardProgress.value, 0), 1);
     return kb + bottomInset * (1 - progress);

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -1,6 +1,6 @@
 import { useCallback, useRef, useState } from 'react';
-import { Keyboard } from 'react-native';
 import {
+  KeyboardController,
   useKeyboardHandler,
   useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller';
@@ -54,8 +54,9 @@ export interface ComposerPanel {
   openPanel: () => void;
   /** Hide the panel (caller is responsible for refocusing the input). */
   closePanel: () => void;
-  /** Toggle the panel. When opening, dismisses the keyboard. */
-  togglePanel: (refocus: () => void) => void;
+  /** Toggle the panel. Opening hides the keyboard (keeping caret focus);
+   *  closing brings the keyboard back without moving the pill. */
+  togglePanel: () => void;
   /** Call when the input gains focus — collapses the panel without animation fight. */
   onInputFocus: () => void;
 }
@@ -151,7 +152,10 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     panelOpenRef.current = true;
     panelOpenSV.value = 1;
     setPanelOpen(true);
-    Keyboard.dismiss();
+    // keepFocus: true hides the soft keyboard but leaves the TextInput focused,
+    // so the blinking caret stays visible and emojis insert at the cursor.
+    // (RN's Keyboard.dismiss() always blurs, which hides the caret.)
+    KeyboardController.dismiss({ keepFocus: true });
   }, [panelOpenSV, closingSV]);
 
   const closePanel = useCallback(() => {
@@ -170,28 +174,25 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // throughout (no drop-and-bounce). Order matters: arm the closing hand-off
   // and summon the keyboard BEFORE flipping panelOpen, so the spacer never
   // sees the "panel closed, keyboard still down" state with a 0 footprint.
-  const closePanelAndRestoreKeyboard = useCallback(
-    (refocus: () => void) => {
-      if (!panelOpenRef.current) return;
-      closingSV.value = 1;
-      refocus();
-      panelOpenRef.current = false;
-      panelOpenSV.value = 0;
-      setPanelOpen(false);
-    },
-    [panelOpenSV, closingSV]
-  );
+  // setFocusTo('current') re-opens the keyboard on the still-focused input
+  // (the panel kept focus via dismiss({ keepFocus: true })), which a plain
+  // .focus() on an already-focused input would not reliably do.
+  const closePanelAndRestoreKeyboard = useCallback(() => {
+    if (!panelOpenRef.current) return;
+    closingSV.value = 1;
+    KeyboardController.setFocusTo('current');
+    panelOpenRef.current = false;
+    panelOpenSV.value = 0;
+    setPanelOpen(false);
+  }, [panelOpenSV, closingSV]);
 
-  const togglePanel = useCallback(
-    (refocus: () => void) => {
-      if (panelOpenRef.current) {
-        closePanelAndRestoreKeyboard(refocus);
-      } else {
-        openPanel();
-      }
-    },
-    [openPanel, closePanelAndRestoreKeyboard]
-  );
+  const togglePanel = useCallback(() => {
+    if (panelOpenRef.current) {
+      closePanelAndRestoreKeyboard();
+    } else {
+      openPanel();
+    }
+  }, [openPanel, closePanelAndRestoreKeyboard]);
 
   // When the input gains focus (e.g. user taps the text field) while the panel
   // is open, the keyboard is on its way back — arm the same closing hand-off so

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -1,0 +1,156 @@
+import { useCallback, useRef, useState } from 'react';
+import { Keyboard } from 'react-native';
+import {
+  useKeyboardHandler,
+  useReanimatedKeyboardAnimation,
+} from 'react-native-keyboard-controller';
+import {
+  useDerivedValue,
+  useSharedValue,
+  type SharedValue,
+} from 'react-native-reanimated';
+
+export interface ComposerPanelOptions {
+  /** Bottom safe-area inset to leave below the pill when nothing is open. */
+  bottomInset?: number;
+}
+
+/**
+ * Encapsulates the keyboard <-> custom-panel choreography for the message
+ * composer: the emoji panel opens downward, replacing the soft keyboard in the
+ * same footprint.
+ *
+ * The composer renders a single animated spacer below the input pill. That
+ * spacer's height drives both:
+ *   - keyboard avoidance — when the panel is closed it follows the live
+ *     keyboard height, so the pill rides up with the keyboard; and
+ *   - the emoji panel — when the panel is open it holds the LAST real keyboard
+ *     height (captured while the keyboard was up) so dismissing the soft
+ *     keyboard and revealing the panel happens in the same vertical space with
+ *     no layout jump.
+ *
+ * Returned `spacerHeight` is a Reanimated SharedValue to be applied as the
+ * `height` of a `Reanimated.View` sitting under the pill. `panelHeight` is the
+ * plain-JS pixel height to size the emoji panel's content.
+ */
+export interface ComposerPanel {
+  /** Whether the custom (emoji) panel is currently shown. */
+  panelOpen: boolean;
+  /**
+   * Animated height for the spacer/panel container under the pill. Includes
+   * the resting bottom safe-area inset when nothing is open, and collapses
+   * that inset as the keyboard/panel takes over the space.
+   */
+  spacerHeight: SharedValue<number>;
+  /** Static pixel height to lay the panel content out at (last keyboard height). */
+  panelHeight: number;
+  /** Show the panel: dismiss the keyboard, hold its footprint. */
+  openPanel: () => void;
+  /** Hide the panel (caller is responsible for refocusing the input). */
+  closePanel: () => void;
+  /** Toggle the panel. When opening, dismisses the keyboard. */
+  togglePanel: (refocus: () => void) => void;
+  /** Call when the input gains focus — collapses the panel without animation fight. */
+  onInputFocus: () => void;
+}
+
+// Sensible fallback before we've ever seen the keyboard (first open on a fresh
+// launch). Close to a typical Android/iOS keyboard height; it's only used for
+// the very first panel-open before a real measurement lands.
+const FALLBACK_KEYBOARD_HEIGHT = 290;
+
+export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPanel {
+  const { bottomInset = 0 } = options;
+  const { height: keyboardHeight, progress: keyboardProgress } = useReanimatedKeyboardAnimation();
+  // Last real keyboard height we've observed, kept on the UI thread for the
+  // spacer worklet and mirrored to JS state for panel content sizing.
+  const lastKeyboardHeight = useSharedValue(FALLBACK_KEYBOARD_HEIGHT);
+  const [panelHeight, setPanelHeight] = useState(FALLBACK_KEYBOARD_HEIGHT);
+  // panelOpen as a shared value so the spacer worklet can branch without a
+  // JS round-trip; mirrored to React state for conditional rendering.
+  const panelOpenSV = useSharedValue(0);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const panelOpenRef = useRef(false);
+
+  // Capture the keyboard height whenever it's meaningfully open so the panel
+  // can match it. onMove fires continuously; we only latch the peak.
+  useKeyboardHandler(
+    {
+      onMove: (e) => {
+        'worklet';
+        if (e.height > 0) {
+          lastKeyboardHeight.value = e.height;
+        }
+      },
+      onEnd: (e) => {
+        'worklet';
+        if (e.height > 0) {
+          lastKeyboardHeight.value = e.height;
+        }
+      },
+    },
+    []
+  );
+
+  // The spacer height: follow the live keyboard when the panel is closed,
+  // otherwise hold the last keyboard height (panel footprint). The resting
+  // bottom safe-area inset is added on top, and fades out (via keyboard
+  // progress) as the keyboard/panel takes over so we don't double-count it.
+  const spacerHeight = useDerivedValue(() => {
+    if (panelOpenSV.value === 1) {
+      // Panel fully open: just the keyboard footprint, no resting inset.
+      return lastKeyboardHeight.value;
+    }
+    const kb = Math.max(keyboardHeight.value, 0);
+    // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
+    const restingInset = bottomInset * (1 - Math.min(Math.max(keyboardProgress.value, 0), 1));
+    return kb + restingInset;
+  });
+
+  const openPanel = useCallback(() => {
+    // Snapshot the measured height for content layout before dismissing.
+    setPanelHeight(Math.round(lastKeyboardHeight.value) || FALLBACK_KEYBOARD_HEIGHT);
+    panelOpenRef.current = true;
+    panelOpenSV.value = 1;
+    setPanelOpen(true);
+    Keyboard.dismiss();
+  }, [lastKeyboardHeight, panelOpenSV]);
+
+  const closePanel = useCallback(() => {
+    panelOpenRef.current = false;
+    panelOpenSV.value = 0;
+    setPanelOpen(false);
+  }, [panelOpenSV]);
+
+  const togglePanel = useCallback(
+    (refocus: () => void) => {
+      if (panelOpenRef.current) {
+        closePanel();
+        refocus();
+      } else {
+        openPanel();
+      }
+    },
+    [openPanel, closePanel]
+  );
+
+  // When the input refocuses (keyboard comes back), make sure the panel flag
+  // is cleared so the spacer switches back to following the keyboard.
+  const onInputFocus = useCallback(() => {
+    if (panelOpenRef.current) {
+      panelOpenRef.current = false;
+      panelOpenSV.value = 0;
+      setPanelOpen(false);
+    }
+  }, [panelOpenSV]);
+
+  return {
+    panelOpen,
+    spacerHeight,
+    panelHeight,
+    openPanel,
+    closePanel,
+    togglePanel,
+    onInputFocus,
+  };
+}

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -5,6 +5,7 @@ import {
   useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller';
 import {
+  runOnJS,
   useDerivedValue,
   useSharedValue,
   type SharedValue,
@@ -67,6 +68,9 @@ export interface ComposerPanel {
 // the real measured height instead of this constant.
 const FALLBACK_KEYBOARD_HEIGHT = 290;
 let lastSessionKeyboardHeight = FALLBACK_KEYBOARD_HEIGHT;
+function rememberSessionKeyboardHeight(height: number) {
+  if (height > 0) lastSessionKeyboardHeight = height;
+}
 
 export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPanel {
   const { bottomInset = 0, bottomChromeHeight = 0 } = options;
@@ -75,12 +79,6 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // spacer worklet. Seeded from the session cache so a panel opened before this
   // composer ever showed the keyboard still uses a real height when available.
   const lastKeyboardHeight = useSharedValue(lastSessionKeyboardHeight);
-  // bottomChromeHeight as a shared value so the worklet picks up changes
-  // (rotation, tab-bar show/hide) without a stale closure.
-  const chromeHeight = useSharedValue(bottomChromeHeight);
-  chromeHeight.value = bottomChromeHeight;
-  const restingInset = useSharedValue(bottomInset);
-  restingInset.value = bottomInset;
   // panelOpen as a shared value so the spacer worklet can branch without a
   // JS round-trip; mirrored to React state for conditional rendering and to a
   // ref for synchronous reads inside callbacks (avoids stale closures).
@@ -93,28 +91,20 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // mirror it to the module-level session cache for future cold opens.
   useKeyboardHandler(
     {
-      onMove: (e) => {
-        'worklet';
-        if (e.height > 0) {
-          lastKeyboardHeight.value = e.height;
-        }
-      },
       onEnd: (e) => {
         'worklet';
         if (e.height > 0) {
           lastKeyboardHeight.value = e.height;
+          // Mirror the settled height to the JS-thread module cache so a future
+          // composer mount can seed from it. Hopping to JS only on settle (not
+          // every onMove frame) keeps this cheap, and avoids reading a shared
+          // value during render (which Reanimated strict mode warns about).
+          runOnJS(rememberSessionKeyboardHeight)(e.height);
         }
       },
     },
     []
   );
-
-  // Keep the module-level session cache in sync from JS so a future composer
-  // mount seeds from the real height. Reading a SharedValue.value from the JS
-  // thread is allowed; this runs on render, which is cheap and good enough.
-  if (lastKeyboardHeight.value > 0) {
-    lastSessionKeyboardHeight = lastKeyboardHeight.value;
-  }
 
   // The spacer height: follow the live keyboard when the panel is closed,
   // otherwise hold the last keyboard height (panel footprint). In both cases we
@@ -125,12 +115,12 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   const spacerHeight = useDerivedValue(() => {
     if (panelOpenSV.value === 1) {
       // Panel fully open: the keyboard footprint minus the chrome we sit above.
-      return Math.max(lastKeyboardHeight.value - chromeHeight.value, 0);
+      return Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
     }
-    const kb = Math.max(keyboardHeight.value - chromeHeight.value, 0);
+    const kb = Math.max(keyboardHeight.value - bottomChromeHeight, 0);
     // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
     const progress = Math.min(Math.max(keyboardProgress.value, 0), 1);
-    return kb + restingInset.value * (1 - progress);
+    return kb + bottomInset * (1 - progress);
   });
 
   const openPanel = useCallback(() => {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "2.28.0",
     "react-native-get-random-values": "1.11.0",
+    "react-native-keyboard-controller": "1.18.5",
     "react-native-mmkv": "4.1.0",
     "react-native-nitro-modules": "0.32.0",
     "react-native-qrcode-svg": "6.3.21",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "react-native": "0.81.5",
     "react-native-gesture-handler": "2.28.0",
     "react-native-get-random-values": "1.11.0",
-    "react-native-keyboard-controller": "1.18.5",
+    "react-native-keyboard-controller": "1.21.11",
     "react-native-mmkv": "4.1.0",
     "react-native-nitro-modules": "0.32.0",
     "react-native-qrcode-svg": "6.3.21",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,6 +7983,13 @@ react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
+react-native-keyboard-controller@1.18.5:
+  version "1.18.5"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz#ae12131f2019c574178479d2c55784f55e08bb68"
+  integrity sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==
+  dependencies:
+    react-native-is-edge-to-edge "^1.2.1"
+
 react-native-mmkv@4.1.0:
   version "4.1.0"
   resolved "https://registry.npmjs.org/react-native-mmkv/-/react-native-mmkv-4.1.0.tgz"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7983,10 +7983,10 @@ react-native-is-edge-to-edge@^1.1.6, react-native-is-edge-to-edge@^1.2.1:
   resolved "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.2.1.tgz"
   integrity sha512-FLbPWl/MyYQWz+KwqOZsSyj2JmLKglHatd3xLZWskXOpRaio4LfEDEz8E/A6uD8QoTHW6Aobw1jbEwK7KMgR7Q==
 
-react-native-keyboard-controller@1.18.5:
-  version "1.18.5"
-  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.18.5.tgz#ae12131f2019c574178479d2c55784f55e08bb68"
-  integrity sha512-wbYN6Tcu3G5a05dhRYBgjgd74KqoYWuUmroLpigRg9cXy5uYo7prTMIvMgvLtARQtUF7BOtFggUnzgoBOgk0TQ==
+react-native-keyboard-controller@1.21.11:
+  version "1.21.11"
+  resolved "https://registry.yarnpkg.com/react-native-keyboard-controller/-/react-native-keyboard-controller-1.21.11.tgz#c7914734de61a31bc9851a231a211e3967e9e98b"
+  integrity sha512-xUUMZ6D4nJDsYpHrhdTE7+jZoFVbiRaaLnOq3IwlXGY9Gvui0PWHiuOAjA7qmdBc1HMinWWXPXmXn3N/Ic6AXg==
   dependencies:
     react-native-is-edge-to-edge "^1.2.1"
 


### PR DESCRIPTION
Reworks the chat message composer into a single pill-shaped input with a downward-opening emoji panel.

## What changed
- **Unified pill**: emoji toggle on the left, growing text input, attach (paperclip) + circular send on the right — all in one rounded container. Attach hides while composing.
- **Emoji panel opens downward**, replacing the soft keyboard in the same footprint (the keyboard slides out, the panel slides into its place) with no layout flicker. The text caret stays visible while the panel is open.
- **Composer self-avoids the keyboard** via an animated spacer driven by `react-native-keyboard-controller`. The four chat screens (space, DM, DM view, Farcaster DM) drop their `KeyboardAvoidingView` and manual Android keyboard-height tracking.
- Self-sizing pill (device-agnostic), consistent gap with/without the keyboard, single-line centering, and a rounded box when the text grows to multiple lines.

## New dependency
- Adds `react-native-keyboard-controller` (has native code). **A native rebuild is required** after pulling this — a Metro reload is not enough. `KeyboardProvider` is added at the app root.

## Testing
- Verified on a physical Android device.
- **Not yet tested on iOS** — hardened defensively (the library and the layout geometry are platform-agnostic), but iOS should be verified on a device/simulator before relying on it.

## Commits
$(git log --oneline --reverse master..HEAD | sed 's/^[a-f0-9]* /- /')