### PR TITLE
feat: hide bottom tab bar with the emoji panel

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -11,7 +11,16 @@ import { useTheme } from '@/theme';
 import { Tabs } from 'expo-router';
 import React from 'react';
 import { Platform, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
+
+// Visual height of the tab bar's content area (icons), excluding the bottom
+// safe-area inset which is added on top. The default React Navigation value is
+// ~49; bumped slightly here for a roomier touch target. Nothing hardcodes the
+// tab bar height elsewhere — every consumer (chat composer chrome, profile
+// padding, tab bar background) reads the live value via useBottomTabBarHeight(),
+// so changing this constant is the single source of truth.
+const TAB_BAR_CONTENT_HEIGHT = 50;
 
 function ProfileTabIcon({ color }: { color: string; focused: boolean }) {
   // The tab now defaults to the notifications inbox; profile/account is
@@ -45,6 +54,7 @@ function ProfileTabIcon({ color }: { color: string; focused: boolean }) {
 
 export default function TabsLayout() {
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
   // Hide the bottom tab bar while the chat composer's emoji panel is open so
   // the panel gets the full bottom of the screen. The chat screens
   // simultaneously drop their bottomChromeHeight so the panel extends into the
@@ -74,6 +84,13 @@ export default function TabsLayout() {
           position: 'absolute' as const,
           borderTopWidth: 0,
           elevation: 0,
+          // Slightly taller bar with a roomier touch target. The explicit
+          // height must include the bottom safe-area inset (home indicator),
+          // and paddingBottom keeps the icons centered above that inset.
+          height: TAB_BAR_CONTENT_HEIGHT + insets.bottom,
+          paddingBottom: insets.bottom,
+          // 1px of breathing room above the icons.
+          paddingTop: 1,
           // Collapse the bar while the composer emoji panel is open.
           ...(composerPanelOpen ? { display: 'none' as const } : null),
         },

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ import { MiniappOverlayProvider } from '@/context/MiniappOverlayContext';
 import { SwapModalProvider } from '@/context/SwapModalContext';
 import { useUnifiedNotifications } from '@/hooks/useUnifiedNotifications';
 import { feedActiveTabBus } from '@/services/ui/feedActiveTab';
+import { useComposerPanelVisible } from '@/services/ui/composerPanelVisible';
 import { useTheme } from '@/theme';
 import { Tabs } from 'expo-router';
 import React from 'react';
@@ -44,6 +45,11 @@ function ProfileTabIcon({ color }: { color: string; focused: boolean }) {
 
 export default function TabsLayout() {
   const { theme } = useTheme();
+  // Hide the bottom tab bar while the chat composer's emoji panel is open so
+  // the panel gets the full bottom of the screen. The chat screens
+  // simultaneously drop their bottomChromeHeight so the panel extends into the
+  // vacated space (no gap).
+  const composerPanelOpen = useComposerPanelVisible();
 
   return (
     <SwapModalProvider>
@@ -68,6 +74,8 @@ export default function TabsLayout() {
           position: 'absolute' as const,
           borderTopWidth: 0,
           elevation: 0,
+          // Collapse the bar while the composer emoji panel is open.
+          ...(composerPanelOpen ? { display: 'none' as const } : null),
         },
       }}
     >

--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -19,6 +19,7 @@ import { useMiniappOverlay } from '@/context/MiniappOverlayContext';
 import { truncateAddress } from '@/utils/formatAddress';
 import { useTheme } from '@/theme';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useComposerPanelVisible } from '@/services/ui/composerPanelVisible';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Image, StyleSheet, Text, View } from 'react-native';
@@ -61,15 +62,20 @@ export default function DMChatScreen() {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
   const tabBarHeight = useBottomTabBarHeight();
+  // While the composer emoji panel is open the tab bar is hidden, so reclaim
+  // its space: zero the bottom padding here and pass 0 chrome height to the
+  // chat area so the panel extends to the screen bottom with no gap.
+  const composerPanelOpen = useComposerPanelVisible();
+  const effectiveChromeHeight = composerPanelOpen ? 0 : tabBarHeight;
   const containerStyle = useMemo(
     () => [
       styles.container,
       {
-        paddingBottom: tabBarHeight,
+        paddingBottom: effectiveChromeHeight,
         backgroundColor: theme.colors.surface1,
       },
     ],
-    [tabBarHeight, theme.colors.surface1]
+    [effectiveChromeHeight, theme.colors.surface1]
   );
 
   // Grab the conversation from unified conversations first (has richest data)
@@ -329,7 +335,7 @@ export default function DMChatScreen() {
           onOpenFarcasterCast={handleOpenFarcasterCast}
           onLinkPress={handleLinkPress}
           bottomInset={0}
-          tabBarHeight={tabBarHeight}
+          tabBarHeight={effectiveChromeHeight}
         />
 
       </View>
@@ -357,7 +363,7 @@ export default function DMChatScreen() {
         isBookmarked={isBookmarked}
         addBookmark={addBookmark}
         removeBookmark={removeBookmark}
-        tabBarHeight={tabBarHeight}
+        tabBarHeight={effectiveChromeHeight}
         theme={theme}
         draftsRef={draftsRef}
       />

--- a/app/(tabs)/spaces/[id]/[channelId].tsx
+++ b/app/(tabs)/spaces/[id]/[channelId].tsx
@@ -15,6 +15,7 @@ import { useBookmarks } from '@/hooks/useUserConfig';
 import { getSpaceKey } from '@/services/config/spaceStorage';
 import { useTheme } from '@/theme';
 import { useBottomTabBarHeight } from '@react-navigation/bottom-tabs';
+import { useComposerPanelVisible } from '@/services/ui/composerPanelVisible';
 import { router, Stack, useLocalSearchParams } from 'expo-router';
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, StyleSheet, Text, View } from 'react-native';
@@ -59,6 +60,11 @@ export default function SpaceChannelChat() {
   const { enqueueOutbound, isConnected } = useWebSocket();
   const insets = useSafeAreaInsets();
   const tabBarHeight = useBottomTabBarHeight();
+  // While the composer emoji panel is open the tab bar is hidden, so reclaim
+  // its space (zero padding + 0 chrome height) and let the panel reach the
+  // screen bottom.
+  const composerPanelOpen = useComposerPanelVisible();
+  const effectiveChromeHeight = composerPanelOpen ? 0 : tabBarHeight;
 
   const { data: spaceData } = useSpace(spaceId, { enabled: !!spaceId });
   const { data: membersData } = useSpaceMembers(spaceId, { enabled: !!spaceId });
@@ -251,7 +257,7 @@ export default function SpaceChannelChat() {
       style={[
         styles.container,
         {
-          paddingBottom: tabBarHeight,
+          paddingBottom: effectiveChromeHeight,
           backgroundColor: theme.colors.surface1,
         },
       ]}
@@ -287,7 +293,7 @@ export default function SpaceChannelChat() {
         isBookmarked={isBookmarked}
         addBookmark={addBookmark}
         removeBookmark={removeBookmark}
-        tabBarHeight={tabBarHeight}
+        tabBarHeight={effectiveChromeHeight}
         theme={theme}
         draftsRef={draftsRef}
         onChannelLinkPress={handleChannelLinkPress}

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -242,6 +242,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
     // spacing matches the tighter keyboard-up spacing instead of being larger.
     bottomInset,
     bottomChromeHeight,
+    // Publish open/close synchronously (in the toggle action, not via an effect)
+    // so the tab bar hides/shows in the same tick — no extra render-cycle lag.
+    onPanelVisibilityChange: composerPanelVisibleStore.set,
   });
   const showEmojiPicker = composerPanel.panelOpen;
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>('smileys');
@@ -268,13 +271,10 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
     }
   }, [showEmojiPicker, refreshRecent]);
 
-  // Publish the panel's open state so the Tabs layout can hide the bottom tab
-  // bar (more room for emojis) and the chat screen can drop its bottom-chrome
-  // height so the panel extends into the freed space. Reset to false on unmount
-  // so a composer leaving the tree never leaves the tab bar hidden.
-  useEffect(() => {
-    composerPanelVisibleStore.set(showEmojiPicker);
-  }, [showEmojiPicker]);
+  // The panel's open/close is published synchronously via the hook's
+  // onPanelVisibilityChange (see useComposerPanel call above). This effect only
+  // guards unmount: a composer leaving the tree must never leave the tab bar
+  // hidden.
   useEffect(() => () => composerPanelVisibleStore.set(false), []);
 
   // Autocomplete state

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -11,6 +11,7 @@ import { ActivityIndicator, Image, useWindowDimensions, NativeSyntheticEvent, Pl
 import Reanimated, { useAnimatedStyle } from 'react-native-reanimated';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useComposerPanel } from '@/hooks/useComposerPanel';
+import { composerPanelVisibleStore } from '@/services/ui/composerPanelVisible';
 import * as Skin from '@/theme/skins/geometry';
 
 
@@ -266,6 +267,15 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
       refreshRecent();
     }
   }, [showEmojiPicker, refreshRecent]);
+
+  // Publish the panel's open state so the Tabs layout can hide the bottom tab
+  // bar (more room for emojis) and the chat screen can drop its bottom-chrome
+  // height so the panel extends into the freed space. Reset to false on unmount
+  // so a composer leaving the tree never leaves the tab bar hidden.
+  useEffect(() => {
+    composerPanelVisibleStore.set(showEmojiPicker);
+  }, [showEmojiPicker]);
+  useEffect(() => () => composerPanelVisibleStore.set(false), []);
 
   // Autocomplete state
   const [autocompleteType, setAutocompleteType] = useState<'mention' | 'channel' | null>(null);

--- a/components/SocialFeed/content/LikeIcon.tsx
+++ b/components/SocialFeed/content/LikeIcon.tsx
@@ -87,12 +87,17 @@ interface LikeIconProps {
 export function LikeIcon({ type, isLiked, color, activeColor, size }: LikeIconProps) {
   const displayColor = isLiked ? activeColor : color;
 
+  // The Quorum/Quilibrium logo glyphs read slightly larger than the heart and
+  // the other action icons at the same nominal size, so scale them to 0.9x to
+  // sit visually level with them in the action row.
+  const logoSize = Math.round(size * 0.9);
+
   switch (type) {
     case LikeIconType.Quilibrium:
-      return <QuilibriumLogoIcon size={size} opacity={isLiked ? 1 : 0.6} />;
+      return <QuilibriumLogoIcon size={logoSize} opacity={isLiked ? 1 : 0.6} />;
 
     case LikeIconType.Quorum:
-      return <QuorumLogoIcon size={size} opacity={isLiked ? 1 : 0.6} />;
+      return <QuorumLogoIcon size={logoSize} opacity={isLiked ? 1 : 0.6} />;
 
     case LikeIconType.GM:
       return <BoldText text="GM" color={displayColor} size={size} />;

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -90,6 +90,11 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // window the spacer holds the panel footprint until the rising keyboard
   // catches up, so the pill never drops to the bottom and bounces back up.
   const closingSV = useSharedValue(0);
+  // Whether the panel was opened while the keyboard was up (input focused). If
+  // it was opened with NO keyboard (input unfocused), closing must NOT arm the
+  // keyboard hand-off — there's no keyboard coming back, so the spacer should
+  // collapse to 0 rather than hold the footprint forever (which leaves a gap).
+  const openedWithKeyboardRef = useRef(false);
 
   // Capture the keyboard height whenever it's meaningfully open so the panel
   // can match it. We latch the height on settle and, once the keyboard is fully
@@ -124,10 +129,12 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // resting bottom inset is added when nothing is open and fades out (via
   // keyboard progress) as the keyboard/panel takes over.
   const spacerHeight = useDerivedValue(() => {
-    const panelFootprint = Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
     if (panelOpenSV.value === 1) {
-      // Panel fully open: the keyboard footprint minus the chrome we sit above.
-      return panelFootprint;
+      // Panel fully open: the tab bar is hidden, so the panel takes the FULL
+      // keyboard height (no chrome subtraction) and reaches the screen bottom.
+      // Not subtracting bottomChromeHeight here also makes open instant — the
+      // height doesn't depend on the store round-trip that zeroes the chrome.
+      return Math.max(lastKeyboardHeight.value, 0);
     }
     // useReanimatedKeyboardAnimation().height is NEGATIVE-going (0 -> -kbHeight),
     // matching the library's own components which negate it. Flip the sign to
@@ -135,11 +142,12 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     const liveKeyboardHeight = -keyboardHeight.value;
     const kb = Math.max(liveKeyboardHeight - bottomChromeHeight, 0);
     if (closingSV.value === 1) {
-      // Closing the panel by summoning the keyboard back: hold the panel
-      // footprint and let the RISING keyboard meet it. Math.max means the pill
-      // stays put and the hand-off is seamless once the keyboard catches up —
-      // no drop-to-bottom-then-bounce.
-      return Math.max(kb, panelFootprint);
+      // Closing the panel by summoning the keyboard back. The tab bar reappears
+      // on close, so the target is the chrome-subtracted keyboard footprint.
+      // Hold it and let the RISING keyboard meet it (Math.max) so the pill stays
+      // put — seamless once the keyboard catches up.
+      const target = Math.max(lastKeyboardHeight.value - bottomChromeHeight, 0);
+      return Math.max(kb, target);
     }
     // progress goes 0 -> 1 as the keyboard appears; fade the resting inset out.
     const progress = Math.min(Math.max(keyboardProgress.value, 0), 1);
@@ -149,6 +157,8 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   const openPanel = useCallback(() => {
     // Any prior close hand-off is moot once we're opening again.
     closingSV.value = 0;
+    // Remember whether a keyboard was up at open time — drives the close path.
+    openedWithKeyboardRef.current = KeyboardController.isVisible();
     panelOpenRef.current = true;
     panelOpenSV.value = 1;
     setPanelOpen(true);
@@ -179,8 +189,16 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // .focus() on an already-focused input would not reliably do.
   const closePanelAndRestoreKeyboard = useCallback(() => {
     if (!panelOpenRef.current) return;
-    closingSV.value = 1;
-    KeyboardController.setFocusTo('current');
+    if (openedWithKeyboardRef.current) {
+      // Opened with the keyboard up: bring it back and hold the footprint
+      // during the hand-off so the pill doesn't drop-and-bounce.
+      closingSV.value = 1;
+      KeyboardController.setFocusTo('current');
+    } else {
+      // Opened with NO keyboard: nothing is coming back, so just collapse the
+      // spacer (don't arm the hand-off — that would leave a permanent gap).
+      closingSV.value = 0;
+    }
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
     setPanelOpen(false);

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -22,6 +22,13 @@ export interface ComposerPanelOptions {
    * the top of the keyboard.
    */
   bottomChromeHeight?: number;
+  /**
+   * Called synchronously whenever the panel opens (true) or closes (false).
+   * Fired inside the open/close actions (not via an effect) so dependent UI —
+   * e.g. hiding the bottom tab bar — reacts in the same tick with no extra
+   * render-cycle latency.
+   */
+  onPanelVisibilityChange?: (open: boolean) => void;
 }
 
 /**
@@ -74,7 +81,11 @@ function rememberSessionKeyboardHeight(height: number) {
 }
 
 export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPanel {
-  const { bottomInset = 0, bottomChromeHeight = 0 } = options;
+  const { bottomInset = 0, bottomChromeHeight = 0, onPanelVisibilityChange } = options;
+  // Keep the latest callback in a ref so the open/close callbacks don't need it
+  // in their dep arrays (which would re-create them every render).
+  const onVisibilityRef = useRef(onPanelVisibilityChange);
+  onVisibilityRef.current = onPanelVisibilityChange;
   const { height: keyboardHeight, progress: keyboardProgress } = useReanimatedKeyboardAnimation();
   // Last real keyboard height we've observed, kept on the UI thread for the
   // spacer worklet. Seeded from the session cache so a panel opened before this
@@ -161,6 +172,7 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     openedWithKeyboardRef.current = KeyboardController.isVisible();
     panelOpenRef.current = true;
     panelOpenSV.value = 1;
+    onVisibilityRef.current?.(true);
     setPanelOpen(true);
     // keepFocus: true hides the soft keyboard but leaves the TextInput focused,
     // so the blinking caret stays visible and emojis insert at the cursor.
@@ -177,6 +189,7 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     closingSV.value = 0;
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
+    onVisibilityRef.current?.(false);
     setPanelOpen(false);
   }, [panelOpenSV, closingSV]);
 
@@ -201,6 +214,7 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     }
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
+    onVisibilityRef.current?.(false);
     setPanelOpen(false);
   }, [panelOpenSV, closingSV]);
 
@@ -220,6 +234,7 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     closingSV.value = 1;
     panelOpenRef.current = false;
     panelOpenSV.value = 0;
+    onVisibilityRef.current?.(false);
     setPanelOpen(false);
   }, [panelOpenSV, closingSV]);
 

--- a/services/ui/composerPanelVisible.ts
+++ b/services/ui/composerPanelVisible.ts
@@ -1,0 +1,49 @@
+/**
+ * composerPanelVisible — reactive module-level store for "the chat composer's
+ * emoji panel is open". Two unrelated parts of the tree react to it:
+ *   - the Tabs layout hides the bottom tab bar so the panel gets more room; and
+ *   - the chat screens drop their `bottomChromeHeight` to 0 so the emoji panel
+ *     extends down into the space the (now hidden) tab bar vacated, with no gap.
+ *
+ * Why a module-level store and not React context: the producer (MessageInput,
+ * deep in a chat screen) and the consumers (the Tabs layout above it, and the
+ * chat screen itself) don't share a convenient common provider, and a context
+ * would re-render every tab on each toggle. `useSyncExternalStore` gives the
+ * consumers a cheap reactive subscription. Mirrors the existing
+ * `feedActiveTab` bus rationale, but this one holds state (not a one-shot event).
+ */
+
+import { useSyncExternalStore } from 'react';
+
+let panelOpen = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  for (const l of listeners) l();
+}
+
+export const composerPanelVisibleStore = {
+  /** Producer: set whether the composer emoji panel is currently open. */
+  set(open: boolean) {
+    if (panelOpen === open) return;
+    panelOpen = open;
+    emit();
+  },
+  /** For useSyncExternalStore. */
+  subscribe(listener: () => void): () => void {
+    listeners.add(listener);
+    return () => listeners.delete(listener);
+  },
+  getSnapshot(): boolean {
+    return panelOpen;
+  },
+};
+
+/** Reactive hook: re-renders the caller when the composer panel opens/closes. */
+export function useComposerPanelVisible(): boolean {
+  return useSyncExternalStore(
+    composerPanelVisibleStore.subscribe,
+    composerPanelVisibleStore.getSnapshot,
+    composerPanelVisibleStore.getSnapshot,
+  );
+}


### PR DESCRIPTION
Builds on the unified message composer (#99). When the chat emoji panel opens, the bottom tab bar collapses and the panel takes the full bottom of the screen — matching common messengers.

## What changed
- **Hide the tab bar while the emoji panel is open**, and let the panel extend into the freed space (no gap): the chat screen's bottom padding and the composer's bottom-chrome height both drop to 0 when the panel is open. Driven by a small reactive store (`composerPanelVisible`) that the composer sets and the tab navigator + chat screens read.
- **Fix: no gap when closing a panel that was opened without the keyboard** (input unfocused). The keyboard hand-off now only arms when a keyboard was actually present at open time.
- **Snappier open/close**: panel visibility is published synchronously from the open/close action (not via an effect), removing a render-cycle of latency; the open panel takes the full keyboard height directly so it no longer grows in two steps.
- **Slightly taller bottom tab bar** for a roomier touch target (single source of truth; all consumers read the live height).
- Unrelated small fix: scale the Quorum/Quilibrium like-icon logos to 0.9x so they sit visually level with the other action-row icons.

## Testing
- Verified on a physical Android device. The system nav bar already renders edge-to-edge, so the panel reaches the true screen bottom without extra config.
- Not yet tested on iOS.

## Note
The remaining emoji-panel open/close hitch is the emoji grid mounting (a separate, pre-existing perf item), not the keyboard/tab-bar choreography.

## Commits
$(git log --oneline --reverse master..HEAD | sed 's/^[a-f0-9]* /- /')