### PR TITLE
fix: pad bottom sheets by safe-area inset so content clears the nav bar

### DIFF
--- a/components/AudioSpaceOverlay.tsx
+++ b/components/AudioSpaceOverlay.tsx
@@ -25,6 +25,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import Animated, {
   runOnJS,
@@ -100,6 +101,7 @@ export function AudioSpaceOverlay() {
     remoteVideoStreams,
   } = useAudioSpace();
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
   const { user } = useAuth();
   const localFid = user?.farcaster?.fid;
   // Build the per-FID video lookup once per render. Local participant's
@@ -537,7 +539,7 @@ export function AudioSpaceOverlay() {
               Leave. Camera sits next to Mic because they're the two
               publishing controls. */}
           {state !== 'scheduled' && (
-          <View style={[styles.controlBar, { borderTopColor: theme.colors.surface3 }]}>
+          <View style={[styles.controlBar, { borderTopColor: theme.colors.surface3, paddingBottom: Skin.space(16) + insets.bottom }]}>
             {(() => {
               const canPublishLocal =
                 role === 'host' || role === 'cohost' || role === 'speaker';

--- a/components/BrowserModal.tsx
+++ b/components/BrowserModal.tsx
@@ -1102,7 +1102,8 @@ export default function BrowserModal({ visible, url, onClose, isQNative = false,
       )}
 
       {/* Navigation Bar */}
-      <View style={styles.navigationBar}>
+      {/* Bottom inset so the nav buttons clear the system nav bar. */}
+      <View style={[styles.navigationBar, { paddingBottom: Skin.space(12) + insets.bottom }]}>
         <TouchableOpacity
           onPress={handleGoBack}
           disabled={!canGoBack && !backEnabled}
@@ -1573,7 +1574,8 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets, isQN
       flexDirection: 'row',
       justifyContent: 'space-around',
       alignItems: 'center',
-      paddingVertical: Skin.space(12),
+      paddingTop: Skin.space(12),
+      // paddingBottom applied inline = Skin.space(12) + insets.bottom.
       borderTopWidth: Skin.border(1),
       borderTopColor: theme.colors.border,
       backgroundColor: theme.colors.background,

--- a/components/Chat/EditHistoryModal.tsx
+++ b/components/Chat/EditHistoryModal.tsx
@@ -13,6 +13,7 @@ import {
   ScrollView,
   Dimensions,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { formatTime } from './types';
 import * as Skin from '@/theme/skins/geometry';
@@ -43,6 +44,7 @@ export const EditHistoryModal = React.memo(function EditHistoryModal({
   theme,
 }: EditHistoryModalProps) {
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const insets = useSafeAreaInsets();
 
   // Build timeline: original + all edits, newest first
   const timeline = useMemo(() => {
@@ -76,7 +78,8 @@ export const EditHistoryModal = React.memo(function EditHistoryModal({
     >
       <View style={styles.overlay}>
         <Pressable style={styles.backdrop} onPress={onClose} />
-        <View style={styles.container}>
+        {/* Bottom inset so content clears the system nav bar. */}
+        <View style={[styles.container, { paddingBottom: Math.max(insets.bottom, Skin.space(16)) }]}>
           <View style={styles.header}>
             <Text style={styles.headerTitle}>Edit History</Text>
             <Pressable onPress={onClose} hitSlop={8}>
@@ -126,7 +129,7 @@ const createStyles = (theme: AppTheme) =>
       borderTopRightRadius: Skin.radius(16),
       maxHeight: '70%',
       width: SCREEN_WIDTH,
-      paddingBottom: Skin.space(34),
+      // paddingBottom applied inline from the real safe-area inset.
     },
     header: {
       flexDirection: 'row',

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -7,6 +7,7 @@
 import type { AppTheme } from '@/theme';
 import React, { useEffect, useState } from 'react';
 import { View, Text, StyleSheet, Modal, Pressable, Dimensions } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Clipboard from 'expo-clipboard';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -74,6 +75,7 @@ export function MessageActionSheet({
   theme,
 }: MessageActionSheetProps) {
   const styles = createStyles(theme);
+  const insets = useSafeAreaInsets();
   const { confirm, confirmDialog } = useConfirmDialog();
   // While a confirm dialog is open ON TOP of this sheet, swallow the sheet's own
   // back/backdrop dismissal — otherwise an Android back could close the sheet
@@ -200,7 +202,10 @@ export function MessageActionSheet({
     >
       <View style={styles.overlay}>
         <Pressable style={styles.backdrop} onPress={guardedClose} />
-        <View style={styles.container}>
+        {/* Pad the bottom by the real safe-area inset so the last row clears
+            the system nav bar (Android 3-button nav is taller than the old
+            hardcoded 34px home-indicator guess, which clipped "Report"). */}
+        <View style={[styles.container, { paddingBottom: Math.max(insets.bottom, Skin.space(16)) }]}>
           {/* Drag handle */}
           <View style={styles.handleContainer}>
             <View style={styles.handle} />
@@ -309,7 +314,7 @@ const createStyles = (theme: AppTheme) =>
       borderTopLeftRadius: Skin.radius(16),
       borderTopRightRadius: Skin.radius(16),
       width: SCREEN_WIDTH,
-      paddingBottom: Skin.space(34), // Safe area for home indicator
+      // paddingBottom is applied inline from the real safe-area inset.
     },
     handleContainer: {
       alignItems: 'center',

--- a/components/CreateSpaceSheet.tsx
+++ b/components/CreateSpaceSheet.tsx
@@ -22,6 +22,7 @@ import {
   TextInput,
   View,
 } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAudioSpace } from '@/context/AudioSpaceContext';
 import { useToast } from '@/context/ToastContext';
@@ -110,6 +111,7 @@ export function CreateSpaceSheet({
   onClose: () => void;
 }) {
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
   const { createSpace, join } = useAudioSpace();
   const { showToast } = useToast();
   const [title, setTitle] = React.useState('');
@@ -254,7 +256,10 @@ export function CreateSpaceSheet({
           <View
             style={[
               styles.sheet,
-              { backgroundColor: theme.colors.surface1 },
+              // Real safe-area inset so the anchored submit button clears the
+              // system nav bar (Android 3-button nav is taller than the old
+              // hardcoded 24px guess).
+              { backgroundColor: theme.colors.surface1, paddingBottom: Math.max(insets.bottom, Skin.space(24)) },
             ]}
           >
             <View style={styles.header}>
@@ -508,9 +513,8 @@ const styles = createSkinnable(() => StyleSheet.create({
     borderTopRightRadius: Skin.radius(16),
     paddingHorizontal: Skin.space(16),
     paddingTop: Skin.space(16),
-    // Extra bottom padding so the anchored submit button has room
-    // above the home indicator on devices with a bottom inset.
-    paddingBottom: Platform.OS === 'ios' ? 34 : 24,
+    // paddingBottom applied inline from the real safe-area inset so the
+    // anchored submit button clears the home indicator / nav bar.
     // Fixed slice of screen so the ScrollView always has space and
     // the anchored submit doesn't crowd the inputs. The previous
     // `maxHeight: '90%'` left the sheet content-sized when short,

--- a/components/FarcasterReimportSheet.tsx
+++ b/components/FarcasterReimportSheet.tsx
@@ -13,6 +13,7 @@
 
 import React, { useState } from 'react';
 import { ActivityIndicator, Modal, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useTheme } from '@/theme';
 import {
@@ -40,6 +41,7 @@ interface Props {
 
 export default function FarcasterReimportSheet({ visible, onClose, onImported }: Props) {
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
   const [mnemonic, setMnemonic] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,7 +96,13 @@ export default function FarcasterReimportSheet({ visible, onClose, onImported }:
   return (
     <Modal visible={visible} animationType="slide" transparent onRequestClose={onClose}>
       <View style={[styles.backdrop, { backgroundColor: 'rgba(0,0,0,0.45)' }]}>
-        <View style={[styles.card, { backgroundColor: theme.colors.surface1 }]}>
+        {/* Bottom inset so the Cancel/Import buttons clear the system nav bar. */}
+        <View
+          style={[
+            styles.card,
+            { backgroundColor: theme.colors.surface1, paddingBottom: Math.max(insets.bottom, Skin.space(20)) },
+          ]}
+        >
           <Text style={[styles.title, { color: theme.colors.textStrong }]}>
             Re-import Farcaster
           </Text>
@@ -167,7 +175,7 @@ const styles = createSkinnable(() => StyleSheet.create({
   },
   card: {
     padding: Skin.space(20),
-    paddingBottom: Skin.space(32),
+    // paddingBottom applied inline from the real safe-area inset.
     borderTopLeftRadius: Skin.radius(16),
     borderTopRightRadius: Skin.radius(16),
     gap: Skin.space(12),

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -6,6 +6,7 @@
 
 import React, { useState } from 'react';
 import { ActivityIndicator, Alert, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import type { AppTheme } from '@/theme';
 import { useTheme } from '@/theme';
@@ -46,6 +47,7 @@ interface ReportModalProps {
 
 export function ReportModal({ visible, onClose, target, onSubmitted }: ReportModalProps) {
   const { theme } = useTheme();
+  const insets = useSafeAreaInsets();
   const { user } = useAuth();
   const { showToast } = useToast();
   const [reason, setReason] = useState<ReportReason | null>(null);
@@ -127,7 +129,13 @@ export function ReportModal({ visible, onClose, target, onSubmitted }: ReportMod
           behavior={Platform.OS === 'ios' ? 'padding' : undefined}
           style={styles.kbWrap}
         >
-          <Pressable style={styles.sheet} onPress={(e) => e.stopPropagation()}>
+          {/* Pad the bottom by the real safe-area inset so the action buttons
+              clear the system nav bar (Android 3-button nav is taller than the
+              old hardcoded inset). */}
+          <Pressable
+            style={[styles.sheet, { paddingBottom: Math.max(insets.bottom, Skin.space(20)) }]}
+            onPress={(e) => e.stopPropagation()}
+          >
             <Text style={styles.title}>{headerLabel}</Text>
             <Text style={styles.subtitle}>
               Pick a reason and add detail if you'd like. Reports go to the
@@ -211,7 +219,7 @@ const createStyles = (theme: AppTheme) =>
       backgroundColor: theme.colors.surface1,
       paddingHorizontal: Skin.space(20),
       paddingTop: Skin.space(24),
-      paddingBottom: Skin.space(36),
+      // paddingBottom applied inline from the real safe-area inset.
       borderTopLeftRadius: Skin.radius(16),
       borderTopRightRadius: Skin.radius(16),
       gap: Skin.space(12),


### PR DESCRIPTION
## Problem

Several bottom sheets had their last row/buttons clipped under the Android system navigation bar. Reported on the message action sheet (the `Report` row) and the report modal (the `Cancel` / `Submit report` buttons).

**Cause:** these hand-rolled sheets hardcoded their bottom padding (e.g. `Skin.space(34)`, `Skin.space(36)`, `Platform.OS === 'ios' ? 34 : 24`), a value tuned for an iPhone home indicator. Android 3-button navigation is taller, so the content slid under it.

## Fix

Replace the hardcoded bottom padding with `Math.max(insets.bottom, <min>)` from `useSafeAreaInsets()`, so each sheet keeps a sensible minimum on devices without a bottom inset but expands to clear the nav bar where one exists. This matches the shared `BaseModal`, which already does this (most modals route through it and were unaffected).

## Audited the whole surface

Swept every bottom-anchored modal. Everything using `BaseModal` was already correct. Fixed the 7 that hand-roll their own `Modal`:

- `MessageActionSheet` (message long-press menu)
- `ReportModal` (report message / cast)
- `FarcasterReimportSheet`
- `EditHistoryModal`
- `CreateSpaceSheet` (replaced the `Platform iOS?34:24` literals)
- `AudioSpaceOverlay` control bar
- `BrowserModal` nav bar (it already read `insets` but never applied `.bottom` to the bar)

## Testing

- `tsc` clean on all 7 edited files.
- Recommend a quick on-device check on Android 3-button nav: open the message action sheet and the report modal, confirm the last row clears the nav bar.