### PR TITLE
fix: gate pin/delete buttons on role, not space ownership

### DIFF
--- a/app/(tabs)/spaces/[id]/[channelId].tsx
+++ b/app/(tabs)/spaces/[id]/[channelId].tsx
@@ -79,10 +79,16 @@ export default function SpaceChannelChat() {
     return !!getSpaceKey(spaceId, 'owner');
   }, [spaceId]);
 
-  const hasRolePin = useHasPermission(spaceId, user?.address, 'message:pin');
-  const hasRoleDelete = useHasPermission(spaceId, user?.address, 'message:delete');
-  const hasPinPermission = hasRolePin || isSpaceOwner;
-  const hasDeletePermission = hasRoleDelete || isSpaceOwner;
+  // Pin/delete are role-only, NOT owner-derived. Receivers can't verify space
+  // ownership (no ownerAddress on the wire — privacy), so the receive-side guard
+  // rejects an owner's pin/delete of others' messages unless the owner holds a
+  // role granting it (see the remove-message validation in WebSocketContext +
+  // shared canDeleteMessage). Granting it here only showed buttons whose action
+  // recipients would drop. Match desktop: hide them. Owners still delete their
+  // own messages via the author check. `isSpaceOwner` stays for owner-only UI
+  // (invite, settings entry).
+  const hasPinPermission = useHasPermission(spaceId, user?.address, 'message:pin');
+  const hasDeletePermission = useHasPermission(spaceId, user?.address, 'message:delete');
 
   // The space's roles, passed to UserProfileModal so the owner can assign /
   // remove roles from a member's profile (tapped from a message avatar).


### PR DESCRIPTION
## Problem

In a space channel, a space owner with no assigned role still saw the **Pin** and **Delete** buttons on other people's messages. Those actions are validated on receipt (a recipient drops a pin/delete unless the sender holds a role granting it, or is the message author), so the buttons were inert: tapping them did nothing for other clients. This also diverged from desktop, which already hides them.

## Fix

Compute `hasPinPermission` / `hasDeletePermission` from roles only, dropping the `|| isSpaceOwner` shortcut. Owners can still delete their **own** messages (via the author check), and `isSpaceOwner` still drives genuinely owner-only UI (invite button, settings entry).

The receive-side enforcement that makes this safe already shipped (PR #76): both the live and batch message paths re-validate incoming deletes against the sender's role with no owner bypass. This PR just stops showing buttons whose action would be rejected.

## Testing

- `tsc` clean on the edited file.
- On-device: confirmed an owner with no role saw the buttons before this change. Recommend re-checking after: owner-with-no-role should no longer see Pin/Delete on others' messages; an owner or user **with** a pin/delete role still does; self-delete still works for everyone.