### PR TITLE
feat: sync primaryUsername across devices

### DIFF
--- a/context/AuthContext.tsx
+++ b/context/AuthContext.tsx
@@ -311,11 +311,12 @@ export function AuthProvider({ children }: AuthProviderProps) {
             // Config sync runs in parallel with encryption setup.
             //
             // This is the config -> user read-back bridge. Synced config fields
-            // (name, profile_image, bio, isProfilePublic) arrive from the server
-            // but only name/profile_image were previously copied into `user`, so
-            // a value set on another device (e.g. the public-profile toggle)
-            // never reached this device's `user` and showed stale. We now also
-            // bridge bio + isProfilePublic.
+            // (name, profile_image, bio, isProfilePublic, primaryUsername) arrive
+            // from the server but only name/profile_image were previously copied
+            // into `user`, so a value set on another device (e.g. the
+            // public-profile toggle or the primary QNS username) never reached
+            // this device's `user` and showed stale. We now also bridge
+            // bio + isProfilePublic + primaryUsername.
             //
             // Precedence: config sync is last-write-wins by server timestamp
             // (saveConfig stamps config.timestamp = Date.now()). Only let the
@@ -358,6 +359,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
                     ...(configIsNewer && {
                       bio: config.bio ?? base.bio,
                       isProfilePublic: guardPublic,
+                      primaryUsername: config.primaryUsername ?? base.primaryUsername,
                     }),
                   };
                 });
@@ -374,6 +376,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
                       neverStamped && cur.isProfilePublic === false && remotePublic
                         ? false
                         : remotePublic,
+                    primaryUsername: config.primaryUsername ?? cur.primaryUsername,
                   }),
                 };
                 mmkvStorage.setItem(STORAGE_KEYS.USER, JSON.stringify(merged));
@@ -491,7 +494,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
         try {
           const config = await getConfig(prev.address);
           if (config.allowSync) {
-            const configUpdates: { name?: string; profile_image?: string; bio?: string; isProfilePublic?: boolean } = {};
+            const configUpdates: { name?: string; profile_image?: string; bio?: string; isProfilePublic?: boolean; primaryUsername?: string } = {};
             if (updates.displayName !== undefined) {
               configUpdates.name = updates.displayName;
             }
@@ -503,6 +506,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
             }
             if (updates.isProfilePublic !== undefined) {
               configUpdates.isProfilePublic = updates.isProfilePublic;
+            }
+            if (updates.primaryUsername !== undefined) {
+              configUpdates.primaryUsername = updates.primaryUsername;
             }
 
             if (Object.keys(configUpdates).length > 0) {


### PR DESCRIPTION
## What

Mobile wrote synced config fields outbound but never read `primaryUsername` back into the in-memory `user`. On a fresh login on a second device, the QNS primary username was decrypted and stored locally but dropped before reaching `user` — so it showed empty/stale, and the published public profile could go out without `primary_username` (the value other users' apps read to display `name.q`).

## Change

`primaryUsername` now rides the exact same machinery `bio`/`isProfilePublic` already use (shipped in #81):

- **Outbound** (`updateProfile`): copied into `configUpdates` so `saveConfig` syncs it.
- **Read-back** (`configTask` bridge): overlaid back onto `user` (both in-memory `setUser` and the MMKV persist), gated on the existing `configIsNewer` last-write-wins check.

No new design decisions — precedence/guard semantics are inherited from the existing bridge.

## Why now

Unblocked by `@quilibrium/quorum-shared@2.1.0-31`, which added `primaryUsername` to `UserConfig`.

## Verification

- Additive, pure-JS change (no native, no wire/type change of our own — the field already exists in `-31`).
- `tsc` clean (no new errors in `AuthContext.tsx` vs. the pre-existing master baseline).
- Mirrors #81's already-runtime-tested bridge exactly. Cross-device runtime proof deferred (needs an account with a QNS name on two devices).