### PR TITLE
feat: sync profile changes to DM partners (dm-update-profile)

### DIFF
--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -302,7 +302,7 @@ export default function ProfileModal({
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
-  const { enqueueOutbound } = useWebSocket();
+  const { enqueueOutbound, subscribe } = useWebSocket();
   const { showToast } = useToast();
   const { allowSync, setAllowSync, isLoading: isSyncLoading } = useSyncSettings();
   const queryClient = useQueryClient();
@@ -911,6 +911,16 @@ export default function ProfileModal({
         });
       }
 
+      // Broadcast the avatar change to all DM partners (identity sync over
+      // established DM sessions). Avatar-only: send userIcon, not displayName.
+      // Fire-and-forget — the service dedupes per partner and never throws.
+      void import('@/services/dm/dmProfileService').then(({ broadcastProfileToAllDMs }) =>
+        broadcastProfileToAllDMs(
+          { selfAddress: user.address, userIcon: profileImage },
+          { enqueueOutbound, subscribe },
+        ),
+      );
+
       // Mirror to the public-profile endpoint when the user is public.
       // Re-derive the Farcaster link each publish so the by-fid index
       // stays current — cheap (in-memory crypto over a 32-byte key) and
@@ -999,6 +1009,21 @@ export default function ProfileModal({
           return envelopes;
         });
       }
+
+      // Broadcast the name/bio change to all DM partners. Match the space
+      // loop's field convention: displayName always (this handler owns it),
+      // bio gated on the public-profile toggle. Fire-and-forget + per-partner
+      // dedup inside the service.
+      void import('@/services/dm/dmProfileService').then(({ broadcastProfileToAllDMs }) =>
+        broadcastProfileToAllDMs(
+          {
+            selfAddress: user.address,
+            displayName: newDisplayName || undefined,
+            bio: user.isProfilePublic ? newBio : undefined,
+          },
+          { enqueueOutbound, subscribe },
+        ),
+      );
 
       // If the user's profile is public, also re-publish to the public
       // endpoint so non-space-members who look us up see the latest.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -469,6 +469,53 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     }, CONVERSATION_REFRESH_DEBOUNCE_MS);
   }, [queryClient]);
 
+  // Receive side of DM profile sync. A `dm-update-profile` control message
+  // carries a partner's GLOBAL profile change (displayName / userIcon / bio)
+  // over the established DM session. It must NOT be persisted/rendered as a
+  // chat post — it updates the conversation row in place. Shared by both DM
+  // decrypt paths (handleIncomingMessage + applyDMGroupResults) so the two
+  // intercepts can't drift. Returns true when it handled the message (caller
+  // should stop processing it), false otherwise.
+  const applyDmProfileUpdate = useCallback(
+    async (decryptedMessage: Message, senderAddress: string): Promise<boolean> => {
+      const content = decryptedMessage.content as
+        | { type?: string; senderId?: string; displayName?: string; userIcon?: string; bio?: string }
+        | undefined;
+      if (content?.type !== 'dm-update-profile') return false;
+
+      // Anti-spoof: the claimed senderId must match the cryptographically
+      // authenticated envelope sender. On mismatch we still consume the
+      // message (return true → never persisted as a post), just don't apply it.
+      // Mirrors desktop's "return true even on mismatch".
+      if (content.senderId && content.senderId !== senderAddress) {
+        logger.warn('[DMProfile] dropped dm-update-profile with mismatched senderId', {
+          claimed: content.senderId?.slice(0, 8),
+          envelope: senderAddress.slice(0, 8),
+        });
+        return true;
+      }
+
+      // No DM row means no established conversation to update — drop silently.
+      const conversationId = `${senderAddress}/${senderAddress}`;
+      const existing = await storage.getConversation(conversationId);
+      if (!existing) return true;
+
+      // Merge: displayName/userIcon truthy-guarded (empty = leave), bio
+      // `!== undefined` (empty string = deliberate clear). Same convention as
+      // the space update-profile handler and desktop's handleDMProfileUpdate.
+      const merged: Conversation = {
+        ...existing,
+        ...(content.displayName ? { displayName: content.displayName } : {}),
+        ...(content.userIcon ? { icon: content.userIcon } : {}),
+        ...(content.bio !== undefined ? { bio: content.bio } : {}),
+      };
+      await storage.saveConversation(merged);
+      scheduleConversationRefresh(conversationId);
+      return true;
+    },
+    [storage, scheduleConversationRefresh],
+  );
+
   /**
    * Initialize device keys and set them in the encryption service
    */
@@ -2483,6 +2530,17 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // Extract sender address from conversation ID (may have been updated for self-sync)
         const senderAddress = conversationId.split('/')[0];
 
+        // Intercept dm-update-profile control messages — update the partner's
+        // conversation row in place, never persist as a chat post. Handles both
+        // parse branches above (new-session + subsequent-message) since both
+        // converge here. Best-effort: delete from server so it doesn't replay.
+        if (await applyDmProfileUpdate(decryptedMessage, senderAddress)) {
+          getDeviceKeyset().then(dk => {
+            if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+          });
+          return;
+        }
+
         // Save conversation to storage (creates new or updates existing)
         const existingConversation = await storage.getConversation(conversationId);
         // Get sender display name for preview
@@ -2622,7 +2680,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // Message processing failed — isolate so other messages continue processing
       }
     },
-    [queryClient, storage]
+    [queryClient, storage, applyDmProfileUpdate]
   );
 
   /**
@@ -3468,6 +3526,20 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           conversationId = `${actualRecipient}/${actualRecipient}`;
         }
 
+        // Intercept dm-update-profile control messages — same as the JS path.
+        // Update the partner's conversation row in place, never persist as a
+        // post. senderAddress here is the (post-self-sync) conversation owner.
+        const batchProfileSender = conversationId.split('/')[0];
+        if (await applyDmProfileUpdate(decryptedMessage, batchProfileSender)) {
+          const originalMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalMsg) {
+            getDeviceKeyset().then(dk => {
+              if (dk) deleteInboxMessages(originalMsg.inboxAddress, [originalMsg.timestamp], dk).catch(() => {});
+            });
+          }
+          continue;
+        }
+
         const resolvedSenderAddress = conversationId.split('/')[0];
 
         // Save conversation
@@ -3658,7 +3730,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         logger.debug(`[DM-fallback ${meFb}] handleIncomingMessage threw`, err);
       }
     }
-  }, [queryClient, storage, handleIncomingMessage]);
+  }, [queryClient, storage, handleIncomingMessage, applyDmProfileUpdate]);
 
   /**
    * Process message queue with throttling to prevent CPU overload
@@ -4291,7 +4363,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // running this on every connect is cheap and safe.
         runProfileBroadcastMigrations();
         const spaces = getAllSpaces();
-        if (spaces.length === 0) return;
         for (const space of spaces) {
           try {
             const res = await maybeSendUpdateProfileMessage({
@@ -4313,6 +4384,26 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // Per-space failure is non-fatal — others still get the broadcast.
           }
         }
+
+        // Rebroadcast identity to all DM partners too (a user may have DM
+        // partners but no spaces, which is why this runs unconditionally —
+        // the early "no spaces" return was removed above). The DM service
+        // has its own per-partner signature gate, so reconnects with
+        // unchanged identity are no-ops on the wire. Name/icon only — bio is
+        // gated to the public-profile path, matching the space rebroadcast.
+        try {
+          const { broadcastProfileToAllDMs } = await import('../services/dm/dmProfileService');
+          await broadcastProfileToAllDMs(
+            {
+              selfAddress: user.address,
+              displayName: displayName || undefined,
+              userIcon: userIcon || undefined,
+            },
+            { enqueueOutbound, subscribe },
+          );
+        } catch {
+          // DM rebroadcast best-effort; never affects the space rebroadcast.
+        }
       } catch {
         // Module imports / spaces lookup failed; clear the fingerprint
         // so the next dep change retries instead of treating this
@@ -4331,6 +4422,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     user?.farcaster?.fid,
     user?.farcaster?.username,
     enqueueOutbound,
+    subscribe,
   ]);
 
   const value = useMemo<WebSocketContextValue>(

--- a/services/dm/dmProfileService.ts
+++ b/services/dm/dmProfileService.ts
@@ -1,0 +1,227 @@
+/*
+ * DM profile broadcast — identity sync over established DM sessions.
+ *
+ * When the user changes their GLOBAL profile (displayName / userIcon / bio),
+ * desktop sends a `dm-update-profile` control message over each existing
+ * Double-Ratchet DM session so partners' conversation rows stay current. This
+ * is mobile's port of that send path (desktop: MessageService.broadcastProfileToAllDMs).
+ *
+ * Mirrors three existing mobile patterns:
+ *  - the control-message envelope shape from services/calling/call-signaling.ts
+ *    (unsigned synthetic-messageId control message; the envelope sender is the
+ *    cryptographic authentication, not a per-message signature),
+ *  - the device-target assembly + sendEncryptedMessageToAllDevices call from
+ *    CallContext.sendSignal,
+ *  - the MMKV dedup gate from services/space/spaceMessageService.ts so the
+ *    on-connect rebroadcast doesn't re-send unchanged identity to every DM
+ *    partner on every reconnect (each send is a real wire message + push).
+ *
+ * Field semantics (match desktop + mobile's space update-profile handler):
+ *  - displayName / userIcon: truthy guard — empty/omitted = "leave unchanged".
+ *  - bio: `!== undefined` — empty string `''` = deliberate clear, omitted = unchanged.
+ */
+
+import type { DMUpdateProfileMessage, Message } from '@quilibrium/quorum-shared';
+import { createMMKV, type MMKV } from 'react-native-mmkv';
+import { getMMKVAdapter } from '../storage/mmkvAdapter';
+import { getDeviceKeyset } from '../onboarding/secureStorage';
+
+export interface DMProfilePayload {
+  selfAddress: string;
+  displayName?: string;
+  userIcon?: string;
+  bio?: string;
+}
+
+export interface DMBroadcastDeps {
+  enqueueOutbound: (prepareMessage: () => Promise<string[]>) => void;
+  subscribe: (inboxAddresses: string[]) => Promise<void>;
+}
+
+function generateNonce(): string {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+    const r = (Math.random() * 16) | 0;
+    const v = c === 'x' ? r : (r & 0x3) | 0x8;
+    return v.toString(16);
+  });
+}
+
+/**
+ * Build the unsigned `dm-update-profile` control Message for one partner.
+ * Same envelope shape as a call-signal (synthetic messageId, channelId/spaceId
+ * = recipient, no signature/publicKey — control messages are never persisted).
+ */
+function buildDmProfileMessage(
+  payload: DMProfilePayload,
+  recipientAddress: string,
+): Message {
+  const nonce = generateNonce();
+  const now = Date.now();
+
+  const content: DMUpdateProfileMessage = {
+    senderId: payload.selfAddress,
+    type: 'dm-update-profile',
+    ...(payload.displayName ? { displayName: payload.displayName } : {}),
+    ...(payload.userIcon ? { userIcon: payload.userIcon } : {}),
+    ...(payload.bio !== undefined ? { bio: payload.bio } : {}),
+  };
+
+  return {
+    messageId: `dm-profile-${nonce}`,
+    channelId: recipientAddress,
+    spaceId: recipientAddress,
+    digestAlgorithm: 'SHA-256',
+    nonce,
+    createdDate: now,
+    modifiedDate: now,
+    lastModifiedHash: '',
+    // The DMUpdateProfileMessage control type is intentionally NOT part of the
+    // MessageContent union (it's never persisted/rendered), so cast through.
+    content: content as unknown as Message['content'],
+    reactions: [],
+    mentions: { memberIds: [], roleIds: [], channelIds: [] },
+  };
+}
+
+// ── Dedup gate ──────────────────────────────────────────────────────────────
+// The on-connect rebroadcast fires on every reconnect/remount, and the save
+// handlers fire on every tap-save. Without a gate, a partner gets the same
+// identity re-sent (= a real DM + push) on every reconnect. Skip a send whose
+// payload matches the last one recorded for that (self, partner). Recorded only
+// after a successful enqueue so a failure leaves the gate open for retry.
+
+let dmProfileBroadcastStore: MMKV | null = null;
+function getStore(): MMKV {
+  if (!dmProfileBroadcastStore) {
+    dmProfileBroadcastStore = createMMKV({ id: 'quorum-dm-profile-broadcast' });
+  }
+  return dmProfileBroadcastStore;
+}
+
+function gateKey(selfAddress: string, partnerAddress: string): string {
+  return `${selfAddress}:${partnerAddress}`;
+}
+
+// Canonical signature of the exact wire payload. Field presence matters
+// (avatar-only vs name-only have different signatures), and values matter.
+function payloadSignature(p: DMProfilePayload): string {
+  const obj: Record<string, string> = {};
+  if (p.displayName) obj.displayName = p.displayName;
+  if (p.userIcon) obj.userIcon = p.userIcon;
+  if (p.bio !== undefined) obj.bio = p.bio;
+  const sortedKeys = Object.keys(obj).sort();
+  return JSON.stringify(obj, sortedKeys);
+}
+
+/** Clear the gate for one partner (or all of self's partners) so a fresh
+ *  session re-broadcasts. Currently unused but mirrors the space service. */
+export function clearDmProfileBroadcastState(selfAddress: string, partnerAddress?: string): void {
+  const store = getStore();
+  if (partnerAddress) {
+    store.remove(gateKey(selfAddress, partnerAddress));
+    return;
+  }
+  const prefix = `${selfAddress}:`;
+  for (const k of store.getAllKeys()) {
+    if (k.startsWith(prefix)) store.remove(k);
+  }
+}
+
+// ── Send ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Broadcast a global profile change to every direct-DM partner with whom we
+ * have (or can establish) an encryption session.
+ *
+ * Fire-and-forget: never throws, never blocks the caller's UI. Per-partner
+ * failures (no session, registration fetch failure) are swallowed so one bad
+ * partner can't block the rest — exactly like the space broadcast loop.
+ */
+export async function broadcastProfileToAllDMs(
+  payload: DMProfilePayload,
+  deps: DMBroadcastDeps,
+): Promise<void> {
+  const sig = payloadSignature(payload);
+  // Empty payload would no-op on every receiver — nothing to send.
+  if (sig === '{}') return;
+
+  let deviceKeyset: Awaited<ReturnType<typeof getDeviceKeyset>>;
+  try {
+    deviceKeyset = await getDeviceKeyset();
+  } catch {
+    return;
+  }
+  if (!deviceKeyset) return;
+
+  const adapter = getMMKVAdapter();
+
+  // Read ALL direct conversations in one pass. getConversations slices to
+  // `limit` (default 50) from an in-memory array, so a single large limit
+  // returns everything with nextCursor === null. We deliberately avoid the
+  // cursor-paging loop: the adapter's cursor uses `timestamp <= cursor`, which
+  // re-starts at the same index when two conversations share a timestamp
+  // (import/sync can produce that), so paging could revisit rows. One big read
+  // sidesteps that entirely.
+  const { conversations: partners } = await adapter.getConversations({
+    type: 'direct',
+    limit: 100000,
+  });
+
+  const store = getStore();
+  const { sendEncryptedMessageToAllDevices } = await import('@/hooks/chat/useSendDirectMessage');
+  const { toAllDeviceInfos } = await import('@/hooks/chat/useRecipientRegistration');
+  const { getQuorumClient } = await import('@/services/api/quorumClient');
+  const apiClient = getQuorumClient();
+
+  for (const conv of partners) {
+    const partnerAddress = conv.address;
+    // Skip rows we can't DM: missing address, ourselves, or Farcaster threads
+    // (not E2EE DM sessions — an encrypted control message is meaningless there).
+    if (!partnerAddress || partnerAddress === payload.selfAddress) continue;
+    if (conv.source === 'farcaster') continue;
+
+    // Dedup: already sent this exact identity to this partner.
+    if (store.getString(gateKey(payload.selfAddress, partnerAddress)) === sig) continue;
+
+    try {
+      let allTargetDevices: {
+        identityKey: number[];
+        signedPreKey: number[];
+        inboxAddress: string;
+        inboxEncryptionKey: number[];
+      }[] = [];
+      try {
+        const reg = await apiClient.fetchUserRegistration(partnerAddress);
+        if (reg) allTargetDevices = toAllDeviceInfos(reg);
+      } catch {
+        // Registration fetch failed — nothing to send this partner this round.
+      }
+      if (allTargetDevices.length === 0) continue;
+
+      const conversationId = `${partnerAddress}/${partnerAddress}`;
+      const message = buildDmProfileMessage(payload, partnerAddress);
+
+      await sendEncryptedMessageToAllDevices(
+        conversationId,
+        partnerAddress,
+        message,
+        allTargetDevices,
+        deps.enqueueOutbound,
+        deps.subscribe,
+        {
+          identityPublicKey: deviceKeyset.identityPublicKey,
+          inboxAddress: deviceKeyset.inboxAddress,
+          inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+        },
+        payload.selfAddress,
+        payload.displayName,
+      );
+
+      // Record only after a successful enqueue so a throw retries next round.
+      store.set(gateKey(payload.selfAddress, partnerAddress), sig);
+    } catch {
+      // Per-partner failure (no session, encrypt error) is non-fatal — the
+      // gate stays open for this partner so the next broadcast retries.
+    }
+  }
+}


### PR DESCRIPTION
## What

When a user changes their global profile (display name, avatar, bio), mobile now mirrors desktop: it propagates the change to every existing DM partner over the encrypted session, so the partner's conversation row (name / avatar / bio) stays current instead of going stale. Ports desktop's `broadcastProfileToAllDMs` / `handleDMProfileUpdate`.

## Receive

A shared `applyDmProfileUpdate` helper intercepts `dm-update-profile` in **both** DM decrypt paths (the JS path in `handleIncomingMessage` and the native batch path in `applyDMGroupResults`), before any `saveMessage`, so the control message is **never persisted/rendered as a chat post** (the previous behaviour was a garbage JSON post bubble).

- Anti-spoof: the claimed `senderId` must equal the authenticated envelope sender; on mismatch the message is consumed but not applied.
- Merge convention matches the existing space `update-profile` handler: `displayName`/`userIcon` truthy-guarded, `bio` `!== undefined` (empty string = deliberate clear).
- No DM row → dropped silently.

## Send

New `services/dm/dmProfileService.ts` `broadcastProfileToAllDMs` — fire-and-forget, per-partner `try/catch`, with an MMKV dedup gate (mirrors `spaceMessageService`) so reconnect rebroadcasts don't re-spam unchanged identity. Skips self + Farcaster threads. Wired into both `ProfileModal` save handlers (avatar + name/bio) and the on-connect rebroadcast (which now also runs for users with DM partners but no spaces).

## Why now

Unblocked by `@quilibrium/quorum-shared@2.1.0-31` (`DMUpdateProfileMessage` + `Conversation.bio` confirmed in the installed dist).

## Verification

- `tsc` introduces **no new errors** vs. the pre-existing master baseline (confirmed by stash-diff; the 2 remaining `WebSocketContext` errors exist on master).
- New service file is eslint-clean.
- Mirrors desktop's working feature **and** mobile's own working space `update-profile` handler / call-signaling control-message path / DM send primitive.
- Passed an adversarial static review: one pagination bug (equal-timestamp cursor revisit) found and fixed (now reads all direct conversations in one pass); receive-side dep-array completeness fixed.
- **Runtime e2e not verified** — blocked by the documented DM crypto issues (Symptom B desktop→mobile `decrypt_failed`; `@noble` v2 mismatch), both lead-dev territory. Receive side is inert until a `dm-update-profile` actually arrives; send side mirrors existing working DM sends.