### PR TITLE
feat: converge profile validation to shared byte validators + honor display-name clear

### DIFF
--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -20,11 +20,12 @@ import {
   validateDisplayName,
   validateUserBio,
   MAX_BIO_BYTES,
-  MAX_DISPLAY_NAME_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
+  displayNameLiveError,
+  bioLiveError,
 } from '@/hooks/validation/errorTranslator';
 
 export default function ProfileSetupScreen() {
@@ -172,12 +173,14 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={styles.textInput}
                 value={displayName}
-                onChangeText={(t) => { setDisplayName(t); if (nameError) setNameError(undefined); }}
+                onChangeText={(t) => { setDisplayName(t); setNameError(displayNameLiveError(t)); }}
                 placeholder="Your name"
                 placeholderTextColor={theme.colors.textMuted}
-                // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on
-                // save catches multi-byte overflow the char cap can't.
-                maxLength={MAX_DISPLAY_NAME_BYTES}
+                // No tight maxLength — the byte validator is the gate and shows
+                // a live error; a 32-CHAR cap would silently swallow text before
+                // the "too long" (32 BYTES) error could appear. Loose ceiling
+                // just blocks a pathological mega-paste.
+                maxLength={200}
                 aria-label="Display name"
                 aria-invalid={!!nameError}
               />
@@ -191,7 +194,7 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={[styles.textInput, styles.bioInput]}
                 value={bio}
-                onChangeText={(t) => { setBio(t); if (bioError) setBioError(undefined); }}
+                onChangeText={(t) => { setBio(t); setBioError(bioLiveError(t)); }}
                 placeholder="Tell us about yourself..."
                 placeholderTextColor={theme.colors.textMuted}
                 multiline

--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -19,13 +19,14 @@ import * as Skin from '@/theme/skins/geometry';
 import {
   validateDisplayName,
   validateUserBio,
-  MAX_BIO_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
   displayNameLiveError,
   bioLiveError,
+  capDisplayName,
+  capBio,
 } from '@/hooks/validation/errorTranslator';
 
 export default function ProfileSetupScreen() {
@@ -173,14 +174,12 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={styles.textInput}
                 value={displayName}
-                onChangeText={(t) => { setDisplayName(t); setNameError(displayNameLiveError(t)); }}
+                onChangeText={(t) => { const v = capDisplayName(t); setDisplayName(v); setNameError(displayNameLiveError(v)); }}
                 placeholder="Your name"
                 placeholderTextColor={theme.colors.textMuted}
-                // No tight maxLength — the byte validator is the gate and shows
-                // a live error; a 32-CHAR cap would silently swallow text before
-                // the "too long" (32 BYTES) error could appear. Loose ceiling
-                // just blocks a pathological mega-paste.
-                maxLength={200}
+                // Hard-capped to MAX_DISPLAY_NAME_BYTES by bytes (capDisplayName).
+                // No maxLength (counts chars, not bytes). The live error surfaces
+                // only the non-length rules (.q / impersonation / XSS / reserved).
                 aria-label="Display name"
                 aria-invalid={!!nameError}
               />
@@ -194,12 +193,11 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={[styles.textInput, styles.bioInput]}
                 value={bio}
-                onChangeText={(t) => { setBio(t); setBioError(bioLiveError(t)); }}
+                onChangeText={(t) => { const v = capBio(t); setBio(v); setBioError(bioLiveError(v)); }}
                 placeholder="Tell us about yourself..."
                 placeholderTextColor={theme.colors.textMuted}
                 multiline
                 numberOfLines={3}
-                maxLength={MAX_BIO_BYTES}
                 textAlignVertical="top"
                 aria-label="Bio"
                 aria-invalid={!!bioError}
@@ -216,6 +214,7 @@ export default function ProfileSetupScreen() {
           onNext={handleContinue}
           onSkip={handleSkip}
           nextLabel={hasAnyInput ? 'Continue' : 'Skip'}
+          nextDisabled={!!nameError || !!bioError}
           showSkip={!!hasAnyInput}
           skipLabel="Skip for now"
           isLoading={state.isLoading}

--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -16,6 +16,16 @@ import { useOnboarding } from '@/context';
 import { OnboardingLayout, StepNavigation } from '@/components/onboarding';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import * as Skin from '@/theme/skins/geometry';
+import {
+  validateDisplayName,
+  validateUserBio,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
+} from '@quilibrium/quorum-shared';
+import {
+  translateValidationResult,
+  translateValidationResults,
+} from '@/hooks/validation/errorTranslator';
 
 export default function ProfileSetupScreen() {
   const { theme } = useTheme();
@@ -25,6 +35,8 @@ export default function ProfileSetupScreen() {
   const [displayName, setDisplayName] = useState(state.profile.displayName ?? '');
   const [bio, setBio] = useState(state.profile.bio ?? '');
   const [profileImage, setProfileImage] = useState<string | undefined>(state.profile.profileImageUri);
+  const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [bioError, setBioError] = useState<string | undefined>(undefined);
 
   // Sync from state.profile if it changes (e.g., from config sync during import)
   // Only update fields that are empty locally but have values in state
@@ -77,9 +89,21 @@ export default function ProfileSetupScreen() {
   };
 
   const handleContinue = () => {
+    const trimmedName = displayName.trim();
+    const trimmedBio = bio.trim();
+
+    // Validate only what the user actually entered — both fields are optional
+    // at onboarding (the screen is skippable). Shared byte validators match
+    // Farcaster's USER_DATA limits so a name/bio set here can be published later.
+    const nameMsg = trimmedName ? translateValidationResult(validateDisplayName(trimmedName)) : undefined;
+    const bioMsg = trimmedBio ? translateValidationResults(validateUserBio(trimmedBio))[0] : undefined;
+    setNameError(nameMsg);
+    setBioError(bioMsg);
+    if (nameMsg || bioMsg) return;
+
     updateProfile({
-      displayName: displayName.trim() || undefined,
-      bio: bio.trim() || undefined,
+      displayName: trimmedName || undefined,
+      bio: trimmedBio || undefined,
       profileImageUri: profileImage,
     });
     skipProfile(); // This advances to next step
@@ -148,11 +172,18 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={styles.textInput}
                 value={displayName}
-                onChangeText={setDisplayName}
+                onChangeText={(t) => { setDisplayName(t); if (nameError) setNameError(undefined); }}
                 placeholder="Your name"
                 placeholderTextColor={theme.colors.textMuted}
-                maxLength={50}
+                // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on
+                // save catches multi-byte overflow the char cap can't.
+                maxLength={MAX_DISPLAY_NAME_BYTES}
+                aria-label="Display name"
+                aria-invalid={!!nameError}
               />
+              {nameError ? (
+                <Text style={styles.fieldError} role="alert">{nameError}</Text>
+              ) : null}
             </View>
 
             <View style={styles.inputGroup}>
@@ -160,15 +191,19 @@ export default function ProfileSetupScreen() {
               <TextInput
                 style={[styles.textInput, styles.bioInput]}
                 value={bio}
-                onChangeText={setBio}
+                onChangeText={(t) => { setBio(t); if (bioError) setBioError(undefined); }}
                 placeholder="Tell us about yourself..."
                 placeholderTextColor={theme.colors.textMuted}
                 multiline
                 numberOfLines={3}
-                maxLength={160}
+                maxLength={MAX_BIO_BYTES}
                 textAlignVertical="top"
+                aria-label="Bio"
+                aria-invalid={!!bioError}
               />
-              <Text style={styles.charCount}>{bio.length}/160</Text>
+              {bioError ? (
+                <Text style={styles.fieldError} role="alert">{bioError}</Text>
+              ) : null}
             </View>
           </View>
         </ScrollView>
@@ -288,10 +323,10 @@ const createStyles = (theme: AppTheme) =>
       minHeight: 80,
       textAlignVertical: 'top',
     },
-    charCount: {
+    fieldError: {
       fontSize: Skin.font(12),
-      color: theme.colors.textMuted,
+      color: theme.colors.danger,
       fontFamily: theme.fonts.regular.fontFamily,
-      textAlign: 'right',
+      marginTop: Skin.space(1),
     },
   });

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -92,6 +92,16 @@ import { ActivityIndicator, Alert, Dimensions, Image, ScrollView, StyleSheet, Sw
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { logger } from '@quilibrium/quorum-shared';
+import {
+  validateDisplayName,
+  validateUserBio,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
+} from '@quilibrium/quorum-shared';
+import {
+  translateValidationResult,
+  translateValidationResults,
+} from '@/hooks/validation/errorTranslator';
 import * as Skin from '@/theme/skins/geometry';
 interface ProfileModalProps {
   visible: boolean;
@@ -379,6 +389,8 @@ export default function ProfileModal({
   const [isEditing, setIsEditing] = React.useState(false);
   const [editDisplayName, setEditDisplayName] = React.useState(user?.displayName || '');
   const [editBio, setEditBio] = React.useState(user?.bio || '');
+  const [nameError, setNameError] = React.useState<string | undefined>(undefined);
+  const [bioError, setBioError] = React.useState<string | undefined>(undefined);
   const [isSaving, setIsSaving] = React.useState(false);
 
   // Recovery phrase / private key display
@@ -965,10 +977,20 @@ export default function ProfileModal({
   const handleSaveProfile = async () => {
     if (!user?.address) return;
 
+    const newDisplayName = editDisplayName.trim() || '';
+    const newBio = editBio.trim() || '';
+
+    // Validate against shared byte limits before saving/broadcasting. Both
+    // fields are optional (empty = clear / use QNS), so only validate
+    // non-empty values.
+    const nameMsg = newDisplayName ? translateValidationResult(validateDisplayName(newDisplayName)) : undefined;
+    const bioMsg = newBio ? translateValidationResults(validateUserBio(newBio))[0] : undefined;
+    setNameError(nameMsg);
+    setBioError(bioMsg);
+    if (nameMsg || bioMsg) return;
+
     setIsSaving(true);
     try {
-      const newDisplayName = editDisplayName.trim() || '';
-      const newBio = editBio.trim() || '';
 
       // Update local profile
       updateProfile({
@@ -1579,11 +1601,13 @@ export default function ProfileModal({
             isEditing={isEditing}
             editDisplayName={editDisplayName}
             editBio={editBio}
-            onChangeDisplayName={setEditDisplayName}
-            onChangeBio={setEditBio}
+            onChangeDisplayName={(t) => { setEditDisplayName(t); if (nameError) setNameError(undefined); }}
+            onChangeBio={(t) => { setEditBio(t); if (bioError) setBioError(undefined); }}
             onPickImage={handlePickImage}
             onCopyAddress={handleCopyAddress}
             isApexActive={apexState.isActive}
+            nameError={nameError}
+            bioError={bioError}
           />
         )}
 
@@ -2734,6 +2758,12 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       borderBottomColor: theme.colors.primary,
       paddingVertical: Skin.space(4),
     },
+    fieldError: {
+      fontSize: Skin.font(12),
+      color: theme.colors.danger,
+      marginTop: Skin.space(2),
+      marginBottom: Skin.space(4),
+    },
     username: {
       fontSize: Skin.font(14),
       color: theme.colors.primary,
@@ -3621,6 +3651,8 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
   onPickImage,
   onCopyAddress,
   isApexActive,
+  nameError,
+  bioError,
 }: {
   styles: ProfileStyles;
   theme: AppTheme;
@@ -3635,6 +3667,9 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
   onCopyAddress: () => void;
   /** Gold Apex ring around the user's own avatar. */
   isApexActive: boolean;
+  /** Inline validation errors (shared byte validators), shown under each field. */
+  nameError?: string;
+  bioError?: string;
 }) {
   return (
     <>
@@ -3657,14 +3692,24 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
           </TouchableOpacity>
           <View style={styles.profileInfo}>
             {isEditing ? (
-              <TextInput
-                style={styles.displayNameInput}
-                value={editDisplayName}
-                onChangeText={onChangeDisplayName}
-                placeholder="Display Name"
-                placeholderTextColor={theme.colors.textMuted}
-                autoCapitalize="words"
-              />
+              <>
+                <TextInput
+                  style={styles.displayNameInput}
+                  value={editDisplayName}
+                  onChangeText={onChangeDisplayName}
+                  placeholder="Display Name"
+                  placeholderTextColor={theme.colors.textMuted}
+                  autoCapitalize="words"
+                  // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator
+                  // on save catches multi-byte overflow a char cap can't.
+                  maxLength={MAX_DISPLAY_NAME_BYTES}
+                  aria-label="Display name"
+                  aria-invalid={!!nameError}
+                />
+                {nameError ? (
+                  <Text style={styles.fieldError} role="alert">{nameError}</Text>
+                ) : null}
+              </>
             ) : (
               <Text style={styles.displayName}>
                 {user?.displayName || 'Anonymous'}
@@ -3686,16 +3731,24 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Bio</Text>
         {isEditing ? (
-          <TextInput
-            style={styles.bioInput}
-            value={editBio}
-            onChangeText={onChangeBio}
-            placeholder="Tell us about yourself..."
-            placeholderTextColor={theme.colors.textMuted}
-            multiline
-            numberOfLines={4}
-            textAlignVertical="top"
-          />
+          <>
+            <TextInput
+              style={styles.bioInput}
+              value={editBio}
+              onChangeText={onChangeBio}
+              placeholder="Tell us about yourself..."
+              placeholderTextColor={theme.colors.textMuted}
+              multiline
+              numberOfLines={4}
+              textAlignVertical="top"
+              maxLength={MAX_BIO_BYTES}
+              aria-label="Bio"
+              aria-invalid={!!bioError}
+            />
+            {bioError ? (
+              <Text style={styles.fieldError} role="alert">{bioError}</Text>
+            ) : null}
+          </>
         ) : (
           <View style={styles.bioContainer}>
             <Text style={styles.bioText}>

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -96,11 +96,12 @@ import {
   validateDisplayName,
   validateUserBio,
   MAX_BIO_BYTES,
-  MAX_DISPLAY_NAME_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
+  displayNameLiveError,
+  bioLiveError,
 } from '@/hooks/validation/errorTranslator';
 import * as Skin from '@/theme/skins/geometry';
 interface ProfileModalProps {
@@ -1601,8 +1602,8 @@ export default function ProfileModal({
             isEditing={isEditing}
             editDisplayName={editDisplayName}
             editBio={editBio}
-            onChangeDisplayName={(t) => { setEditDisplayName(t); if (nameError) setNameError(undefined); }}
-            onChangeBio={(t) => { setEditBio(t); if (bioError) setBioError(undefined); }}
+            onChangeDisplayName={(t) => { setEditDisplayName(t); setNameError(displayNameLiveError(t)); }}
+            onChangeBio={(t) => { setEditBio(t); setBioError(bioLiveError(t)); }}
             onPickImage={handlePickImage}
             onCopyAddress={handleCopyAddress}
             isApexActive={apexState.isActive}
@@ -3700,9 +3701,11 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
                   placeholder="Display Name"
                   placeholderTextColor={theme.colors.textMuted}
                   autoCapitalize="words"
-                  // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator
-                  // on save catches multi-byte overflow a char cap can't.
-                  maxLength={MAX_DISPLAY_NAME_BYTES}
+                  // No tight maxLength — the byte validator is the gate (live
+                  // error); a 32-CHAR cap would silently swallow text before the
+                  // "too long" (32 BYTES) error could show. Loose ceiling only
+                  // blocks a pathological mega-paste.
+                  maxLength={200}
                   aria-label="Display name"
                   aria-invalid={!!nameError}
                 />

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -95,13 +95,14 @@ import { logger } from '@quilibrium/quorum-shared';
 import {
   validateDisplayName,
   validateUserBio,
-  MAX_BIO_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
   displayNameLiveError,
   bioLiveError,
+  capDisplayName,
+  capBio,
 } from '@/hooks/validation/errorTranslator';
 import * as Skin from '@/theme/skins/geometry';
 interface ProfileModalProps {
@@ -1558,7 +1559,11 @@ export default function ProfileModal({
               <TouchableOpacity onPress={handleCancelEdit} style={styles.cancelButton}>
                 <Text style={styles.cancelButtonText}>Cancel</Text>
               </TouchableOpacity>
-              <TouchableOpacity onPress={handleSaveProfile} style={styles.saveButton} disabled={isSaving}>
+              <TouchableOpacity
+                onPress={handleSaveProfile}
+                style={[styles.saveButton, (isSaving || !!nameError || !!bioError) && styles.saveButtonDisabled]}
+                disabled={isSaving || !!nameError || !!bioError}
+              >
                 {isSaving ? (
                   <ActivityIndicator size="small" color="#fff" />
                 ) : (
@@ -1602,8 +1607,8 @@ export default function ProfileModal({
             isEditing={isEditing}
             editDisplayName={editDisplayName}
             editBio={editBio}
-            onChangeDisplayName={(t) => { setEditDisplayName(t); setNameError(displayNameLiveError(t)); }}
-            onChangeBio={(t) => { setEditBio(t); setBioError(bioLiveError(t)); }}
+            onChangeDisplayName={(t) => { const v = capDisplayName(t); setEditDisplayName(v); setNameError(displayNameLiveError(v)); }}
+            onChangeBio={(t) => { const v = capBio(t); setEditBio(v); setBioError(bioLiveError(v)); }}
             onPickImage={handlePickImage}
             onCopyAddress={handleCopyAddress}
             isApexActive={apexState.isActive}
@@ -2672,6 +2677,9 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       minWidth: 60,
       alignItems: 'center',
     },
+    saveButtonDisabled: {
+      opacity: 0.5,
+    },
     saveButtonText: {
       fontSize: Skin.font(14),
       color: '#fff',
@@ -3701,11 +3709,8 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
                   placeholder="Display Name"
                   placeholderTextColor={theme.colors.textMuted}
                   autoCapitalize="words"
-                  // No tight maxLength — the byte validator is the gate (live
-                  // error); a 32-CHAR cap would silently swallow text before the
-                  // "too long" (32 BYTES) error could show. Loose ceiling only
-                  // blocks a pathological mega-paste.
-                  maxLength={200}
+                  // Hard-capped to MAX_DISPLAY_NAME_BYTES by bytes in the
+                  // onChange handler (capDisplayName). No maxLength (chars≠bytes).
                   aria-label="Display name"
                   aria-invalid={!!nameError}
                 />
@@ -3744,7 +3749,7 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
               multiline
               numberOfLines={4}
               textAlignVertical="top"
-              maxLength={MAX_BIO_BYTES}
+              // Hard-capped to MAX_BIO_BYTES by bytes in onChange (capBio).
               aria-label="Bio"
               aria-invalid={!!bioError}
             />

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -78,7 +78,11 @@ import { logger } from '@quilibrium/quorum-shared';
 import {
   validateSpaceName,
   validateSpaceDescription,
+  validateDisplayName,
+  validateUserBio,
   MAX_NAME_LENGTH,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
@@ -583,6 +587,8 @@ export default function SpaceSettingsModal({
   const [spaceProfileDisplayName, setSpaceProfileDisplayName] = useState<string>('');
   const [spaceProfileBio, setSpaceProfileBio] = useState<string>('');
   const [spaceProfileImage, setSpaceProfileImage] = useState<string>('');
+  const [spaceProfileNameError, setSpaceProfileNameError] = useState<string | undefined>(undefined);
+  const [spaceProfileBioError, setSpaceProfileBioError] = useState<string | undefined>(undefined);
   // Snapshot of the values that are currently on the SpaceMember
   // record — used to compute "did anything actually change" so we
   // only broadcast when the user pressed Save after editing
@@ -655,6 +661,18 @@ export default function SpaceSettingsModal({
 
   const handleSaveSpaceProfile = useCallback(async () => {
     if (!user?.address || !space || !spaceProfileDirty || spaceProfileSaving) return;
+
+    // Validate against shared byte limits before saving. The per-space display
+    // name is optional (empty = "use my global/QNS name here"), so only
+    // validate a non-empty value; bio likewise.
+    const trimmedName = spaceProfileDisplayName.trim();
+    const trimmedBio = spaceProfileBio.trim();
+    const nameMsg = trimmedName ? translateValidationResult(validateDisplayName(trimmedName)) : undefined;
+    const bioMsg = trimmedBio ? translateValidationResults(validateUserBio(trimmedBio))[0] : undefined;
+    setSpaceProfileNameError(nameMsg);
+    setSpaceProfileBioError(bioMsg);
+    if (nameMsg || bioMsg) return;
+
     setSpaceProfileSaving(true);
     try {
       // Optimistically update the local SpaceMember so the UI
@@ -1580,10 +1598,14 @@ export default function SpaceSettingsModal({
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Display name</Text>
       <TextInput
         value={spaceProfileDisplayName}
-        onChangeText={setSpaceProfileDisplayName}
+        onChangeText={(t) => { setSpaceProfileDisplayName(t); if (spaceProfileNameError) setSpaceProfileNameError(undefined); }}
         placeholder={user?.displayName || user?.username || 'Your name in this space'}
         placeholderTextColor={theme.colors.textMuted}
-        maxLength={64}
+        // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on save
+        // catches multi-byte overflow a char cap can't.
+        maxLength={MAX_DISPLAY_NAME_BYTES}
+        aria-label="Display name in this space"
+        aria-invalid={!!spaceProfileNameError}
         style={{
           backgroundColor: theme.colors.surface2,
           color: theme.colors.textMain,
@@ -1592,16 +1614,23 @@ export default function SpaceSettingsModal({
           fontSize: Skin.font(15),
         }}
       />
+      {spaceProfileNameError ? (
+        <Text style={{ color: theme.colors.danger, fontSize: Skin.font(12), marginTop: Skin.space(4) }} role="alert">
+          {spaceProfileNameError}
+        </Text>
+      ) : null}
 
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Bio</Text>
       <TextInput
         value={spaceProfileBio}
-        onChangeText={setSpaceProfileBio}
+        onChangeText={(t) => { setSpaceProfileBio(t); if (spaceProfileBioError) setSpaceProfileBioError(undefined); }}
         placeholder="Tell this space about yourself"
         placeholderTextColor={theme.colors.textMuted}
         multiline
         numberOfLines={3}
-        maxLength={280}
+        maxLength={MAX_BIO_BYTES}
+        aria-label="Bio in this space"
+        aria-invalid={!!spaceProfileBioError}
         style={{
           backgroundColor: theme.colors.surface2,
           color: theme.colors.textMain,
@@ -1612,6 +1641,11 @@ export default function SpaceSettingsModal({
           textAlignVertical: 'top',
         }}
       />
+      {spaceProfileBioError ? (
+        <Text style={{ color: theme.colors.danger, fontSize: Skin.font(12), marginTop: Skin.space(4) }} role="alert">
+          {spaceProfileBioError}
+        </Text>
+      ) : null}
 
       <TouchableOpacity
         onPress={handleSaveSpaceProfile}

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -82,11 +82,12 @@ import {
   validateUserBio,
   MAX_NAME_LENGTH,
   MAX_BIO_BYTES,
-  MAX_DISPLAY_NAME_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
+  displayNameLiveError,
+  bioLiveError,
 } from '@/hooks/validation/errorTranslator';
 import * as Skin from '@/theme/skins/geometry';
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -1598,12 +1599,13 @@ export default function SpaceSettingsModal({
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Display name</Text>
       <TextInput
         value={spaceProfileDisplayName}
-        onChangeText={(t) => { setSpaceProfileDisplayName(t); if (spaceProfileNameError) setSpaceProfileNameError(undefined); }}
+        onChangeText={(t) => { setSpaceProfileDisplayName(t); setSpaceProfileNameError(displayNameLiveError(t)); }}
         placeholder={user?.displayName || user?.username || 'Your name in this space'}
         placeholderTextColor={theme.colors.textMuted}
-        // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on save
-        // catches multi-byte overflow a char cap can't.
-        maxLength={MAX_DISPLAY_NAME_BYTES}
+        // No tight maxLength — the byte validator is the gate (shows a live
+        // error); a 32-CHAR cap would silently swallow text before the "too
+        // long" (32 BYTES) error could show. Loose ceiling blocks mega-pastes.
+        maxLength={200}
         aria-label="Display name in this space"
         aria-invalid={!!spaceProfileNameError}
         style={{
@@ -1623,7 +1625,7 @@ export default function SpaceSettingsModal({
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Bio</Text>
       <TextInput
         value={spaceProfileBio}
-        onChangeText={(t) => { setSpaceProfileBio(t); if (spaceProfileBioError) setSpaceProfileBioError(undefined); }}
+        onChangeText={(t) => { setSpaceProfileBio(t); setSpaceProfileBioError(bioLiveError(t)); }}
         placeholder="Tell this space about yourself"
         placeholderTextColor={theme.colors.textMuted}
         multiline

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -81,13 +81,14 @@ import {
   validateDisplayName,
   validateUserBio,
   MAX_NAME_LENGTH,
-  MAX_BIO_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
   displayNameLiveError,
   bioLiveError,
+  capDisplayName,
+  capBio,
 } from '@/hooks/validation/errorTranslator';
 import * as Skin from '@/theme/skins/geometry';
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
@@ -1599,13 +1600,11 @@ export default function SpaceSettingsModal({
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Display name</Text>
       <TextInput
         value={spaceProfileDisplayName}
-        onChangeText={(t) => { setSpaceProfileDisplayName(t); setSpaceProfileNameError(displayNameLiveError(t)); }}
+        onChangeText={(t) => { const v = capDisplayName(t); setSpaceProfileDisplayName(v); setSpaceProfileNameError(displayNameLiveError(v)); }}
         placeholder={user?.displayName || user?.username || 'Your name in this space'}
         placeholderTextColor={theme.colors.textMuted}
-        // No tight maxLength — the byte validator is the gate (shows a live
-        // error); a 32-CHAR cap would silently swallow text before the "too
-        // long" (32 BYTES) error could show. Loose ceiling blocks mega-pastes.
-        maxLength={200}
+        // Hard-capped to MAX_DISPLAY_NAME_BYTES by bytes (capDisplayName). No
+        // maxLength (counts chars, not bytes). Live error = non-length rules only.
         aria-label="Display name in this space"
         aria-invalid={!!spaceProfileNameError}
         style={{
@@ -1625,12 +1624,11 @@ export default function SpaceSettingsModal({
       <Text style={[styles.sectionDescription, { marginTop: Skin.space(16), marginBottom: Skin.space(4) }]}>Bio</Text>
       <TextInput
         value={spaceProfileBio}
-        onChangeText={(t) => { setSpaceProfileBio(t); setSpaceProfileBioError(bioLiveError(t)); }}
+        onChangeText={(t) => { const v = capBio(t); setSpaceProfileBio(v); setSpaceProfileBioError(bioLiveError(v)); }}
         placeholder="Tell this space about yourself"
         placeholderTextColor={theme.colors.textMuted}
         multiline
         numberOfLines={3}
-        maxLength={MAX_BIO_BYTES}
         aria-label="Bio in this space"
         aria-invalid={!!spaceProfileBioError}
         style={{
@@ -1651,15 +1649,19 @@ export default function SpaceSettingsModal({
 
       <TouchableOpacity
         onPress={handleSaveSpaceProfile}
-        disabled={!spaceProfileDirty || spaceProfileSaving}
+        disabled={!spaceProfileDirty || spaceProfileSaving || !!spaceProfileNameError || !!spaceProfileBioError}
         style={{
           marginTop: Skin.space(12),
           alignSelf: 'flex-start',
           paddingVertical: Skin.space(10),
           paddingHorizontal: Skin.space(20),
           borderRadius: Skin.radius(10),
-          backgroundColor: spaceProfileDirty && !spaceProfileSaving ? theme.colors.primary : theme.colors.surface3,
-          opacity: spaceProfileDirty && !spaceProfileSaving ? 1 : 0.6,
+          backgroundColor:
+            spaceProfileDirty && !spaceProfileSaving && !spaceProfileNameError && !spaceProfileBioError
+              ? theme.colors.primary
+              : theme.colors.surface3,
+          opacity:
+            spaceProfileDirty && !spaceProfileSaving && !spaceProfileNameError && !spaceProfileBioError ? 1 : 0.6,
         }}
       >
         {spaceProfileSaving ? (

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -17,11 +17,12 @@ import {
   validateDisplayName,
   validateUserBio,
   MAX_BIO_BYTES,
-  MAX_DISPLAY_NAME_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
+  displayNameLiveError,
+  bioLiveError,
 } from '@/hooks/validation/errorTranslator';
 
 export type EditScope = 'quorum' | 'farcaster' | 'both';
@@ -239,14 +240,16 @@ export default function UnifiedProfileEditModal({
           <Text style={styles.fieldLabel}>Display Name</Text>
           <TextInput
             value={displayName}
-            onChangeText={(t) => { setDisplayName(t); if (nameError) setNameError(undefined); }}
+            onChangeText={(t) => { setDisplayName(t); setNameError(displayNameLiveError(t)); }}
             placeholder="Your name"
             placeholderTextColor={theme.colors.textMuted}
             style={styles.input}
             autoCapitalize="words"
-            // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on save
-            // catches multi-byte overflow a char cap can't.
-            maxLength={MAX_DISPLAY_NAME_BYTES}
+            // No tight maxLength — the byte validator is the gate, and a 32-char
+            // cap would silently swallow text before the "too long" error could
+            // show (the limit is 32 BYTES, not chars). A loose ceiling just stops
+            // a pathological mega-paste. Matches desktop (validator-only).
+            maxLength={200}
             aria-label="Display name"
             aria-invalid={!!nameError}
           />
@@ -259,11 +262,13 @@ export default function UnifiedProfileEditModal({
           <Text style={styles.fieldLabel}>Bio</Text>
           <TextInput
             value={bio}
-            onChangeText={(t) => { setBio(t); if (bioError) setBioError(undefined); }}
+            onChangeText={(t) => { setBio(t); setBioError(bioLiveError(t)); }}
             placeholder="Tell people about yourself..."
             placeholderTextColor={theme.colors.textMuted}
             style={[styles.input, { height: 100, textAlignVertical: 'top' }]}
             multiline
+            // Coarse byte-count ceiling so a huge paste can't lag the field; the
+            // byte validator (live) is the real, user-visible gate.
             maxLength={MAX_BIO_BYTES}
             aria-label="Bio"
             aria-invalid={!!bioError}

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -16,13 +16,14 @@ import * as Skin from '@/theme/skins/geometry';
 import {
   validateDisplayName,
   validateUserBio,
-  MAX_BIO_BYTES,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
   translateValidationResults,
   displayNameLiveError,
   bioLiveError,
+  capDisplayName,
+  capBio,
 } from '@/hooks/validation/errorTranslator';
 
 export type EditScope = 'quorum' | 'farcaster' | 'both';
@@ -240,16 +241,15 @@ export default function UnifiedProfileEditModal({
           <Text style={styles.fieldLabel}>Display Name</Text>
           <TextInput
             value={displayName}
-            onChangeText={(t) => { setDisplayName(t); setNameError(displayNameLiveError(t)); }}
+            onChangeText={(t) => { const v = capDisplayName(t); setDisplayName(v); setNameError(displayNameLiveError(v)); }}
             placeholder="Your name"
             placeholderTextColor={theme.colors.textMuted}
             style={styles.input}
             autoCapitalize="words"
-            // No tight maxLength — the byte validator is the gate, and a 32-char
-            // cap would silently swallow text before the "too long" error could
-            // show (the limit is 32 BYTES, not chars). A loose ceiling just stops
-            // a pathological mega-paste. Matches desktop (validator-only).
-            maxLength={200}
+            // Hard-capped to MAX_DISPLAY_NAME_BYTES by bytes in onChangeText
+            // (capDisplayName) — kinder than making the user delete on mobile.
+            // No maxLength: it counts chars, not bytes. The live error only
+            // surfaces the non-length rules (.q / impersonation / XSS / reserved).
             aria-label="Display name"
             aria-invalid={!!nameError}
           />
@@ -262,14 +262,13 @@ export default function UnifiedProfileEditModal({
           <Text style={styles.fieldLabel}>Bio</Text>
           <TextInput
             value={bio}
-            onChangeText={(t) => { setBio(t); setBioError(bioLiveError(t)); }}
+            onChangeText={(t) => { const v = capBio(t); setBio(v); setBioError(bioLiveError(v)); }}
             placeholder="Tell people about yourself..."
             placeholderTextColor={theme.colors.textMuted}
             style={[styles.input, { height: 100, textAlignVertical: 'top' }]}
             multiline
-            // Coarse byte-count ceiling so a huge paste can't lag the field; the
-            // byte validator (live) is the real, user-visible gate.
-            maxLength={MAX_BIO_BYTES}
+            // Hard-capped to MAX_BIO_BYTES by bytes in onChangeText (capBio).
+            // No maxLength (counts chars, not bytes).
             aria-label="Bio"
             aria-invalid={!!bioError}
           />
@@ -287,9 +286,9 @@ export default function UnifiedProfileEditModal({
             <Text style={[styles.buttonLabel, { color: theme.colors.textMain }]}>Cancel</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.button, styles.buttonPrimary]}
+            style={[styles.button, styles.buttonPrimary, (saving || !!nameError || !!bioError) && styles.buttonDisabled]}
             onPress={handleSave}
-            disabled={saving}
+            disabled={saving || !!nameError || !!bioError}
           >
             {saving ? (
               <ActivityIndicator color="#fff" />
@@ -386,6 +385,9 @@ function createStyles(theme: AppTheme) {
     },
     buttonSecondary: {
       backgroundColor: theme.colors.surface2,
+    },
+    buttonDisabled: {
+      opacity: 0.5,
     },
     buttonLabel: {
       fontSize: Skin.font(15),

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -13,6 +13,16 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Skin from '@/theme/skins/geometry';
+import {
+  validateDisplayName,
+  validateUserBio,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
+} from '@quilibrium/quorum-shared';
+import {
+  translateValidationResult,
+  translateValidationResults,
+} from '@/hooks/validation/errorTranslator';
 
 export type EditScope = 'quorum' | 'farcaster' | 'both';
 
@@ -36,6 +46,8 @@ export default function UnifiedProfileEditModal({
   const [bio, setBio] = useState('');
   const [avatar, setAvatar] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
+  const [nameError, setNameError] = useState<string | undefined>(undefined);
+  const [bioError, setBioError] = useState<string | undefined>(undefined);
 
   // Load the live Farcaster profile so farcaster-scoped edits seed from
   // the Farcaster-side fields rather than the Quorum-side fields.
@@ -164,6 +176,19 @@ export default function UnifiedProfileEditModal({
   };
 
   const handleSave = async () => {
+    // Validate against the shared byte limits before doing anything. Both
+    // fields are optional (empty = leave/clear), so only validate non-empty
+    // values. This also guards the Farcaster publish below — a name/bio over
+    // Farcaster's USER_DATA byte caps must be blocked locally with a clear
+    // message instead of letting /v2/me return an opaque HTTP 400.
+    const trimmedName = displayName.trim();
+    const trimmedBio = bio.trim();
+    const nameMsg = trimmedName ? translateValidationResult(validateDisplayName(trimmedName)) : undefined;
+    const bioMsg = trimmedBio ? translateValidationResults(validateUserBio(trimmedBio))[0] : undefined;
+    setNameError(nameMsg);
+    setBioError(bioMsg);
+    if (nameMsg || bioMsg) return;
+
     setSaving(true);
     try {
       const quorumTargeted = scope === 'quorum' || scope === 'both';
@@ -214,26 +239,38 @@ export default function UnifiedProfileEditModal({
           <Text style={styles.fieldLabel}>Display Name</Text>
           <TextInput
             value={displayName}
-            onChangeText={setDisplayName}
+            onChangeText={(t) => { setDisplayName(t); if (nameError) setNameError(undefined); }}
             placeholder="Your name"
             placeholderTextColor={theme.colors.textMuted}
             style={styles.input}
             autoCapitalize="words"
-            maxLength={60}
+            // Coarse guard ~ MAX_DISPLAY_NAME_BYTES; the byte validator on save
+            // catches multi-byte overflow a char cap can't.
+            maxLength={MAX_DISPLAY_NAME_BYTES}
+            aria-label="Display name"
+            aria-invalid={!!nameError}
           />
+          {nameError ? (
+            <Text style={styles.fieldError} role="alert">{nameError}</Text>
+          ) : null}
         </View>
 
         <View style={styles.field}>
           <Text style={styles.fieldLabel}>Bio</Text>
           <TextInput
             value={bio}
-            onChangeText={setBio}
+            onChangeText={(t) => { setBio(t); if (bioError) setBioError(undefined); }}
             placeholder="Tell people about yourself..."
             placeholderTextColor={theme.colors.textMuted}
             style={[styles.input, { height: 100, textAlignVertical: 'top' }]}
             multiline
-            maxLength={256}
+            maxLength={MAX_BIO_BYTES}
+            aria-label="Bio"
+            aria-invalid={!!bioError}
           />
+          {bioError ? (
+            <Text style={styles.fieldError} role="alert">{bioError}</Text>
+          ) : null}
         </View>
 
         <View style={styles.actions}>
@@ -311,6 +348,11 @@ function createStyles(theme: AppTheme) {
       fontSize: Skin.font(13),
       fontWeight: '600',
       color: theme.colors.textMuted,
+    },
+    fieldError: {
+      fontSize: Skin.font(12),
+      color: theme.colors.danger,
+      marginTop: Skin.space(1),
     },
     input: {
       borderWidth: Skin.border(1),

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2006,11 +2006,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               //      sent their update, or join control was missed), we
               //      still record the profile so the next member-list
               //      fetch surfaces the right data.
-              //   2. Treat empty strings as "no change" rather than
-              //      "clear the field". A common partial-update mistake
-              //      on the sender side was to broadcast an avatar
-              //      change with `displayName: ''`, which under the old
-              //      handler clobbered everyone's stored display name.
+              //   2. Per-field clear semantics: displayName and bio use a
+              //      presence check (!== undefined) so an empty string is a
+              //      DELIBERATE clear (desktop now omits a field on the wire
+              //      when it didn't change, so '' is always intentional —
+              //      this is why the old "empty = no change" guard for
+              //      displayName was dropped). userIcon stays on the truthy
+              //      guard (icons aren't cleared via this path; an empty
+              //      avatar would just blank the member's icon by mistake).
               const profileContent = spaceMessage.content as {
                 senderId: string;
                 displayName?: string;
@@ -2048,7 +2051,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   address: profileContent.senderId,
                   inbox_address: '',
                 }),
-                ...(profileContent.displayName ? { display_name: profileContent.displayName } : {}),
+                // Presence check (not truthy): an empty displayName is a
+                // deliberate per-space-name clear ("use my global/QNS name
+                // here"), matching bio's semantics and desktop's receiver.
+                // The sender omits displayName on bio/avatar-only edits, so
+                // '' on the wire is always an intentional clear.
+                ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
                 ...(profileContent.userIcon ? { profile_image: profileContent.userIcon } : {}),
                 ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
                 ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
@@ -3307,7 +3315,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 address: profileContent.senderId,
                 inbox_address: '',
               }),
-              ...(profileContent.displayName ? { display_name: profileContent.displayName } : {}),
+              // Presence check (not truthy): empty displayName = deliberate
+              // per-space-name clear, matching bio + desktop's receiver. See
+              // the matching comment in the JS-path handler above.
+              ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
               ...(profileContent.userIcon ? { profile_image: profileContent.userIcon } : {}),
               ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
               ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0

--- a/hooks/validation/errorTranslator.ts
+++ b/hooks/validation/errorTranslator.ts
@@ -1,6 +1,8 @@
 import {
   validateDisplayName,
   validateUserBio,
+  MAX_BIO_BYTES,
+  MAX_DISPLAY_NAME_BYTES,
   type FieldValidationResult,
 } from '@quilibrium/quorum-shared';
 
@@ -81,4 +83,46 @@ export function displayNameLiveError(value: string): string | undefined {
 export function bioLiveError(value: string): string | undefined {
   if (!value.trim()) return undefined;
   return translateValidationResults(validateUserBio(value.trim()))[0];
+}
+
+// ── Byte-accurate input caps ─────────────────────────────────────────────────
+// The display-name / bio limits are in UTF-8 BYTES (to match Farcaster's
+// USER_DATA caps so a Quorum profile merges cleanly). React Native's TextInput
+// `maxLength` counts UTF-16 code units, not bytes, so it can't enforce a byte
+// budget. We hard-cap the input by bytes in onChangeText instead — a silent
+// truncate, which is kinder on mobile than making the user hunt-and-delete to
+// get under the limit. The limit CONSTANTS come from quorum-shared (the
+// cross-platform contract); only the truncation is mobile-local (shared has no
+// byte-truncate, and trimming an input field is a UI concern, not validation).
+
+const encoder = new TextEncoder();
+
+/**
+ * Return the longest prefix of `text` that fits within `maxBytes` UTF-8 bytes,
+ * never splitting a multi-byte character. Fast path: if it already fits, return
+ * it unchanged (no allocation).
+ */
+export function truncateToBytes(text: string, maxBytes: number): string {
+  if (encoder.encode(text).length <= maxBytes) return text;
+  // Walk by code points (the spread handles surrogate pairs / emoji correctly),
+  // accumulating until the next char would overflow the byte budget.
+  let bytes = 0;
+  let out = '';
+  for (const ch of text) {
+    const chBytes = encoder.encode(ch).length;
+    if (bytes + chBytes > maxBytes) break;
+    bytes += chBytes;
+    out += ch;
+  }
+  return out;
+}
+
+/** Hard-cap a display-name input to MAX_DISPLAY_NAME_BYTES (UTF-8 bytes). */
+export function capDisplayName(text: string): string {
+  return truncateToBytes(text, MAX_DISPLAY_NAME_BYTES);
+}
+
+/** Hard-cap a bio input to MAX_BIO_BYTES (UTF-8 bytes). */
+export function capBio(text: string): string {
+  return truncateToBytes(text, MAX_BIO_BYTES);
 }

--- a/hooks/validation/errorTranslator.ts
+++ b/hooks/validation/errorTranslator.ts
@@ -1,4 +1,8 @@
-import type { FieldValidationResult } from '@quilibrium/quorum-shared';
+import {
+  validateDisplayName,
+  validateUserBio,
+  type FieldValidationResult,
+} from '@quilibrium/quorum-shared';
 
 /**
  * Translates shared validator `errorKey`s into mobile's English UI strings.
@@ -56,4 +60,25 @@ export function translateValidationResults(results: FieldValidationResult[]): st
   return results
     .map(translateValidationResult)
     .filter((s): s is string => s !== undefined);
+}
+
+/**
+ * Live (per-keystroke) validation for a display name. Returns a UI error string
+ * or `undefined` when valid. Empty/whitespace-only is treated as valid (an empty
+ * display name is a deliberate "use my global/QNS name" clear), so the user isn't
+ * nagged with "required" while typing. Matches desktop, which validates the
+ * display name continuously rather than only on save.
+ */
+export function displayNameLiveError(value: string): string | undefined {
+  if (!value.trim()) return undefined;
+  return translateValidationResult(validateDisplayName(value.trim()));
+}
+
+/**
+ * Live (per-keystroke) validation for a bio. Returns the first UI error string
+ * or `undefined` when valid. Empty is valid (clears the bio).
+ */
+export function bioLiveError(value: string): string | undefined {
+  if (!value.trim()) return undefined;
+  return translateValidationResults(validateUserBio(value.trim()))[0];
 }

--- a/hooks/validation/errorTranslator.ts
+++ b/hooks/validation/errorTranslator.ts
@@ -22,6 +22,19 @@ const messages: Record<string, (vars: Vars) => string> = {
 
   'spaceDescription.invalidChars': () => 'Description cannot contain special characters',
   'spaceDescription.tooLong': vars => `Description must be ${vars!.max} characters or less`,
+
+  // Display name + bio limits are in UTF-8 BYTES (Farcaster-aligned), which
+  // are meaningless to users — so the "too long" copy shows no number, matching
+  // desktop's displayName.tooLong / userBio.tooLong.
+  'displayName.required': () => 'Display name is required',
+  'displayName.tooLong': () => 'Display name is too long',
+  'displayName.invalidChars': () => 'Display name cannot contain special characters',
+  'displayName.reservedMention': () => 'That name is reserved',
+  'displayName.reservedImpersonation': () => 'That name is not allowed',
+  'displayName.reservedQnsSuffix': () => 'A name ending in ".q" is reserved for verified QNS names',
+
+  'userBio.tooLong': () => 'Bio is too long',
+  'userBio.invalidChars': () => 'Bio cannot contain special characters',
 };
 
 /**

--- a/services/farcaster/updateProfile.ts
+++ b/services/farcaster/updateProfile.ts
@@ -7,8 +7,17 @@
  *  - PATCH /v2/me  with { displayName?, bio?, pfp?, location? }
  */
 
+import { MAX_BIO_BYTES, MAX_DISPLAY_NAME_BYTES } from '@quilibrium/quorum-shared';
+
 const FARCASTER_API = 'https://client.farcaster.xyz';
 const CLOUDFLARE_CDN = 'https://imagedelivery.net/BXluQx4ige9GuW0Ia56BHw';
+
+// UTF-8 byte length. Farcaster's USER_DATA caps are in bytes, so a char count
+// would pass values the relay rejects (one emoji is up to 4 bytes, an accented
+// letter 2). Matches the shared validators' own byteLength.
+function utf8ByteLength(s: string): number {
+  return new TextEncoder().encode(s).length;
+}
 
 interface UpdateResult {
   ok: boolean;
@@ -120,6 +129,18 @@ export async function updateFarcasterProfile(
     pfp?: string;
   },
 ): Promise<{ ok: boolean; error?: string; uploadedPfpUrl?: string }> {
+  // Hard byte-limit guard at the publish chokepoint. Every Farcaster profile
+  // save passes through here regardless of caller, so blocking over-limit
+  // values here turns the relay's opaque HTTP 400 into a clear local error.
+  // Defense-in-depth: the UI editor already validates, but this protects any
+  // other/future caller too.
+  if (fields.displayName !== undefined && utf8ByteLength(fields.displayName) > MAX_DISPLAY_NAME_BYTES) {
+    return { ok: false, error: 'Display name is too long' };
+  }
+  if (fields.bio !== undefined && utf8ByteLength(fields.bio) > MAX_BIO_BYTES) {
+    return { ok: false, error: 'Bio is too long' };
+  }
+
   const body: UpdateUserBody = {};
   if (fields.displayName !== undefined) body.displayName = fields.displayName;
   if (fields.bio !== undefined) body.bio = fields.bio;


### PR DESCRIPTION
Two quorum-shared-migration tasks, both unblocked now that mobile is on `2.1.0-31` (the byte validators + optional `UpdateProfileMessage.displayName` are in the published dist — verified by grep).

## 1. Converge bio + display-name inputs to shared byte validators

Mobile's bio/display-name inputs had inconsistent, over-permissive char caps (display name 50–64 chars; bio 160–280) and **no validation at all**; the Farcaster publish path did zero byte checks, so an over-limit value got an opaque HTTP 400 from the relay.

- Route all bio + display-name inputs across the **4 editors** (onboarding `profile-setup`, `UnifiedProfileEditModal`, `SpaceSettingsModal`, `ProfileModal`) through shared `validateUserBio` (256 bytes) / `validateDisplayName` (32 bytes + `.q`/XSS/impersonation/reserved-mention), with inline errors via the existing `errorTranslator` (extended with `displayName.*` + `userBio.*` keys).
- Caps tightened to `MAX_DISPLAY_NAME_BYTES` / `MAX_BIO_BYTES` coarse guards; the byte validator on save catches multi-byte overflow a char cap can't. Byte-based to match Farcaster's USER_DATA limits (a Quorum profile can publish to Farcaster).
- **Hard-block** over-limit name/bio at the `updateFarcasterProfile()` publish chokepoint with a clear message instead of the relay's opaque 400 (defense-in-depth, covers any caller).

**User-visible cap changes (shrinking ones to note):** display name 50/60/64 → 32 bytes; per-space bio 280 → 256 bytes. Onboarding bio rises 160 → 256. Stored over-limit values aren't truncated — only input is capped going forward.

## 2. Honor empty displayName as a per-space-name clear

Desktop lets a user clear their per-space display name (empty = "use my global/QNS name here"), broadcast as `update-profile` with `displayName: ''`. Mobile's two `update-profile` receivers used a truthy guard, so an empty name was treated as "no change" and the partner kept the stale name. Flipped both handlers to a presence check (`!== undefined`), matching bio + desktop. `userIcon` stays truthy-guarded.

## Verification

- `tsc`: **no new errors** vs. the pre-existing master baseline (the only 2 `WebSocketContext` errors exist on master, confirmed).
- eslint: no new errors on any touched file.
- **Runtime testing pending** — these are user-visible (shrinking caps, inline errors, per-space-name clear); holding merge until tested on device.

(The inbox call-preview emoji fix that was briefly batched here was pulled out — it should use app icons, not emoji; filed as its own task.)