### PR TITLE
feat: channel drag reorder

### DIFF
--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -1,5 +1,14 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { View, Text, StyleSheet, AccessibilityActionEvent } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+  type SharedValue,
+} from 'react-native-reanimated';
+import * as Haptics from 'expo-haptics';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
 import { useTheme, type AppTheme } from '@/theme';
@@ -16,8 +25,7 @@ export interface DraggableChannelGroupProps {
   defaultChannelId: string;
   /**
    * Ref to the RNGH ScrollView wrapping the Channels tab. Threaded down to the
-   * Pan gesture (Task 5) so a drag wins over the scroll. In Task 3 (static,
-   * pre-drag) this is unused — accept it now so the prop shape is stable.
+   * Pan gesture so a drag wins over the scroll.
    * Typed loosely (object | null) to avoid importing the RNGH ScrollView ref
    * type into this file; the gesture only needs the ref object.
    */
@@ -36,20 +44,185 @@ export interface DraggableChannelGroupProps {
   onReorder: (groupIndex: number, channelOrder: string[]) => void;
 }
 
+interface DraggableRowProps {
+  channel: Channel;
+  index: number;
+  count: number;
+  styles: ReturnType<typeof createStyles>;
+  theme: AppTheme;
+  activeIndex: SharedValue<number>;
+  translateY: SharedValue<number>;
+  positions: SharedValue<number[]>;
+  scrollRef: React.RefObject<unknown>;
+  iconColor: string;
+  iconBg: string | undefined;
+  statusGlyphs: React.ReactNode;
+  a11yActions: { name: string; label: string }[];
+  onOpen: () => void;
+  onAccessibilityAction: (e: AccessibilityActionEvent) => void;
+  onSwapHaptic: () => void;
+  onLiftHaptic: () => void;
+  onDropHaptic: () => void;
+  onPersist: (visualOrder: number[]) => void;
+}
+
+function DraggableRow({
+  channel, index, count, styles, theme,
+  activeIndex, translateY, positions, scrollRef,
+  iconColor, iconBg, statusGlyphs, a11yActions,
+  onOpen, onAccessibilityAction,
+  onSwapHaptic, onLiftHaptic, onDropHaptic, onPersist,
+}: DraggableRowProps) {
+  const ROW = CHANNEL_ROW_HEIGHT;
+
+  const pan = useMemo(
+    () =>
+      Gesture.Pan()
+        .activateAfterLongPress(0)
+        .simultaneousWithExternalGesture(
+          scrollRef as React.RefObject<React.ComponentType | undefined>
+        )
+        .onStart(() => {
+          activeIndex.value = index;
+          translateY.value = 0;
+          runOnJS(onLiftHaptic)();
+        })
+        .onUpdate((e) => {
+          translateY.value = e.translationY;
+          const currentSlot = positions.value.indexOf(index);
+          const targetSlot = Math.max(
+            0,
+            Math.min(count - 1, currentSlot + Math.round(e.translationY / ROW))
+          );
+          if (targetSlot !== currentSlot) {
+            const next = [...positions.value];
+            next.splice(currentSlot, 1);
+            next.splice(targetSlot, 0, index);
+            positions.value = next;
+            runOnJS(onSwapHaptic)();
+          }
+        })
+        .onEnd(() => {
+          const finalOrder = positions.value;
+          runOnJS(onPersist)(finalOrder);
+          runOnJS(onDropHaptic)();
+        })
+        .onFinalize(() => {
+          activeIndex.value = -1;
+          translateY.value = 0;
+        }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [index, count, scrollRef]
+  );
+
+  const animatedStyle = useAnimatedStyle(() => {
+    const isActive = activeIndex.value === index;
+    const slot = positions.value.indexOf(index);
+    if (isActive) {
+      return {
+        top: index * ROW,
+        transform: [
+          { translateY: translateY.value },
+          { scale: withSpring(1.03) },
+        ],
+        zIndex: 999,
+        elevation: 8,
+        shadowColor: '#000',
+        shadowOpacity: 0.3,
+        shadowRadius: 8,
+        shadowOffset: { width: 0, height: 4 },
+        backgroundColor: theme.colors.surface4,
+      };
+    }
+    return {
+      top: index * ROW,
+      transform: [
+        { translateY: withSpring((slot - index) * ROW, { damping: 20 }) },
+        { scale: 1 },
+      ],
+      zIndex: 0,
+      elevation: 0,
+      shadowOpacity: 0,
+      backgroundColor: theme.colors.surface3,
+    };
+  });
+
+  return (
+    <Animated.View
+      style={[styles.row, animatedStyle]}
+      accessibilityRole="none"
+      accessibilityLabel={`Channel ${channel.channelName}`}
+      accessibilityActions={a11yActions}
+      onAccessibilityAction={onAccessibilityAction}
+    >
+      <TouchableOpacity
+        style={[styles.iconButton, iconBg ? { backgroundColor: iconBg } : null]}
+        onPress={onOpen}
+      >
+        <IconSymbol
+          name={(channel.icon || 'hashtag') as IconSymbolName}
+          size={14}
+          color={iconColor}
+          variant={channel.iconVariant ?? 'outline'}
+        />
+      </TouchableOpacity>
+      <TouchableOpacity
+        style={styles.nameContainer}
+        onPress={onOpen}
+        accessibilityLabel={`Channel ${channel.channelName}. Double tap to open settings.`}
+      >
+        <Text style={styles.name}>{channel.channelName}</Text>
+      </TouchableOpacity>
+      {statusGlyphs}
+      <GestureDetector gesture={pan}>
+        <View
+          style={styles.handle}
+          importantForAccessibility="no-hide-descendants"
+          accessibilityElementsHidden={true}
+        >
+          <IconSymbol name={'grip.vertical' as IconSymbolName} size={16} color={theme.colors.textMuted} />
+        </View>
+      </GestureDetector>
+    </Animated.View>
+  );
+}
+
 export function DraggableChannelGroup({
   groupIndex,
   channels,
   defaultChannelId: _defaultChannelId,
-  scrollRef: _scrollRef,
+  scrollRef,
   resolveIconColor,
   onOpenChannel,
   renderStatusGlyphs,
   onMoveUp,
   onMoveDown,
-  onReorder: _onReorder,
+  onReorder,
 }: DraggableChannelGroupProps) {
   const { theme } = useTheme();
   const styles = createStyles(theme);
+
+  const activeIndex = useSharedValue(-1);
+  const translateY = useSharedValue(0);
+  const positions = useSharedValue<number[]>(channels.map((_, i) => i));
+
+  React.useEffect(() => {
+    positions.value = channels.map((_, i) => i);
+  }, [channels, positions]);
+
+  const persistOrder = useCallback(
+    (visualOrder: number[]) => {
+      const channelOrder = visualOrder.map((i) => channels[i].channelId);
+      onReorder(groupIndex, channelOrder);
+    },
+    [channels, groupIndex, onReorder]
+  );
+
+  const haptic = useCallback((style: 'light' | 'medium' | 'select') => {
+    if (style === 'light') Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    else if (style === 'medium') Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    else Haptics.selectionAsync();
+  }, []);
 
   const handleAccessibilityAction = useCallback(
     (channelIndex: number) => (e: AccessibilityActionEvent) => {
@@ -62,53 +235,34 @@ export function DraggableChannelGroup({
   return (
     <View style={{ height: channels.length * CHANNEL_ROW_HEIGHT }}>
       {channels.map((channel, channelIndex) => {
-        const a11yActions = [];
+        const a11yActions: { name: string; label: string }[] = [];
         if (channelIndex > 0) a11yActions.push({ name: 'moveUp', label: 'Move up' });
         if (channelIndex < channels.length - 1)
           a11yActions.push({ name: 'moveDown', label: 'Move down' });
-
+        const color = resolveIconColor(channel.iconColor, theme.colors.textMuted);
         return (
-          <View
+          <DraggableRow
             key={channel.channelId}
-            style={[styles.row, { top: channelIndex * CHANNEL_ROW_HEIGHT }]}
-            accessibilityRole="none"
-            accessibilityLabel={`Channel ${channel.channelName}`}
-            accessibilityActions={a11yActions}
+            channel={channel}
+            index={channelIndex}
+            count={channels.length}
+            styles={styles}
+            theme={theme}
+            activeIndex={activeIndex}
+            translateY={translateY}
+            positions={positions}
+            scrollRef={scrollRef}
+            iconColor={color}
+            iconBg={channel.icon ? color + '20' : undefined}
+            statusGlyphs={renderStatusGlyphs(channel)}
+            a11yActions={a11yActions}
+            onOpen={() => onOpenChannel(channel.channelId)}
             onAccessibilityAction={handleAccessibilityAction(channelIndex)}
-          >
-            <TouchableOpacity
-              style={[
-                styles.iconButton,
-                channel.icon && {
-                  backgroundColor:
-                    resolveIconColor(channel.iconColor, theme.colors.textMuted) + '20',
-                },
-              ]}
-              onPress={() => onOpenChannel(channel.channelId)}
-            >
-              <IconSymbol
-                name={(channel.icon || 'hashtag') as IconSymbolName}
-                size={14}
-                color={resolveIconColor(channel.iconColor, theme.colors.textMuted)}
-                variant={channel.iconVariant ?? 'outline'}
-              />
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={styles.nameContainer}
-              onPress={() => onOpenChannel(channel.channelId)}
-              accessibilityLabel={`Channel ${channel.channelName}. Double tap to open settings.`}
-            >
-              <Text style={styles.name}>{channel.channelName}</Text>
-            </TouchableOpacity>
-            {renderStatusGlyphs(channel)}
-            <View
-              style={styles.handle}
-              importantForAccessibility="no-hide-descendants"
-              accessibilityElementsHidden={true}
-            >
-              <IconSymbol name={'grip.vertical' as IconSymbolName} size={16} color={theme.colors.textMuted} />
-            </View>
-          </View>
+            onLiftHaptic={() => haptic('light')}
+            onSwapHaptic={() => haptic('select')}
+            onDropHaptic={() => haptic('medium')}
+            onPersist={persistOrder}
+          />
         );
       })}
     </View>

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -151,7 +151,7 @@ function DraggableRow({
   return (
     <Animated.View
       style={[styles.row, animatedStyle]}
-      accessibilityRole="none"
+      accessibilityRole="adjustable"
       accessibilityLabel={`Channel ${channel.channelName}`}
       accessibilityActions={a11yActions}
       onAccessibilityAction={onAccessibilityAction}
@@ -208,8 +208,10 @@ export function DraggableChannelGroup({
   const positions = useSharedValue<number[]>(channels.map((_, i) => i));
 
   React.useEffect(() => {
-    positions.value = channels.map((_, i) => i);
-  }, [channels, positions]);
+    if (activeIndex.value === -1) {
+      positions.value = channels.map((_, i) => i);
+    }
+  }, [channels, positions, activeIndex]);
 
   const persistOrder = useCallback(
     (visualOrder: number[]) => {

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -183,7 +183,9 @@ function DraggableRow({
         onPress={onOpen}
         accessibilityLabel={`Channel ${channel.channelName}. Double tap to open settings.`}
       >
-        <Text style={styles.name}>{channel.channelName}</Text>
+        <Text style={styles.name} numberOfLines={1}>
+          {channel.channelName}
+        </Text>
       </TouchableOpacity>
       {statusGlyphs}
       <GestureDetector gesture={pan}>

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -74,6 +74,7 @@ function DraggableRow({
   onSwapHaptic, onLiftHaptic, onDropHaptic, onPersist,
 }: DraggableRowProps) {
   const ROW = CHANNEL_ROW_HEIGHT;
+  const scale = useSharedValue(1);
 
   const pan = useMemo(
     () =>
@@ -85,6 +86,7 @@ function DraggableRow({
         .onStart(() => {
           activeIndex.value = index;
           translateY.value = 0;
+          scale.value = withSpring(1.03);
           runOnJS(onLiftHaptic)();
         })
         .onUpdate((e) => {
@@ -102,7 +104,8 @@ function DraggableRow({
             runOnJS(onSwapHaptic)();
           }
         })
-        .onEnd(() => {
+        .onEnd((_, success) => {
+          if (!success) return;
           const finalOrder = positions.value;
           runOnJS(onPersist)(finalOrder);
           runOnJS(onDropHaptic)();
@@ -110,6 +113,7 @@ function DraggableRow({
         .onFinalize(() => {
           activeIndex.value = -1;
           translateY.value = 0;
+          scale.value = withSpring(1);
         }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [index, count, scrollRef]
@@ -121,10 +125,7 @@ function DraggableRow({
     if (isActive) {
       return {
         top: index * ROW,
-        transform: [
-          { translateY: translateY.value },
-          { scale: withSpring(1.03) },
-        ],
+        transform: [{ translateY: translateY.value }, { scale: scale.value }],
         zIndex: 999,
         elevation: 8,
         shadowColor: '#000',
@@ -137,8 +138,8 @@ function DraggableRow({
     return {
       top: index * ROW,
       transform: [
-        { translateY: withSpring((slot - index) * ROW, { damping: 20 }) },
-        { scale: 1 },
+        { translateY: withSpring((slot - index) * ROW, { damping: 20, stiffness: 200 }) },
+        { scale: scale.value },
       ],
       zIndex: 0,
       elevation: 0,

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -6,6 +6,7 @@ import Animated, {
   useAnimatedStyle,
   withSpring,
   runOnJS,
+  makeMutable,
   type SharedValue,
 } from 'react-native-reanimated';
 import * as Haptics from 'expo-haptics';
@@ -51,7 +52,9 @@ interface DraggableRowProps {
   styles: ReturnType<typeof createStyles>;
   theme: AppTheme;
   activeIndex: SharedValue<number>;
-  translateY: SharedValue<number>;
+  dragY: SharedValue<number>;
+  animY: SharedValue<number>;
+  scale: SharedValue<number>;
   positions: SharedValue<number[]>;
   scrollRef: React.RefObject<unknown>;
   iconColor: string;
@@ -64,17 +67,19 @@ interface DraggableRowProps {
   onLiftHaptic: () => void;
   onDropHaptic: () => void;
   onPersist: (visualOrder: number[]) => void;
+  // animY values for ALL rows — needed on the UI thread to spring idle rows on swap
+  allAnimY: SharedValue<number>[];
 }
 
 function DraggableRow({
   channel, index, count, styles, theme,
-  activeIndex, translateY, positions, scrollRef,
+  activeIndex, dragY, animY, scale, positions, scrollRef,
   iconColor, iconBg, statusGlyphs, a11yActions,
   onOpen, onAccessibilityAction,
   onSwapHaptic, onLiftHaptic, onDropHaptic, onPersist,
+  allAnimY,
 }: DraggableRowProps) {
   const ROW = CHANNEL_ROW_HEIGHT;
-  const scale = useSharedValue(1);
 
   const pan = useMemo(
     () =>
@@ -85,35 +90,45 @@ function DraggableRow({
         )
         .onStart(() => {
           activeIndex.value = index;
-          translateY.value = 0;
-          scale.value = withSpring(1.03);
+          dragY.value = 0;
+          scale.value = withSpring(1.03, { damping: 15, stiffness: 200 });
           runOnJS(onLiftHaptic)();
         })
         .onUpdate((e) => {
-          translateY.value = e.translationY;
+          dragY.value = e.translationY;
+          // Target slot = which slot the dragged row's centre is currently over,
+          // computed from the row's resting top (index * ROW) plus finger offset.
+          const absY = index * ROW + e.translationY;
+          const targetSlot = Math.max(0, Math.min(count - 1, Math.round(absY / ROW)));
           const currentSlot = positions.value.indexOf(index);
-          const targetSlot = Math.max(
-            0,
-            Math.min(count - 1, currentSlot + Math.round(e.translationY / ROW))
-          );
           if (targetSlot !== currentSlot) {
             const next = [...positions.value];
             next.splice(currentSlot, 1);
             next.splice(targetSlot, 0, index);
             positions.value = next;
+            // Spring idle rows to their new slot positions immediately
+            for (let i = 0; i < next.length; i++) {
+              const rowIndex = next[i];
+              if (rowIndex !== index) {
+                allAnimY[rowIndex].value = withSpring(i * ROW, { damping: 20, stiffness: 220 });
+              }
+            }
             runOnJS(onSwapHaptic)();
           }
         })
         .onEnd((_, success) => {
           if (!success) return;
           const finalOrder = positions.value;
+          // Snap active row to its final resting slot
+          const finalSlot = finalOrder.indexOf(index);
+          animY.value = withSpring(finalSlot * ROW, { damping: 20, stiffness: 220 });
           runOnJS(onPersist)(finalOrder);
           runOnJS(onDropHaptic)();
         })
         .onFinalize(() => {
           activeIndex.value = -1;
-          translateY.value = 0;
-          scale.value = withSpring(1);
+          dragY.value = 0;
+          scale.value = withSpring(1, { damping: 15, stiffness: 200 });
         }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [index, count, scrollRef]
@@ -121,11 +136,10 @@ function DraggableRow({
 
   const animatedStyle = useAnimatedStyle(() => {
     const isActive = activeIndex.value === index;
-    const slot = positions.value.indexOf(index);
     if (isActive) {
       return {
-        top: index * ROW,
-        transform: [{ translateY: translateY.value }, { scale: scale.value }],
+        top: 0,
+        transform: [{ translateY: animY.value + dragY.value }, { scale: scale.value }],
         zIndex: 999,
         elevation: 8,
         shadowColor: '#000',
@@ -136,11 +150,8 @@ function DraggableRow({
       };
     }
     return {
-      top: index * ROW,
-      transform: [
-        { translateY: withSpring((slot - index) * ROW, { damping: 20, stiffness: 200 }) },
-        { scale: scale.value },
-      ],
+      top: 0,
+      transform: [{ translateY: animY.value }, { scale: 1 }],
       zIndex: 0,
       elevation: 0,
       shadowOpacity: 0,
@@ -204,14 +215,43 @@ export function DraggableChannelGroup({
   const styles = createStyles(theme);
 
   const activeIndex = useSharedValue(-1);
-  const translateY = useSharedValue(0);
   const positions = useSharedValue<number[]>(channels.map((_, i) => i));
+
+  // Per-row shared values stored in a ref — created once, never recreated.
+  // `makeMutable` is Reanimated's low-level shared value factory that can be
+  // called outside the render cycle safely (unlike useSharedValue which is
+  // a hook). We store them in a ref so they survive re-renders.
+  const rowValuesRef = React.useRef<{
+    animY: SharedValue<number>[];
+    scale: SharedValue<number>[];
+    dragY: SharedValue<number>[];
+  } | null>(null);
+
+  if (!rowValuesRef.current || rowValuesRef.current.animY.length < channels.length) {
+    const prev = rowValuesRef.current;
+    const start = prev ? prev.animY.length : 0;
+    const animY = prev ? [...prev.animY] : [];
+    const scale = prev ? [...prev.scale] : [];
+    const dragY = prev ? [...prev.dragY] : [];
+    for (let i = start; i < channels.length; i++) {
+      animY.push(makeMutable(i * CHANNEL_ROW_HEIGHT));
+      scale.push(makeMutable(1));
+      dragY.push(makeMutable(0));
+    }
+    rowValuesRef.current = { animY, scale, dragY };
+  }
+
+  const { animY, scale, dragY } = rowValuesRef.current;
 
   React.useEffect(() => {
     if (activeIndex.value === -1) {
       positions.value = channels.map((_, i) => i);
+      // Reset each row's animated position to its natural slot
+      for (let i = 0; i < channels.length; i++) {
+        animY[i].value = i * CHANNEL_ROW_HEIGHT;
+      }
     }
-  }, [channels, positions, activeIndex]);
+  }, [channels, positions, activeIndex, animY]);
 
   const persistOrder = useCallback(
     (visualOrder: number[]) => {
@@ -252,7 +292,9 @@ export function DraggableChannelGroup({
             styles={styles}
             theme={theme}
             activeIndex={activeIndex}
-            translateY={translateY}
+            dragY={dragY[channelIndex]}
+            animY={animY[channelIndex]}
+            scale={scale[channelIndex]}
             positions={positions}
             scrollRef={scrollRef}
             iconColor={color}
@@ -265,6 +307,7 @@ export function DraggableChannelGroup({
             onSwapHaptic={() => haptic('select')}
             onDropHaptic={() => haptic('medium')}
             onPersist={persistOrder}
+            allAnimY={animY}
           />
         );
       })}

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -1,0 +1,146 @@
+import React, { useCallback } from 'react';
+import { View, Text, StyleSheet, AccessibilityActionEvent } from 'react-native';
+import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { useTheme, type AppTheme } from '@/theme';
+import * as Skin from '@/theme/skins/geometry';
+import type { Channel } from '@quilibrium/quorum-shared';
+
+// Fixed row height drives the reorder math. Matches `channelItem` in
+// SpaceSettingsModal: paddingVertical 8 (x2) + 28px icon button = 44.
+export const CHANNEL_ROW_HEIGHT = 44;
+
+export interface DraggableChannelGroupProps {
+  groupIndex: number;
+  channels: Channel[];
+  defaultChannelId: string;
+  /**
+   * Ref to the RNGH ScrollView wrapping the Channels tab. Threaded down to the
+   * Pan gesture (Task 5) so a drag wins over the scroll. In Task 3 (static,
+   * pre-drag) this is unused — accept it now so the prop shape is stable.
+   * Typed loosely (object | null) to avoid importing the RNGH ScrollView ref
+   * type into this file; the gesture only needs the ref object.
+   */
+  scrollRef: React.RefObject<unknown>;
+  /** Resolve a channel iconColor to a hex string (passed from the modal). */
+  resolveIconColor: (iconColor: string | undefined, fallback: string) => string;
+  /** Tapping a row opens that channel's settings drawer. */
+  onOpenChannel: (channelId: string) => void;
+  /** Renders the lock/star status glyphs for a channel. */
+  renderStatusGlyphs: (channel: Channel) => React.ReactNode;
+  /** a11y: move a channel up one position within its group. */
+  onMoveUp: (groupIndex: number, channelIndex: number) => void;
+  /** a11y: move a channel down one position within its group. */
+  onMoveDown: (groupIndex: number, channelIndex: number) => void;
+  /** Persist a new full channel order for this group. */
+  onReorder: (groupIndex: number, channelOrder: string[]) => void;
+}
+
+export function DraggableChannelGroup({
+  groupIndex,
+  channels,
+  defaultChannelId: _defaultChannelId,
+  scrollRef: _scrollRef,
+  resolveIconColor,
+  onOpenChannel,
+  renderStatusGlyphs,
+  onMoveUp,
+  onMoveDown,
+  onReorder: _onReorder,
+}: DraggableChannelGroupProps) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
+
+  const handleAccessibilityAction = useCallback(
+    (channelIndex: number) => (e: AccessibilityActionEvent) => {
+      if (e.nativeEvent.actionName === 'moveUp') onMoveUp(groupIndex, channelIndex);
+      else if (e.nativeEvent.actionName === 'moveDown') onMoveDown(groupIndex, channelIndex);
+    },
+    [groupIndex, onMoveUp, onMoveDown],
+  );
+
+  return (
+    <View style={{ height: channels.length * CHANNEL_ROW_HEIGHT }}>
+      {channels.map((channel, channelIndex) => {
+        const a11yActions = [];
+        if (channelIndex > 0) a11yActions.push({ name: 'moveUp', label: 'Move up' });
+        if (channelIndex < channels.length - 1)
+          a11yActions.push({ name: 'moveDown', label: 'Move down' });
+
+        return (
+          <View
+            key={channel.channelId}
+            style={[styles.row, { top: channelIndex * CHANNEL_ROW_HEIGHT }]}
+            accessibilityRole="none"
+            accessibilityLabel={`Channel ${channel.channelName}`}
+            accessibilityActions={a11yActions}
+            onAccessibilityAction={handleAccessibilityAction(channelIndex)}
+          >
+            <TouchableOpacity
+              style={[
+                styles.iconButton,
+                channel.icon && {
+                  backgroundColor:
+                    resolveIconColor(channel.iconColor, theme.colors.textMuted) + '20',
+                },
+              ]}
+              onPress={() => onOpenChannel(channel.channelId)}
+            >
+              <IconSymbol
+                name={(channel.icon || 'hashtag') as IconSymbolName}
+                size={14}
+                color={resolveIconColor(channel.iconColor, theme.colors.textMuted)}
+                variant={channel.iconVariant ?? 'outline'}
+              />
+            </TouchableOpacity>
+            <TouchableOpacity
+              style={styles.nameContainer}
+              onPress={() => onOpenChannel(channel.channelId)}
+              accessibilityLabel={`Channel ${channel.channelName}. Double tap to open settings.`}
+            >
+              <Text style={styles.name}>{channel.channelName}</Text>
+            </TouchableOpacity>
+            {renderStatusGlyphs(channel)}
+            <View style={styles.handle} importantForAccessibility="no-hide-descendants">
+              <IconSymbol name={'grip.vertical' as IconSymbolName} size={16} color={theme.colors.textMuted} />
+            </View>
+          </View>
+        );
+      })}
+    </View>
+  );
+}
+
+const createStyles = (theme: AppTheme) =>
+  StyleSheet.create({
+    row: {
+      position: 'absolute',
+      left: 0,
+      right: 0,
+      height: CHANNEL_ROW_HEIGHT,
+      flexDirection: 'row',
+      alignItems: 'center',
+      paddingHorizontal: Skin.space(12),
+      backgroundColor: theme.colors.surface3,
+    },
+    iconButton: {
+      width: 28,
+      height: 28,
+      borderRadius: Skin.radius(6),
+      backgroundColor: theme.colors.surface4,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginRight: Skin.space(6),
+    },
+    nameContainer: { flex: 1 },
+    name: {
+      fontSize: Skin.font(15),
+      fontFamily: theme.fonts.medium.fontFamily,
+      fontWeight: theme.fonts.medium.fontWeight,
+      color: theme.colors.textMain,
+    },
+    handle: {
+      padding: Skin.space(8),
+      marginLeft: Skin.space(4),
+    },
+  });

--- a/components/SpaceSettings/DraggableChannelGroup.tsx
+++ b/components/SpaceSettings/DraggableChannelGroup.tsx
@@ -101,7 +101,11 @@ export function DraggableChannelGroup({
               <Text style={styles.name}>{channel.channelName}</Text>
             </TouchableOpacity>
             {renderStatusGlyphs(channel)}
-            <View style={styles.handle} importantForAccessibility="no-hide-descendants">
+            <View
+              style={styles.handle}
+              importantForAccessibility="no-hide-descendants"
+              accessibilityElementsHidden={true}
+            >
               <IconSymbol name={'grip.vertical' as IconSymbolName} size={16} color={theme.colors.textMuted} />
             </View>
           </View>

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -37,7 +37,10 @@ import {
 import {
   useAddGroup,
   useMoveChannel,
+  useReorderChannels,
 } from '@/hooks/chat';
+import { DraggableChannelGroup } from '@/components/SpaceSettings/DraggableChannelGroup';
+import { ScrollView as GHScrollView } from 'react-native-gesture-handler';
 import { useSpaceMembers } from '@/hooks/chat/useSpaces';
 import { useStartDirectMessage } from '@/hooks/chat/useStartDirectMessage';
 import { useUserMuting } from '@/hooks/chat/useUserMuting';
@@ -63,7 +66,7 @@ import { truncateAddress } from '@/utils/formatAddress';
 import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
 import { resolveChannelIconColor } from '@/utils/channelIcon';
 import * as Clipboard from 'expo-clipboard';
-import React, { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { UserProfileInfo } from '@/components/UserProfileModal';
 
 const UserProfileModal = React.lazy(() => import('@/components/UserProfileModal'));
@@ -788,6 +791,8 @@ export default function SpaceSettingsModal({
   // Channels
   const addGroupMutation = useAddGroup();
   const moveChannelMutation = useMoveChannel();
+  const reorderChannelsMutation = useReorderChannels();
+  const channelsScrollRef = useRef<React.ComponentRef<typeof GHScrollView>>(null);
 
   // Members
   const { data: members = [] } = useSpaceMembers(spaceId, { enabled: !!spaceId });
@@ -1243,6 +1248,19 @@ export default function SpaceSettingsModal({
       // Mutation handles its own error state
     }
   }, [space, spaceId, moveChannelMutation]);
+
+  const handleReorderChannels = useCallback(
+    async (groupIndex: number, channelOrder: string[]) => {
+      try {
+        await reorderChannelsMutation.mutateAsync({ spaceId, groupIndex, channelOrder });
+        const updated = getSpace(spaceId);
+        setSpace(updated);
+      } catch {
+        // mutation handles its own error state
+      }
+    },
+    [spaceId, reorderChannelsMutation],
+  );
 
   const handleDeleteSpace = useCallback(async () => {
     setShowDeleteSpaceConfirm(false);
@@ -1832,44 +1850,25 @@ export default function SpaceSettingsModal({
           </View>
 
           {/* Channels List */}
-          {group.channels.map((channel, channelIndex) => (
-            <View key={channel.channelId} style={styles.channelItem}>
-              <TouchableOpacity
-                style={[styles.channelIconButton, channel.icon && { backgroundColor: resolveChannelIconColor(channel.iconColor, theme.colors.textMuted) + '20' }]}
-                onPress={() => setDrawerTarget({ kind: 'channel', spaceId, groupIndex, channelId: channel.channelId })}
-              >
-                <IconSymbol
-                  name={(channel.icon || 'hashtag') as IconSymbolName}
-                  size={14}
-                  color={resolveChannelIconColor(channel.iconColor, theme.colors.textMuted)}
-                  variant={channel.iconVariant ?? 'outline'}
-                />
-              </TouchableOpacity>
-              <TouchableOpacity
-                style={styles.channelNameContainer}
-                onPress={() => setDrawerTarget({ kind: 'channel', spaceId, groupIndex, channelId: channel.channelId })}
-              >
-                <Text style={styles.channelName}>{channel.channelName}</Text>
-              </TouchableOpacity>
-              <ChannelStatusGlyphs channel={channel} defaultChannelId={space?.defaultChannelId ?? ''} />
-              <View style={styles.channelActions}>
-                <TouchableOpacity
-                  style={[styles.channelArrowButton, channelIndex === 0 && styles.channelArrowDisabled]}
-                  onPress={() => handleMoveChannelUp(groupIndex, channelIndex)}
-                  disabled={channelIndex === 0}
-                >
-                  <IconSymbol name="chevron.up" size={14} color={channelIndex === 0 ? theme.colors.surface5 : theme.colors.textMuted} />
-                </TouchableOpacity>
-                <TouchableOpacity
-                  style={[styles.channelArrowButton, channelIndex === group.channels.length - 1 && styles.channelArrowDisabled]}
-                  onPress={() => handleMoveChannelDown(groupIndex, channelIndex)}
-                  disabled={channelIndex === group.channels.length - 1}
-                >
-                  <IconSymbol name="chevron.down" size={14} color={channelIndex === group.channels.length - 1 ? theme.colors.surface5 : theme.colors.textMuted} />
-                </TouchableOpacity>
-              </View>
-            </View>
-          ))}
+          <DraggableChannelGroup
+            groupIndex={groupIndex}
+            channels={group.channels}
+            defaultChannelId={space?.defaultChannelId ?? ''}
+            scrollRef={channelsScrollRef}
+            resolveIconColor={resolveChannelIconColor}
+            onOpenChannel={(channelId) =>
+              setDrawerTarget({ kind: 'channel', spaceId, groupIndex, channelId })
+            }
+            renderStatusGlyphs={(channel) => (
+              <ChannelStatusGlyphs
+                channel={channel}
+                defaultChannelId={space?.defaultChannelId ?? ''}
+              />
+            )}
+            onMoveUp={handleMoveChannelUp}
+            onMoveDown={handleMoveChannelDown}
+            onReorder={handleReorderChannels}
+          />
 
           {group.channels.length === 0 && (
             <Text style={styles.emptyGroupText}>No channels in this group</Text>
@@ -3240,17 +3239,6 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       paddingHorizontal: Skin.space(8),
       paddingVertical: Skin.space(4),
       flex: 1,
-    },
-    channelActions: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: Skin.space(2),
-    },
-    channelArrowButton: {
-      padding: Skin.space(6),
-    },
-    channelArrowDisabled: {
-      opacity: 0.3,
     },
     channelDeleteButton: {
       padding: Skin.space(6),

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -1794,7 +1794,8 @@ export default function SpaceSettingsModal({
   );
 
   const renderChannelsTab = () => (
-    <ScrollView
+    <GHScrollView
+      ref={channelsScrollRef}
       style={styles.membersScrollView}
       contentContainerStyle={styles.tabContentContainer}
       showsVerticalScrollIndicator={true}
@@ -1885,7 +1886,7 @@ export default function SpaceSettingsModal({
           </Text>
         </View>
       )}
-    </ScrollView>
+    </GHScrollView>
   );
 
   const renderRolesTab = () => (

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -1801,7 +1801,7 @@ export default function SpaceSettingsModal({
       keyboardShouldPersistTaps="handled"
     >
       <Text style={styles.sectionDescription}>
-        Manage channel groups and channels. Use the arrows to reorder channels.
+        Manage channel groups and channels. Drag the handle to reorder channels.
       </Text>
 
       <View style={styles.addButtonRow}>

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -1846,7 +1846,9 @@ export default function SpaceSettingsModal({
                   variant={group.iconVariant ?? 'outline'}
                 />
               ) : null}
-              <Text style={styles.channelGroupName}>{group.groupName}</Text>
+              <Text style={styles.channelGroupName} numberOfLines={1}>
+                {group.groupName}
+              </Text>
             </TouchableOpacity>
           </View>
 
@@ -3186,6 +3188,7 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       flex: 1,
     },
     channelGroupName: {
+      flex: 1,
       fontSize: Skin.font(14),
       fontFamily: theme.fonts.bold.fontFamily,
       fontWeight: theme.fonts.bold.fontWeight,

--- a/components/shared/BaseModal.tsx
+++ b/components/shared/BaseModal.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Animated, Dimensions, Keyboard, KeyboardAvoidingView, Modal, Platform, StyleSheet, TouchableWithoutFeedback, View, ViewStyle } from 'react-native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets, EdgeInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
@@ -142,22 +143,24 @@ export function BaseModal({
       onRequestClose={onClose}
       testID={testID}
     >
-      <View style={styles.container}>
-        {/* Animated backdrop */}
-        <Animated.View
-          style={[
-            styles.backdrop,
-            { opacity: backdropAnim },
-          ]}
-        >
-          <TouchableWithoutFeedback onPress={onClose}>
-            <View style={StyleSheet.absoluteFillObject} />
-          </TouchableWithoutFeedback>
-        </Animated.View>
+      <GestureHandlerRootView style={{ flex: 1 }}>
+        <View style={styles.container}>
+          {/* Animated backdrop */}
+          <Animated.View
+            style={[
+              styles.backdrop,
+              { opacity: backdropAnim },
+            ]}
+          >
+            <TouchableWithoutFeedback onPress={onClose}>
+              <View style={StyleSheet.absoluteFillObject} />
+            </TouchableWithoutFeedback>
+          </Animated.View>
 
-        {/* Animated content */}
-        {modalContent}
-      </View>
+          {/* Animated content */}
+          {modalContent}
+        </View>
+      </GestureHandlerRootView>
     </Modal>
   );
 }

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -84,6 +84,7 @@ const SF_TO_TABLER: Record<string, TablerComponentName> = {
   'chevron.down': tabler('IconChevronDown'),
   'chevron.left.forwardslash.chevron.right': tabler('IconCode'),
   'line.3.horizontal': tabler('IconMenu2'),
+  'grip.vertical': tabler('IconGripVertical'),
 
   // Arrows
   'arrow.left': tabler('IconArrowLeft'),


### PR DESCRIPTION
- feat: add grip.vertical icon for drag handle
- fix: root gesture-handler inside BaseModal so modal gestures fire on Android
- feat: DraggableChannelGroup static row layout (no drag yet)
- fix: hide grip handle from iOS VoiceOver (add accessibilityElementsHidden)
- feat: render channel rows via DraggableChannelGroup; replace chevrons with grip handle + a11y move actions
- fix: update channels tab hint text (drag handle, not arrows)
- feat: drag-to-reorder channels within a group (handle + reanimated + haptics)
- fix: guard persist on gesture cancel; drive scale from shared value (no per-frame spring restart)
- fix: guard mid-drag positions reset; fix VoiceOver row focus (adjustable role)
- fix: rewrite drag math — per-row animY shared values, correct slot targeting, no per-frame spring restart
- style: truncate channel and group names to one line