### PR TITLE
Shared SegmentedPills component for filter/tab rows

### DIFF
--- a/app/(tabs)/spaces/discover.tsx
+++ b/app/(tabs)/spaces/discover.tsx
@@ -12,8 +12,9 @@ import type { DirectoryEntry } from '@/services/api/quorumClient';
 import { haptics } from '@/utils/haptics';
 import { router, Stack } from 'expo-router';
 import React, { useCallback, useState } from 'react';
-import { ActivityIndicator, FlatList, Image, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, FlatList, Image, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useHeaderHeight } from '@react-navigation/elements';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -146,27 +147,19 @@ export default function DiscoverSpacesScreen() {
         )}
       </View>
 
-      <ScrollView
-        horizontal
-        showsHorizontalScrollIndicator={false}
-        style={{ flexGrow: 0, flexShrink: 0 }}
+      <SegmentedPills
         contentContainerStyle={styles.categoryRow}
-      >
-        {SPACE_CATEGORIES.map((cat) => (
-          <TouchableOpacity
-            key={cat.label}
-            style={[styles.categoryChip, category === cat.value && styles.categoryChipActive]}
-            onPress={() => setCategory(cat.value)}
-          >
-            <Text
-              style={[styles.categoryChipText, category === cat.value && styles.categoryChipTextActive]}
-              numberOfLines={1}
-            >
-              {cat.label}
-            </Text>
-          </TouchableOpacity>
-        ))}
-      </ScrollView>
+        variant="solid"
+        itemRole="button"
+        items={SPACE_CATEGORIES.map<SegmentedPillItem>((cat) => ({
+          // value is `SpaceCategory | null`; the "All" pill uses a string
+          // sentinel since pill keys must be strings.
+          key: cat.value ?? 'all',
+          label: cat.label,
+        }))}
+        activeKey={category ?? 'all'}
+        onChange={(key) => setCategory(key === 'all' ? null : (key as typeof category))}
+      />
 
       {isLoading && entries.length === 0 ? (
         <View style={styles.center}>
@@ -218,24 +211,6 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
     categoryRow: {
       paddingHorizontal: Skin.space(16),
       paddingBottom: Skin.space(8),
-    },
-    categoryChip: {
-      paddingHorizontal: Skin.space(14),
-      paddingVertical: Skin.space(6),
-      borderRadius: Skin.radius(16),
-      backgroundColor: isDark ? 'rgba(255,255,255,0.08)' : 'rgba(0,0,0,0.05)',
-      marginRight: Skin.space(8),
-    },
-    categoryChipActive: {
-      backgroundColor: theme.colors.primary,
-    },
-    categoryChipText: {
-      fontSize: Skin.font(13),
-      color: theme.colors.textMuted,
-    },
-    categoryChipTextActive: {
-      color: '#fff',
-      fontWeight: '600',
     },
     center: {
       flex: 1,

--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -10,6 +10,7 @@ import type { Conversation } from '@/hooks/chat';
 import React, { useCallback, useMemo } from 'react';
 import { ActivityIndicator, Alert, Image, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills } from '@/components/ui/SegmentedPills';
 import { FlashList } from '@shopify/flash-list';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -327,27 +328,20 @@ export function DirectMessagesList({
 
       {/* Filter chips */}
       {(isFavorite || isMuted) && (
-        <View style={styles.filterContainer}>
-          {(['all', 'favorites', 'unknown', 'muted'] as DMFilter[]).map((filter) => (
-            <TouchableOpacity
-              key={filter}
-              style={[
-                styles.filterChip,
-                activeFilter === filter && styles.filterChipActive,
-              ]}
-              onPress={() => setActiveFilter(filter)}
-            >
-              <Text
-                style={[
-                  styles.filterChipText,
-                  activeFilter === filter && styles.filterChipTextActive,
-                ]}
-              >
-                {filter === 'all' ? 'All' : filter === 'favorites' ? 'Favorites' : filter === 'unknown' ? 'Unknown' : 'Muted'}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        <SegmentedPills
+          style={styles.filterContainer}
+          variant="solid"
+          scrollable={false}
+          itemRole="button"
+          items={[
+            { key: 'all', label: 'All' },
+            { key: 'favorites', label: 'Favorites' },
+            { key: 'unknown', label: 'Unknown' },
+            { key: 'muted', label: 'Muted' },
+          ]}
+          activeKey={activeFilter}
+          onChange={(key) => setActiveFilter(key as DMFilter)}
+        />
       )}
 
       <FlashList
@@ -422,24 +416,6 @@ const createStyles = (theme: AppTheme) =>
       gap: Skin.space(8),
       borderBottomWidth: Skin.border(1),
       borderBottomColor: theme.colors.surface3,
-    },
-    filterChip: {
-      paddingHorizontal: Skin.space(12),
-      paddingVertical: Skin.space(6),
-      borderRadius: Skin.radius(16),
-      backgroundColor: theme.colors.surface3 ?? theme.colors.surface2,
-    },
-    filterChipActive: {
-      backgroundColor: theme.colors.primary,
-    },
-    filterChipText: {
-      fontSize: Skin.font(13),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMuted,
-    },
-    filterChipTextActive: {
-      color: '#fff',
     },
     conversationItem: {
       flexDirection: 'row',

--- a/components/Chat/EmojiPicker.tsx
+++ b/components/Chat/EmojiPicker.tsx
@@ -13,6 +13,7 @@ import type { Emoji } from '@quilibrium/quorum-shared';
 import { useEmojiFrecency } from '@/hooks/useEmojiFrecency';
 import { EMOJI_KEYWORDS, searchEmojis } from '@/data/emojiData';
 import * as Skin from '@/theme/skins/geometry';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 
 // Custom emoji type for the picker (includes isCustom flag for rendering)
 type PickerEmoji = {
@@ -410,25 +411,20 @@ export function EmojiPicker({
 
           {/* Category tabs */}
           {!searchQuery && (
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
+            <SegmentedPills
               style={styles.categoryTabs}
               contentContainerStyle={styles.categoryTabsContent}
-            >
-              {categories.map(([key, category]) => (
-                <TouchableOpacity
-                  key={key}
-                  style={[
-                    styles.categoryTab,
-                    selectedCategory === key && styles.categoryTabActive,
-                  ]}
-                  onPress={() => setSelectedCategory(key)}
-                >
-                  <Text style={styles.categoryTabEmoji}>{category.icon}</Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
+              emojiSize={22}
+              items={categories.map<SegmentedPillItem>(([key, category]) => ({
+                key,
+                accessibilityLabel: category.name,
+                ...(typeof category.icon === 'string'
+                  ? { emoji: category.icon }
+                  : { leading: category.icon }),
+              }))}
+              activeKey={selectedCategory}
+              onChange={(key) => setSelectedCategory(key as CategoryKey)}
+            />
           )}
 
           {/* Emoji grid */}
@@ -549,18 +545,6 @@ const createStyles = (theme: AppTheme, keyboardHeight: number) => StyleSheet.cre
   },
   categoryTabsContent: {
     paddingHorizontal: Skin.space(8),
-  },
-  categoryTab: {
-    paddingHorizontal: Skin.space(12),
-    paddingVertical: Skin.space(8),
-    marginHorizontal: Skin.space(2),
-    borderRadius: Skin.radius(8),
-  },
-  categoryTabActive: {
-    backgroundColor: theme.colors.surface3 ?? theme.colors.surface2,
-  },
-  categoryTabEmoji: {
-    fontSize: Skin.font(22),
   },
   emojiGrid: {
     flex: 1,

--- a/components/Chat/EmojiPicker.tsx
+++ b/components/Chat/EmojiPicker.tsx
@@ -414,6 +414,7 @@ export function EmojiPicker({
             <SegmentedPills
               style={styles.categoryTabs}
               contentContainerStyle={styles.categoryTabsContent}
+              pillShape="rect"
               emojiSize={22}
               items={categories.map<SegmentedPillItem>(([key, category]) => ({
                 key,

--- a/components/Chat/ReactionDetailsModal.tsx
+++ b/components/Chat/ReactionDetailsModal.tsx
@@ -17,6 +17,7 @@ import { Image, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 
 import { BaseModal } from '@/components/shared';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
@@ -122,28 +123,20 @@ export function ReactionDetailsModal({
       <View style={styles.container}>
         <Text style={styles.title}>Reactions</Text>
 
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
+        <SegmentedPills
           contentContainerStyle={styles.pillsRow}
-        >
-          {reactions.map((r) => {
-            const active = selectedEmoji === r.emoji;
-            return (
-              <TouchableOpacity
-                key={r.emoji}
-                style={[styles.pill, active && styles.pillActive]}
-                onPress={() => setSelectedEmoji(active ? null : r.emoji)}
-                activeOpacity={0.7}
-              >
-                {renderEmoji(r.emoji, 'pill')}
-                <Text style={[styles.pillCount, active && styles.pillCountActive]}>
-                  {r.count}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-        </ScrollView>
+          itemRole="button"
+          allowReselect
+          items={reactions.map<SegmentedPillItem>((r) => ({
+            key: r.emoji,
+            leading: renderEmoji(r.emoji, 'pill'),
+            count: r.count,
+            accessibilityLabel: `${r.emoji} ${r.count}`,
+          }))}
+          activeKey={selectedEmoji}
+          // allowReselect surfaces a tap on the active pill; toggle it off.
+          onChange={(key) => setSelectedEmoji((prev) => (prev === key ? null : key))}
+        />
 
         <ScrollView style={styles.list} contentContainerStyle={styles.listContent}>
           {filteredRows.length === 0 ? (
@@ -207,35 +200,12 @@ function createStyles(theme: AppTheme) {
       paddingVertical: Skin.space(4),
       paddingHorizontal: Skin.space(4),
     },
-    pill: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      gap: Skin.space(6),
-      paddingHorizontal: Skin.space(12),
-      paddingVertical: Skin.space(8),
-      borderRadius: Skin.radius(16),
-      borderWidth: Skin.border(1),
-      borderColor: theme.colors.surface3,
-      backgroundColor: theme.colors.surface2,
-    },
-    pillActive: {
-      borderColor: theme.colors.accent,
-      backgroundColor: theme.colors.accent + '22',
-    },
     pillEmojiText: {
       fontSize: Skin.font(18),
     },
     pillCustomEmoji: {
       width: 20,
       height: 20,
-    },
-    pillCount: {
-      fontSize: Skin.font(14),
-      fontWeight: '600',
-      color: theme.colors.textMain,
-    },
-    pillCountActive: {
-      color: theme.colors.accent,
     },
     list: {
       flex: 1,

--- a/components/SocialFeed/views/CreateProposalSheet.tsx
+++ b/components/SocialFeed/views/CreateProposalSheet.tsx
@@ -7,8 +7,9 @@ import type {
   ProposalScope,
 } from '@/hooks/useGovernance';
 import React, { useState } from 'react';
-import { ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ScrollView, StyleSheet, Text, TextInput } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import * as Skin from '@/theme/skins/geometry';
 import { createSkinnable } from '@/theme/skins/skinnableStyleSheet';
 
@@ -113,49 +114,32 @@ export default function CreateProposalSheet({
         </Text>
 
         {/* Scope toggle */}
-        <View style={styles.segmentedControl}>
-          {(['protocol', 'client'] as const).map((s) => (
-            <TouchableOpacity
-              key={s}
-              style={[
-                styles.segment,
-                { backgroundColor: scope === s ? theme.colors.accent : theme.colors.surface3 },
-              ]}
-              onPress={() => setScope(s)}
-            >
-              <Text style={[
-                styles.segmentText,
-                { color: scope === s ? theme.colors.surface0 : theme.colors.textMuted },
-              ]}>
-                {s === 'protocol' ? 'Protocol' : 'Client'}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
+        <SegmentedPills
+          style={styles.segmentedControl}
+          variant="solid"
+          pillShape="rect"
+          scrollable={false}
+          items={[
+            { key: 'protocol', label: 'Protocol' },
+            { key: 'client', label: 'Client' },
+          ]}
+          activeKey={scope}
+          onChange={(key) => setScope(key as ProposalScope)}
+        />
 
         {/* Scope-specific fields */}
         {scope === 'protocol' ? (
           <>
             <Text style={[styles.label, { color: theme.colors.textMuted }]}>Category</Text>
-            <View style={styles.pillRow}>
-              {PROTOCOL_CATEGORIES.map((c) => (
-                <TouchableOpacity
-                  key={c.value}
-                  style={[
-                    styles.pill,
-                    { backgroundColor: category === c.value ? theme.colors.accent : theme.colors.surface3 },
-                  ]}
-                  onPress={() => setCategory(c.value)}
-                >
-                  <Text style={[
-                    styles.pillText,
-                    { color: category === c.value ? theme.colors.surface0 : theme.colors.textMuted },
-                  ]}>
-                    {c.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
+            <SegmentedPills
+              style={styles.pillRow}
+              variant="solid"
+              wrap
+              itemRole="button"
+              items={PROTOCOL_CATEGORIES.map<SegmentedPillItem>((c) => ({ key: c.value, label: c.label }))}
+              activeKey={category}
+              onChange={(key) => setCategory(key as ProtocolCategory)}
+            />
 
             <Text style={[styles.label, { color: theme.colors.textMuted }]}>Title</Text>
             <TextInput
@@ -205,25 +189,15 @@ export default function CreateProposalSheet({
         ) : (
           <>
             <Text style={[styles.label, { color: theme.colors.textMuted }]}>Client Area</Text>
-            <View style={styles.pillRow}>
-              {CLIENT_AREAS.map((a) => (
-                <TouchableOpacity
-                  key={a.value}
-                  style={[
-                    styles.pill,
-                    { backgroundColor: clientArea === a.value ? theme.colors.accent : theme.colors.surface3 },
-                  ]}
-                  onPress={() => setClientArea(a.value)}
-                >
-                  <Text style={[
-                    styles.pillText,
-                    { color: clientArea === a.value ? theme.colors.surface0 : theme.colors.textMuted },
-                  ]}>
-                    {a.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </View>
+            <SegmentedPills
+              style={styles.pillRow}
+              variant="solid"
+              wrap
+              itemRole="button"
+              items={CLIENT_AREAS.map<SegmentedPillItem>((a) => ({ key: a.value, label: a.label }))}
+              activeKey={clientArea}
+              onChange={(key) => setClientArea(key as ClientArea)}
+            />
 
             <Text style={[styles.label, { color: theme.colors.textMuted }]}>Title</Text>
             <TextInput
@@ -295,19 +269,7 @@ const styles = createSkinnable(() => StyleSheet.create({
     marginBottom: Skin.space(16),
   },
   segmentedControl: {
-    flexDirection: 'row',
-    gap: Skin.space(8),
     marginBottom: Skin.space(20),
-  },
-  segment: {
-    flex: 1,
-    paddingVertical: Skin.space(8),
-    borderRadius: Skin.radius(10),
-    alignItems: 'center',
-  },
-  segmentText: {
-    fontSize: Skin.font(14),
-    fontWeight: '600',
   },
   label: {
     fontSize: Skin.font(13),
@@ -316,18 +278,7 @@ const styles = createSkinnable(() => StyleSheet.create({
     marginTop: Skin.space(12),
   },
   pillRow: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    gap: Skin.space(8),
-  },
-  pill: {
-    paddingHorizontal: Skin.space(12),
-    paddingVertical: Skin.space(6),
-    borderRadius: Skin.radius(14),
-  },
-  pillText: {
-    fontSize: Skin.font(13),
-    fontWeight: '500',
+    marginBottom: Skin.space(4),
   },
   textInput: {
     borderRadius: Skin.radius(10),

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -11,6 +11,7 @@ import { SnapIcon } from '@/components/SocialFeed/content/SnapIcon';
 import TipModal, { type TipTarget } from '@/components/wallet/TipModal';
 import { ActionSheet, type ActionRowItem } from '@/components/shared/ActionSheet';
 import { ActionRow, ActionRowGroup } from '@/components/shared/ActionRow';
+import { useCenteredPillScroll } from '@/hooks/useCenteredPillScroll';
 import { useMiniappManifest } from '@/hooks/useMiniappManifest';
 import { useOgMetadata } from '@/hooks/useOgMetadata';
 import { SnapEmbed, useSnapDetection } from '@/components/SocialFeed/content/SnapEmbed';
@@ -5230,6 +5231,10 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
   const { regularCastByteLimit, longCastByteLimit, isPro } = useFarcasterCastLimits();
   const maxCastLength = isPro ? longCastByteLimit : regularCastByteLimit;
   const [activeFilter, setActiveFilter] = useState<FeedFilter>('all');
+  // Centre the tapped filter chip in each of the two filter rows (full + mini).
+  // The chips keep their bespoke circular/solid look; only scrolling is shared.
+  const fullFilterScroll = useCenteredPillScroll();
+  const miniFilterScroll = useCenteredPillScroll();
   const [rendered, setRendered] = useState(visible);
   const [castText, setCastText] = useState('');
   const [castCursorPosition, setCastCursorPosition] = useState(0);
@@ -6366,15 +6371,16 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
 
                 {/* Filters Row with Channel Tabs - only show when not searching */}
                 {!searchActive && (
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filtersRow}>
+                  <ScrollView {...fullFilterScroll.scrollViewProps} style={styles.filtersRow}>
                     <View style={{width:16}}/>
                     {filters.map((filter) => {
                       const isActive = activeFilter === filter.id;
                       return (
                         <TouchableOpacity
                           key={filter.id}
+                          onLayout={fullFilterScroll.onItemLayout(filter.id)}
                           style={[styles.filterChip, isActive && styles.filterChipActive]}
-                          onPress={() => setActiveFilter(filter.id)}
+                          onPress={() => { setActiveFilter(filter.id); fullFilterScroll.center(filter.id); }}
                         >
                           <IconSymbol
                             name={filter.icon}
@@ -6555,7 +6561,7 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
                       The icon alone carries the meaning ("All" =
                       rectangle stack, "Media" = play.rectangle, etc.),
                       and the active state is shown by filled background. */}
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.filtersRow}>
+                  <ScrollView {...miniFilterScroll.scrollViewProps} style={styles.filtersRow}>
                     <View style={{width:16}}/>
                     {filters.map((filter) => {
                       const isActive = activeFilter === filter.id;
@@ -6563,8 +6569,9 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
                         <TouchableOpacity
                           key={filter.id}
                           accessibilityLabel={filter.label}
+                          onLayout={miniFilterScroll.onItemLayout(filter.id)}
                           style={[styles.filterChip, isActive && styles.filterChipActive]}
-                          onPress={() => setActiveFilter(filter.id)}
+                          onPress={() => { setActiveFilter(filter.id); miniFilterScroll.center(filter.id); }}
                         >
                           <IconSymbol
                             name={filter.icon}

--- a/components/SpaceModal.tsx
+++ b/components/SpaceModal.tsx
@@ -20,6 +20,7 @@ import { useWebSocket } from '@/context/WebSocketContext';
 import { useToast } from '@/context/ToastContext';
 import { haptics } from '@/utils/haptics';
 import * as Skin from '@/theme/skins/geometry';
+import { SegmentedPills } from '@/components/ui/SegmentedPills';
 import {
   validateSpaceName,
   validateSpaceDescription,
@@ -204,24 +205,16 @@ export default function SpaceModal({
   }, [onClose]);
 
   const renderTabs = () => (
-    <View style={styles.tabContainer}>
-      <TouchableOpacity
-        style={[styles.tab, activeTab === 'join' && styles.tabActive]}
-        onPress={() => setActiveTab('join')}
-      >
-        <Text style={[styles.tabText, activeTab === 'join' && styles.tabTextActive]}>
-          Join
-        </Text>
-      </TouchableOpacity>
-      <TouchableOpacity
-        style={[styles.tab, activeTab === 'create' && styles.tabActive]}
-        onPress={() => setActiveTab('create')}
-      >
-        <Text style={[styles.tabText, activeTab === 'create' && styles.tabTextActive]}>
-          Create
-        </Text>
-      </TouchableOpacity>
-    </View>
+    <SegmentedPills
+      style={styles.tabContainer}
+      scrollable={false}
+      items={[
+        { key: 'join', label: 'Join' },
+        { key: 'create', label: 'Create' },
+      ]}
+      activeKey={activeTab}
+      onChange={(key) => setActiveTab(key as TabType)}
+    />
   );
 
   const renderCreateTab = () => (
@@ -466,29 +459,10 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       color: theme.colors.textStrong,
     },
     tabContainer: {
-      flexDirection: 'row',
       backgroundColor: theme.colors.surface3,
       borderRadius: Skin.radius(12),
       padding: Skin.space(4),
       marginBottom: Skin.space(20),
-    },
-    tab: {
-      flex: 1,
-      paddingVertical: Skin.space(10),
-      alignItems: 'center',
-      borderRadius: Skin.radius(8),
-    },
-    tabActive: {
-      backgroundColor: theme.colors.surface1,
-    },
-    tabText: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMuted,
-    },
-    tabTextActive: {
-      color: theme.colors.textStrong,
     },
     tabContent: {
       flex: 1,

--- a/components/SpaceModal.tsx
+++ b/components/SpaceModal.tsx
@@ -208,6 +208,7 @@ export default function SpaceModal({
     <SegmentedPills
       style={styles.tabContainer}
       scrollable={false}
+      pillShape="rect"
       items={[
         { key: 'join', label: 'Join' },
         { key: 'create', label: 'Create' },

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -2403,6 +2403,7 @@ export default function SpaceSettingsModal({
         {/* Tab bar */}
         <SegmentedPills
           style={styles.tabBar}
+          pillShape="rect"
           items={tabs.map<SegmentedPillItem>((tab) => ({
             key: tab.key,
             label: tab.label,

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -20,6 +20,7 @@ import ShareInviteSheet from '@/components/ShareInviteSheet';
 import { BaseModal, TypeToConfirmModal } from '@/components/shared';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { ChannelSettingsSheet, type ChannelSettingsTarget } from '@/components/Chat/ChannelSettingsSheet';
 import { ChannelStatusGlyphs } from '@/components/Chat/ChannelStatusGlyphs';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
@@ -2400,41 +2401,17 @@ export default function SpaceSettingsModal({
         </View>
 
         {/* Tab bar */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
+        <SegmentedPills
           style={styles.tabBar}
-          contentContainerStyle={styles.tabBarContent}
-        >
-          {tabs.map((tab) => (
-            <TouchableOpacity
-              key={tab.key}
-              style={[styles.tab, activeTab === tab.key && styles.tabActive]}
-              onPress={() => setActiveTab(tab.key)}
-            >
-              <IconSymbol
-                name={tab.icon as IconSymbolName}
-                size={18}
-                color={
-                  activeTab === tab.key
-                    ? tab.key === 'danger'
-                      ? theme.colors.danger
-                      : theme.colors.primary
-                    : theme.colors.textMuted
-                }
-              />
-              <Text
-                style={[
-                  styles.tabText,
-                  activeTab === tab.key && styles.tabTextActive,
-                  tab.key === 'danger' && activeTab === tab.key && { color: theme.colors.danger },
-                ]}
-              >
-                {tab.label}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
+          items={tabs.map<SegmentedPillItem>((tab) => ({
+            key: tab.key,
+            label: tab.label,
+            icon: tab.icon as IconSymbolName,
+            danger: tab.key === 'danger',
+          }))}
+          activeKey={activeTab}
+          onChange={(key) => setActiveTab(key as TabType)}
+        />
 
         {/* Tab content */}
         {renderTabContent()}
@@ -2509,33 +2486,7 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       marginTop: Skin.space(4),
     },
     tabBar: {
-      flexGrow: 0,
       marginBottom: Skin.space(16),
-    },
-    tabBarContent: {
-      gap: Skin.space(8),
-      paddingHorizontal: Skin.space(4),
-    },
-    tab: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(8),
-      paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(8),
-      backgroundColor: theme.colors.surface3,
-      gap: Skin.space(6),
-    },
-    tabActive: {
-      backgroundColor: theme.colors.surface1,
-    },
-    tabText: {
-      fontSize: Skin.font(13),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMuted,
-    },
-    tabTextActive: {
-      color: theme.colors.primary,
     },
     tabContent: {
       flex: 1,

--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -425,74 +425,33 @@ export default function WalletModal({ visible, onClose, isRouteMode = false, noT
           ScrollView for explicit reloads. */}
       {hasWarpcastWallet && (
         <View style={styles.header}>
-          <View style={styles.walletSwitcher}>
-            <TouchableOpacity
-              style={[
-                styles.walletSwitcherOption,
-                activeType === 'builtin' && styles.walletSwitcherOptionActive,
-              ]}
-              onPress={() => switchWallet('builtin')}
-            >
-              <Text style={[
-                styles.walletSwitcherText,
-                activeType === 'builtin' && styles.walletSwitcherTextActive,
-              ]}>
-                Quorum
-              </Text>
-            </TouchableOpacity>
-            <TouchableOpacity
-              style={[
-                styles.walletSwitcherOption,
-                activeType === 'warpcast' && styles.walletSwitcherOptionActive,
-              ]}
-              onPress={() => switchWallet('warpcast')}
-            >
-              <Text style={[
-                styles.walletSwitcherText,
-                activeType === 'warpcast' && styles.walletSwitcherTextActive,
-              ]}>
-                Warpcast
-              </Text>
-            </TouchableOpacity>
-          </View>
+          <SegmentedPills
+            variant="segmented"
+            scrollable={false}
+            items={[
+              { key: 'builtin', label: 'Quorum' },
+              { key: 'warpcast', label: 'Warpcast' },
+            ]}
+            activeKey={activeType}
+            onChange={(key) => switchWallet(key as 'builtin' | 'warpcast')}
+          />
         </View>
       )}
 
       {/* Tab Switcher */}
-      <View style={styles.tabSwitcher}>
-        <TouchableOpacity
-          style={[styles.tabButton, activeTab === 'assets' && styles.tabButtonActive]}
-          onPress={() => setActiveTab('assets')}
-        >
-          <Text numberOfLines={1} style={[styles.tabButtonText, activeTab === 'assets' && styles.tabButtonTextActive]}>
-            Assets
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tabButton, activeTab === 'collectibles' && styles.tabButtonActive]}
-          onPress={() => setActiveTab('collectibles')}
-        >
-          <Text numberOfLines={1} style={[styles.tabButtonText, activeTab === 'collectibles' && styles.tabButtonTextActive]}>
-            Collectibles
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tabButton, activeTab === 'addresses' && styles.tabButtonActive]}
-          onPress={() => setActiveTab('addresses')}
-        >
-          <Text numberOfLines={1} style={[styles.tabButtonText, activeTab === 'addresses' && styles.tabButtonTextActive]}>
-            Addresses
-          </Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tabButton, activeTab === 'history' && styles.tabButtonActive]}
-          onPress={() => setActiveTab('history')}
-        >
-          <Text numberOfLines={1} style={[styles.tabButtonText, activeTab === 'history' && styles.tabButtonTextActive]}>
-            History
-          </Text>
-        </TouchableOpacity>
-      </View>
+      <SegmentedPills
+        style={styles.tabSwitcher}
+        variant="segmented"
+        scrollable={false}
+        items={[
+          { key: 'assets', label: 'Assets' },
+          { key: 'collectibles', label: 'Collectibles' },
+          { key: 'addresses', label: 'Addresses' },
+          { key: 'history', label: 'History' },
+        ]}
+        activeKey={activeTab}
+        onChange={(key) => setActiveTab(key as typeof activeTab)}
+      />
 
       <ScrollView
         showsVerticalScrollIndicator={false}
@@ -1316,62 +1275,13 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       ...theme.textStyles.title3,
       color: theme.colors.textMain,
     },
-    walletSwitcher: {
-      flexDirection: 'row',
-      backgroundColor: theme.colors.surface2,
-      borderRadius: Skin.radius(8),
-      padding: Skin.space(2),
-    },
-    walletSwitcherOption: {
-      paddingHorizontal: Skin.space(10),
-      paddingVertical: Skin.space(4),
-      borderRadius: Skin.radius(6),
-    },
-    walletSwitcherOptionActive: {
-      backgroundColor: theme.colors.background,
-    },
-    walletSwitcherText: {
-      ...theme.textStyles.caption1,
-      color: theme.colors.textMuted,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    walletSwitcherTextActive: {
-      color: theme.colors.textMain,
-    },
     scrollContent: {
       flex: 1,
       paddingHorizontal: Skin.space(20),
     },
     tabSwitcher: {
-      flexDirection: 'row',
       marginHorizontal: Skin.space(20),
       marginBottom: Skin.space(12),
-      backgroundColor: theme.colors.surface2,
-      borderRadius: Skin.radius(12),
-      padding: Skin.space(3),
-      justifyContent: 'space-between',
-    },
-    tabButton: {
-      paddingVertical: Skin.space(7),
-      paddingHorizontal: Skin.space(10),
-      alignItems: 'center',
-      borderRadius: Skin.radius(9),
-      flex: 1,
-    },
-    tabButtonActive: {
-      backgroundColor: theme.colors.background,
-    },
-    tabButtonText: {
-      ...theme.textStyles.footnote,
-      color: theme.colors.textMuted,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    tabButtonTextActive: {
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.bold.fontFamily,
-      fontWeight: theme.fonts.bold.fontWeight,
     },
     evmOnlyNote: {
       flexDirection: 'row',

--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -31,6 +31,7 @@ import HistoryTab from '@/components/wallet/HistoryTab';
 import AssetDetailModal from '@/components/wallet/AssetDetailModal';
 import NFTDetailModal from '@/components/wallet/NFTDetailModal';
 import * as Skin from '@/theme/skins/geometry';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 
 // Storage for wallet display preferences
 const walletDisplayStorage = createMMKV({ id: 'quorum-wallet-display' });
@@ -573,34 +574,20 @@ export default function WalletModal({ visible, onClose, isRouteMode = false, noT
             )}
 
             {/* Chain Filter Pills */}
-            <ScrollView
-              horizontal
-              showsHorizontalScrollIndicator={false}
+            <SegmentedPills
               style={styles.filterContainer}
               contentContainerStyle={styles.filterContent}
-            >
-              {chainFilters.map((chain) => (
-                <TouchableOpacity
-                  key={chain}
-                  style={[
-                    styles.filterPill,
-                    chainFilter === chain && styles.filterPillActive,
-                    chainFilter === chain && chain !== 'all' && { backgroundColor: getChainColor(chain) + '20' },
-                  ]}
-                  onPress={() => setChainFilter(chain)}
-                >
-                  <Text
-                    style={[
-                      styles.filterPillText,
-                      chainFilter === chain && styles.filterPillTextActive,
-                      chainFilter === chain && chain !== 'all' && { color: getChainColor(chain) },
-                    ]}
-                  >
-                    {chain === 'all' ? 'All Networks' : getChainName(chain)}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </ScrollView>
+              itemRole="button"
+              items={chainFilters.map<SegmentedPillItem>((chain) => ({
+                key: chain,
+                label: chain === 'all' ? 'All Networks' : getChainName(chain),
+                // Per-chain brand color drives the active tint (the 'all' pill
+                // falls back to the theme accent).
+                accentColor: chain === 'all' ? undefined : getChainColor(chain),
+              }))}
+              activeKey={chainFilter}
+              onChange={setChainFilter}
+            />
 
             {/* Loading State - hide after 5 seconds */}
             {showLoadingSpinner && ((activeType === 'builtin' && isLoading && !balances) ||
@@ -1407,25 +1394,6 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
     },
     filterContent: {
       paddingHorizontal: Skin.space(20),
-      gap: Skin.space(8),
-    },
-    filterPill: {
-      paddingHorizontal: Skin.space(14),
-      paddingVertical: Skin.space(8),
-      borderRadius: Skin.radius(20),
-      backgroundColor: theme.colors.surface2,
-    },
-    filterPillActive: {
-      backgroundColor: theme.colors.primary + '20',
-    },
-    filterPillText: {
-      fontSize: Skin.font(13),
-      color: theme.colors.textMuted,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    filterPillTextActive: {
-      color: theme.colors.primary,
     },
     loadingContainer: {
       alignItems: 'center',

--- a/components/WalletModal.tsx
+++ b/components/WalletModal.tsx
@@ -577,6 +577,7 @@ export default function WalletModal({ visible, onClose, isRouteMode = false, noT
             <SegmentedPills
               style={styles.filterContainer}
               contentContainerStyle={styles.filterContent}
+              variant="solid"
               itemRole="button"
               items={chainFilters.map<SegmentedPillItem>((chain) => ({
                 key: chain,

--- a/components/qns/AuctionDetailModal.tsx
+++ b/components/qns/AuctionDetailModal.tsx
@@ -35,6 +35,7 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
 import { ActivityIndicator, Alert, FlatList, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -339,27 +340,19 @@ export default function AuctionDetailModal({
             {/* Chain Selector */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Payment Network</Text>
-              <View style={styles.chainSelector}>
-                {availableChains.map(chain => (
-                  <TouchableOpacity
-                    key={chain.name}
-                    style={[
-                      styles.chainOption,
-                      selectedChain === chain.name && styles.chainOptionSelected,
-                      selectedChain === chain.name && { borderColor: getChainColor(chain.name) },
-                    ]}
-                    onPress={() => setSelectedChain(chain.name)}
-                  >
-                    <View style={[styles.chainDot, { backgroundColor: getChainColor(chain.name) }]} />
-                    <Text style={[
-                      styles.chainOptionText,
-                      selectedChain === chain.name && styles.chainOptionTextSelected,
-                    ]}>
-                      {chain.name.charAt(0).toUpperCase() + chain.name.slice(1)}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
+              <SegmentedPills
+                style={styles.chainSelector}
+                variant="solid"
+                wrap
+                itemRole="button"
+                items={availableChains.map<SegmentedPillItem>(chain => ({
+                  key: chain.name,
+                  label: chain.name.charAt(0).toUpperCase() + chain.name.slice(1),
+                  accentColor: getChainColor(chain.name),
+                }))}
+                activeKey={selectedChain}
+                onChange={setSelectedChain}
+              />
               <Text style={styles.balanceText}>
                 Balance: {userBalance} {tokenSymbol}
               </Text>
@@ -515,30 +508,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       color: theme.colors.textMain,
     },
     chainSelector: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
       gap: Skin.space(8),
-    },
-    chainOption: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(8),
-      paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(8),
-      backgroundColor: theme.colors.surface2,
-      borderWidth: Skin.border(2),
-      borderColor: 'transparent',
-      gap: Skin.space(6),
-    },
-    chainOptionSelected: {
-      backgroundColor: isDark ? 'theme.colors.accentSoft' : 'theme.colors.accentSubtle',
-    },
-    chainDot: { width: 8, height: 8, borderRadius: Skin.radius(4) },
-    chainOptionText: { fontSize: Skin.font(13), color: theme.colors.textMuted },
-    chainOptionTextSelected: {
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
     },
     balanceText: {
       fontSize: Skin.font(13),

--- a/components/qns/BuyNameModal.tsx
+++ b/components/qns/BuyNameModal.tsx
@@ -20,6 +20,7 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -253,29 +254,19 @@ export default function BuyNameModal({
             {/* Chain Selector */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Payment Network</Text>
-              <View style={styles.chainSelector}>
-                {availableChains.map(chain => (
-                  <TouchableOpacity
-                    key={chain.name}
-                    style={[
-                      styles.chainOption,
-                      selectedChain === chain.name && styles.chainOptionSelected,
-                      selectedChain === chain.name && { borderColor: getChainColor(chain.name) },
-                    ]}
-                    onPress={() => setSelectedChain(chain.name)}
-                  >
-                    <View style={[styles.chainDot, { backgroundColor: getChainColor(chain.name) }]} />
-                    <Text
-                      style={[
-                        styles.chainOptionText,
-                        selectedChain === chain.name && styles.chainOptionTextSelected,
-                      ]}
-                    >
-                      {chain.name.charAt(0).toUpperCase() + chain.name.slice(1)}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
+              <SegmentedPills
+                style={styles.chainSelector}
+                variant="solid"
+                wrap
+                itemRole="button"
+                items={availableChains.map<SegmentedPillItem>(chain => ({
+                  key: chain.name,
+                  label: chain.name.charAt(0).toUpperCase() + chain.name.slice(1),
+                  accentColor: getChainColor(chain.name),
+                }))}
+                activeKey={selectedChain}
+                onChange={setSelectedChain}
+              />
             </View>
 
             {/* Fee Breakdown */}
@@ -408,37 +399,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       letterSpacing: 0.5,
     },
     chainSelector: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
       gap: Skin.space(8),
-    },
-    chainOption: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(8),
-      paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(8),
-      backgroundColor: theme.colors.surface2,
-      borderWidth: Skin.border(2),
-      borderColor: 'transparent',
-      gap: Skin.space(6),
-    },
-    chainOptionSelected: {
-      backgroundColor: isDark ? 'theme.colors.accentSoft' : 'theme.colors.accentSubtle',
-    },
-    chainDot: {
-      width: 8,
-      height: 8,
-      borderRadius: Skin.radius(4),
-    },
-    chainOptionText: {
-      fontSize: Skin.font(13),
-      color: theme.colors.textMuted,
-    },
-    chainOptionTextSelected: {
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
     },
     priceBreakdown: {
       backgroundColor: theme.colors.surface2,

--- a/components/qns/MarketplaceModal.tsx
+++ b/components/qns/MarketplaceModal.tsx
@@ -11,6 +11,7 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
 import { ActivityIndicator, FlatList, RefreshControl, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills } from '@/components/ui/SegmentedPills';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import BuyNameModal from './BuyNameModal';
 import * as Skin from '@/theme/skins/geometry';
@@ -202,19 +203,18 @@ export default function MarketplaceModal({
 
         {/* Sort Options */}
         <View style={styles.sortContainer}>
-          {(['newest', 'price_low', 'price_high'] as SortOption[]).map(option => (
-            <TouchableOpacity
-              key={option}
-              style={[styles.sortChip, sortBy === option && styles.sortChipActive]}
-              onPress={() => setSortBy(option)}
-            >
-              <Text
-                style={[styles.sortChipText, sortBy === option && styles.sortChipTextActive]}
-              >
-                {option === 'newest' ? 'Newest' : option === 'price_low' ? 'Price ↑' : 'Price ↓'}
-              </Text>
-            </TouchableOpacity>
-          ))}
+          <SegmentedPills
+            variant="solid"
+            wrap
+            itemRole="button"
+            items={[
+              { key: 'newest', label: 'Newest' },
+              { key: 'price_low', label: 'Price ↑' },
+              { key: 'price_high', label: 'Price ↓' },
+            ]}
+            activeKey={sortBy}
+            onChange={(key) => setSortBy(key as SortOption)}
+          />
           {resaleInfo && (
             <Text style={styles.feeInfo}>{resaleInfo.platform_fee_percent}% fee</Text>
           )}
@@ -294,27 +294,6 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       paddingHorizontal: Skin.space(20),
       marginBottom: Skin.space(12),
       gap: Skin.space(8),
-    },
-    sortChip: {
-      paddingVertical: Skin.space(6),
-      paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(16),
-      backgroundColor: theme.colors.surface2,
-      borderWidth: Skin.border(1),
-      borderColor: theme.colors.surface3,
-    },
-    sortChipActive: {
-      backgroundColor: theme.colors.primary,
-      borderColor: theme.colors.primary,
-    },
-    sortChipText: {
-      fontSize: Skin.font(12),
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    sortChipTextActive: {
-      color: '#fff',
     },
     feeInfo: {
       fontSize: Skin.font(11),

--- a/components/qns/OffersModal.tsx
+++ b/components/qns/OffersModal.tsx
@@ -411,6 +411,7 @@ export default function OffersModal({
       <SegmentedPills
         style={styles.tabs}
         scrollable={false}
+        pillShape="rect"
         items={[
           {
             key: 'received',

--- a/components/qns/OffersModal.tsx
+++ b/components/qns/OffersModal.tsx
@@ -29,6 +29,7 @@ import { ActivityIndicator, Alert, FlatList, RefreshControl, StyleSheet, Text, V
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 
 interface OffersModalProps {
   visible: boolean;
@@ -393,6 +394,10 @@ export default function OffersModal({
     </View>
   );
 
+  const pendingReceivedCount = receivedOffers
+    ? receivedOffers.filter((o) => o.state === 'pending').length
+    : 0;
+
   return (
     <BaseModal visible={visible} onClose={onClose} height={0.85} fillHeight>
       <View style={styles.header}>
@@ -403,31 +408,25 @@ export default function OffersModal({
       </View>
 
       {/* Tabs */}
-      <View style={styles.tabs}>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'received' && styles.tabActive]}
-          onPress={() => setActiveTab('received')}
-        >
-          <Text style={[styles.tabText, activeTab === 'received' && styles.tabTextActive]}>
-            Received
-          </Text>
-          {receivedOffers && receivedOffers.filter(o => o.state === 'pending').length > 0 && (
-            <View style={styles.tabBadge}>
-              <Text style={styles.tabBadgeText}>
-                {receivedOffers.filter(o => o.state === 'pending').length}
-              </Text>
-            </View>
-          )}
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'sent' && styles.tabActive]}
-          onPress={() => setActiveTab('sent')}
-        >
-          <Text style={[styles.tabText, activeTab === 'sent' && styles.tabTextActive]}>
-            Sent
-          </Text>
-        </TouchableOpacity>
-      </View>
+      <SegmentedPills
+        style={styles.tabs}
+        scrollable={false}
+        items={[
+          {
+            key: 'received',
+            label: 'Received',
+            trailing:
+              pendingReceivedCount > 0 ? (
+                <View style={styles.tabBadge}>
+                  <Text style={styles.tabBadgeText}>{pendingReceivedCount}</Text>
+                </View>
+              ) : undefined,
+          },
+          { key: 'sent', label: 'Sent' } as SegmentedPillItem,
+        ]}
+        activeKey={activeTab}
+        onChange={(key) => setActiveTab(key as TabType)}
+      />
 
       <FlatList
         data={currentOffers ?? []}
@@ -464,38 +463,11 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       color: theme.colors.textMain,
     },
     tabs: {
-      flexDirection: 'row',
       paddingHorizontal: Skin.space(20),
       marginBottom: Skin.space(12),
-      gap: Skin.space(8),
-    },
-    tab: {
-      flex: 1,
-      flexDirection: 'row',
-      justifyContent: 'center',
-      alignItems: 'center',
-      paddingVertical: Skin.space(10),
-      borderRadius: Skin.radius(10),
-      backgroundColor: theme.colors.surface2,
-      borderWidth: Skin.border(1),
-      borderColor: theme.colors.surface3,
-      gap: Skin.space(6),
-    },
-    tabActive: {
-      backgroundColor: theme.colors.primary,
-      borderColor: theme.colors.primary,
-    },
-    tabText: {
-      fontSize: Skin.font(14),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
-    },
-    tabTextActive: {
-      color: '#fff',
     },
     tabBadge: {
-      backgroundColor: '#fff',
+      backgroundColor: theme.colors.accent,
       borderRadius: Skin.radius(10),
       minWidth: 18,
       height: 18,
@@ -507,7 +479,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       fontSize: Skin.font(11),
       fontFamily: theme.fonts.bold.fontFamily,
       fontWeight: theme.fonts.bold.fontWeight,
-      color: theme.colors.primary,
+      color: theme.colors.surface0,
     },
     listContent: {
       paddingHorizontal: Skin.space(20),

--- a/components/qns/RegisterPaymentModal.tsx
+++ b/components/qns/RegisterPaymentModal.tsx
@@ -21,6 +21,7 @@ import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -260,55 +261,34 @@ export default function RegisterPaymentModal({
             {/* Token Selector */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Payment Token</Text>
-              <View style={styles.tokenSelector}>
-                {AVAILABLE_TOKENS.map(token => (
-                  <TouchableOpacity
-                    key={token}
-                    style={[
-                      styles.tokenOption,
-                      selectedToken === token && styles.tokenOptionSelected,
-                    ]}
-                    onPress={() => setSelectedToken(token)}
-                  >
-                    <Text
-                      style={[
-                        styles.tokenOptionText,
-                        selectedToken === token && styles.tokenOptionTextSelected,
-                      ]}
-                    >
-                      {token}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
+              <SegmentedPills
+                style={styles.tokenSelector}
+                variant="tinted"
+                pillShape="rect"
+                scrollable={false}
+                itemRole="button"
+                items={AVAILABLE_TOKENS.map<SegmentedPillItem>(token => ({ key: token, label: token }))}
+                activeKey={selectedToken}
+                onChange={(key) => setSelectedToken(key as 'wQUIL' | 'USDC')}
+              />
             </View>
 
             {/* Chain Selector */}
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Network</Text>
-              <View style={styles.chainSelector}>
-                {availableChains.map(chain => (
-                  <TouchableOpacity
-                    key={chain.name}
-                    style={[
-                      styles.chainOption,
-                      selectedChain === chain.name && styles.chainOptionSelected,
-                      selectedChain === chain.name && { borderColor: getChainColor(chain.name) },
-                    ]}
-                    onPress={() => setSelectedChain(chain.name)}
-                  >
-                    <View style={[styles.chainDot, { backgroundColor: getChainColor(chain.name) }]} />
-                    <Text
-                      style={[
-                        styles.chainOptionText,
-                        selectedChain === chain.name && styles.chainOptionTextSelected,
-                      ]}
-                    >
-                      {chain.name.charAt(0).toUpperCase() + chain.name.slice(1)}
-                    </Text>
-                  </TouchableOpacity>
-                ))}
-              </View>
+              <SegmentedPills
+                style={styles.chainSelector}
+                variant="solid"
+                wrap
+                itemRole="button"
+                items={availableChains.map<SegmentedPillItem>(chain => ({
+                  key: chain.name,
+                  label: chain.name.charAt(0).toUpperCase() + chain.name.slice(1),
+                  accentColor: getChainColor(chain.name),
+                }))}
+                activeKey={selectedChain}
+                onChange={setSelectedChain}
+              />
             </View>
 
             {/* Price Breakdown */}
@@ -429,64 +409,10 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       letterSpacing: 0.5,
     },
     tokenSelector: {
-      flexDirection: 'row',
       gap: Skin.space(8),
-    },
-    tokenOption: {
-      flex: 1,
-      paddingVertical: Skin.space(12),
-      paddingHorizontal: Skin.space(16),
-      borderRadius: Skin.radius(10),
-      backgroundColor: theme.colors.surface2,
-      alignItems: 'center',
-      borderWidth: Skin.border(2),
-      borderColor: 'transparent',
-    },
-    tokenOptionSelected: {
-      borderColor: theme.colors.primary,
-      backgroundColor: isDark ? 'theme.colors.accentSoft' : 'theme.colors.accentSubtle',
-    },
-    tokenOptionText: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMuted,
-    },
-    tokenOptionTextSelected: {
-      color: theme.colors.primary,
     },
     chainSelector: {
-      flexDirection: 'row',
-      flexWrap: 'wrap',
       gap: Skin.space(8),
-    },
-    chainOption: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(8),
-      paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(8),
-      backgroundColor: theme.colors.surface2,
-      borderWidth: Skin.border(2),
-      borderColor: 'transparent',
-      gap: Skin.space(6),
-    },
-    chainOptionSelected: {
-      backgroundColor: isDark ? 'theme.colors.accentSoft' : 'theme.colors.accentSubtle',
-    },
-    chainDot: {
-      width: 8,
-      height: 8,
-      borderRadius: Skin.radius(4),
-    },
-    chainOptionText: {
-      fontSize: Skin.font(13),
-      color: theme.colors.textMuted,
-    },
-    chainOptionTextSelected: {
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
     },
     priceBreakdown: {
       backgroundColor: theme.colors.surface2,

--- a/components/ui/SegmentedPills.tsx
+++ b/components/ui/SegmentedPills.tsx
@@ -1,0 +1,268 @@
+// SegmentedPills — a horizontal row of selectable "pill" chips used inside
+// modals for filters / tab selectors. Replaces the per-modal hand-rolled pill
+// rows, giving one consistent active state and (optionally) auto-centring the
+// tapped pill.
+//
+// Active-state standard (the fix for the "invisible active pill" problem):
+//   - variant 'tinted' (default): active background = theme.colors.accentSoft
+//     (12% accent), active text/icon = accent (or per-item accentColor, or
+//     danger). Inactive = surface3 / textMuted.
+//   - variant 'solid': active background = full accent (or accentColor),
+//     active text/icon = surface0. For stronger looks (e.g. round icon chips).
+//
+// Built options-array driven (like the shared RadioGroup/Select primitives) and
+// with a Base/Native-style prop split so it can later be promoted to
+// quorum-shared/src/primitives/SegmentedControl with a .web.tsx sibling without
+// a rewrite. See .agents/tasks/2026-06-17-horizontal-pill-menu-ux-improvements.md
+
+import React from 'react';
+import {
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+  type StyleProp,
+  type ViewStyle,
+} from 'react-native';
+import * as Haptics from 'expo-haptics';
+import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { useTheme } from '@/theme';
+import * as Skin from '@/theme/skins/geometry';
+import { useCenteredPillScroll } from '@/hooks/useCenteredPillScroll';
+
+export type SegmentedPillsVariant = 'tinted' | 'solid';
+
+export interface SegmentedPillItem {
+  /** Stable identifier; also the value passed to onChange. */
+  key: string;
+  /** Text label (omit for icon-only / emoji-only chips). */
+  label?: string;
+  /** Icon glyph rendered left of the label (or alone if no label). */
+  icon?: IconSymbolName;
+  /** Emoji glyph rendered left of the label/count (for reaction pills). */
+  emoji?: string;
+  /** Arbitrary leading content (e.g. a custom-emoji <Image>), rendered before
+   *  the label/count. Takes precedence over `icon`/`emoji` when provided. */
+  leading?: React.ReactNode;
+  /** A count shown after the emoji/label (for reaction pills). */
+  count?: number;
+  /** Arbitrary trailing content (e.g. a styled count badge), rendered after
+   *  the label/count. */
+  trailing?: React.ReactNode;
+  /** Per-item active color override (e.g. chain brand colors). */
+  accentColor?: string;
+  /** Use the danger color for the active state (e.g. a "Danger" tab). */
+  danger?: boolean;
+  /** Accessibility label; falls back to `label`. */
+  accessibilityLabel?: string;
+}
+
+interface BaseSegmentedPillsProps {
+  items: SegmentedPillItem[];
+  /** Currently selected key, or null when nothing is selected. */
+  activeKey: string | null;
+  onChange: (key: string) => void;
+  variant?: SegmentedPillsVariant;
+  /** Horizontal scroll (default) vs a fixed flex row that fits the width. */
+  scrollable?: boolean;
+  /** Auto-scroll the tapped pill toward centre (scrollable rows only). */
+  centerOnSelect?: boolean;
+  /** Tapping the active pill calls onChange with the same key (caller may
+   *  treat that as a toggle-off). */
+  allowReselect?: boolean;
+  /** Accessibility role for each pill: 'tab' for tab bars, 'button' for filters. */
+  itemRole?: 'tab' | 'button';
+  /** Font size for `item.emoji` glyphs (default 16; emoji-tab rows use ~22). */
+  emojiSize?: number;
+  /** Icon size for `item.icon` glyphs (default 16). */
+  iconSize?: number;
+  style?: StyleProp<ViewStyle>;
+  contentContainerStyle?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export interface NativeSegmentedPillsProps extends BaseSegmentedPillsProps {
+  /** Light selection haptic on tap (default true). */
+  hapticFeedback?: boolean;
+}
+
+export type SegmentedPillsProps = NativeSegmentedPillsProps;
+
+export function SegmentedPills({
+  items,
+  activeKey,
+  onChange,
+  variant = 'tinted',
+  scrollable = true,
+  centerOnSelect = true,
+  allowReselect = false,
+  itemRole = 'tab',
+  emojiSize = 16,
+  iconSize = 16,
+  hapticFeedback = true,
+  style,
+  contentContainerStyle,
+  testID,
+}: SegmentedPillsProps) {
+  const { theme } = useTheme();
+  const styles = makeStyles(theme);
+  const pills = useCenteredPillScroll();
+
+  const handlePress = (item: SegmentedPillItem) => {
+    const isActive = item.key === activeKey;
+    if (isActive && !allowReselect) return;
+    if (hapticFeedback) Haptics.selectionAsync();
+    onChange(item.key);
+    if (scrollable && centerOnSelect) pills.center(item.key);
+  };
+
+  const renderPill = (item: SegmentedPillItem) => {
+    const isActive = item.key === activeKey;
+    const itemAccent = item.danger ? theme.colors.danger : item.accentColor ?? theme.colors.primary;
+
+    // Foreground (text + icon) color.
+    const fg = isActive
+      ? variant === 'solid'
+        ? theme.colors.surface0
+        : itemAccent
+      : theme.colors.textMuted;
+
+    // Background.
+    const activeBg =
+      variant === 'solid'
+        ? itemAccent
+        : // tinted: prefer the accentSoft token; if a per-item accentColor is
+          // set, derive a matching low-alpha tint from it.
+          item.accentColor || item.danger
+          ? withAlpha(itemAccent, 0.12)
+          : theme.colors.accentSoft;
+
+    const pillStyle = [
+      styles.pill,
+      // In a fixed (non-scrolling) row, pills share the width equally so the row
+      // reads as a segmented control, matching the existing Join/Create tabs.
+      !scrollable ? styles.pillFlex : null,
+      isActive
+        ? { backgroundColor: activeBg }
+        : { backgroundColor: theme.colors.surface3 },
+      // A subtle border on the active tinted pill reads better on light skins
+      // where accentSoft alone is faint.
+      isActive && variant === 'tinted' ? { borderColor: itemAccent } : null,
+    ];
+
+    return (
+      <Pressable
+        key={item.key}
+        onLayout={pills.onItemLayout(item.key)}
+        onPress={() => handlePress(item)}
+        style={({ pressed }) => [pillStyle, pressed && styles.pressed]}
+        accessibilityRole={itemRole}
+        accessibilityState={{ selected: isActive }}
+        accessibilityLabel={item.accessibilityLabel ?? item.label}
+        hitSlop={6}
+      >
+        {item.leading != null ? (
+          item.leading
+        ) : item.icon ? (
+          <IconSymbol name={item.icon} size={iconSize} color={fg} />
+        ) : item.emoji ? (
+          <Text style={[styles.emoji, { fontSize: Skin.font(emojiSize) }]}>{item.emoji}</Text>
+        ) : null}
+        {item.label ? (
+          <Text style={[styles.label, { color: fg }]} numberOfLines={1}>
+            {item.label}
+          </Text>
+        ) : null}
+        {typeof item.count === 'number' ? (
+          <Text style={[styles.count, { color: fg }]}>{item.count}</Text>
+        ) : null}
+        {item.trailing != null ? item.trailing : null}
+      </Pressable>
+    );
+  };
+
+  if (!scrollable) {
+    return (
+      <View style={[styles.fixedRow, style, contentContainerStyle]} testID={testID}>
+        {items.map(renderPill)}
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView
+      {...pills.scrollViewProps}
+      style={[styles.scroll, style]}
+      contentContainerStyle={[styles.scrollContent, contentContainerStyle]}
+      testID={testID}
+    >
+      {items.map(renderPill)}
+    </ScrollView>
+  );
+}
+
+// Append an alpha to a hex color. Mirrors theme.themes.withAlpha for the
+// per-item accentColor case (where we don't have a pre-computed soft token).
+function withAlpha(hex: string, alpha: number): string {
+  // Only handles #RGB / #RRGGBB; passes through rgba()/named colors unchanged
+  // (callers pass hex chain colors and theme hex tokens).
+  if (!hex.startsWith('#')) return hex;
+  let r: number, g: number, b: number;
+  if (hex.length === 4) {
+    r = parseInt(hex[1] + hex[1], 16);
+    g = parseInt(hex[2] + hex[2], 16);
+    b = parseInt(hex[3] + hex[3], 16);
+  } else {
+    r = parseInt(hex.slice(1, 3), 16);
+    g = parseInt(hex.slice(3, 5), 16);
+    b = parseInt(hex.slice(5, 7), 16);
+  }
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+const makeStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
+  StyleSheet.create({
+    scroll: {
+      flexGrow: 0,
+    },
+    scrollContent: {
+      gap: Skin.space(8),
+      paddingHorizontal: Skin.space(4),
+    },
+    fixedRow: {
+      flexDirection: 'row',
+      gap: Skin.space(8),
+    },
+    pill: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'center',
+      gap: Skin.space(6),
+      paddingVertical: Skin.space(8),
+      paddingHorizontal: Skin.space(12),
+      borderRadius: Skin.radius(8),
+      borderWidth: Skin.border(1),
+      borderColor: 'transparent',
+    },
+    pillFlex: {
+      flex: 1,
+    },
+    pressed: {
+      opacity: 0.7,
+    },
+    label: {
+      fontSize: Skin.font(13),
+      fontFamily: theme.fonts.medium.fontFamily,
+      fontWeight: theme.fonts.medium.fontWeight,
+    },
+    count: {
+      fontSize: Skin.font(13),
+      fontFamily: theme.fonts.medium.fontFamily,
+      fontWeight: theme.fonts.medium.fontWeight,
+    },
+    emoji: {
+      // fontSize is applied inline from the emojiSize prop.
+      textAlign: 'center',
+    },
+  });

--- a/components/ui/SegmentedPills.tsx
+++ b/components/ui/SegmentedPills.tsx
@@ -121,6 +121,10 @@ export function SegmentedPills({
     const isActive = item.key === activeKey;
     const itemAccent = item.danger ? theme.colors.danger : item.accentColor ?? theme.colors.primary;
 
+    // Whether this pill carries its own (non-accent) tint color — chains pass a
+    // brand accentColor; danger uses the danger color.
+    const hasItemColor = Boolean(item.accentColor) || Boolean(item.danger);
+
     // Foreground (text + icon) color.
     const fg = isActive
       ? variant === 'solid'
@@ -128,14 +132,14 @@ export function SegmentedPills({
         : itemAccent
       : theme.colors.textMuted;
 
-    // Background.
+    // Background: inactive pills stay flat (surface3); only the active pill gets
+    // a brighter tinted wash. Colored pills (chains/danger) tint in their own
+    // color; plain pills follow the app accent (accentSoft).
     const activeBg =
       variant === 'solid'
         ? itemAccent
-        : // tinted: prefer the accentSoft token; if a per-item accentColor is
-          // set, derive a matching low-alpha tint from it.
-          item.accentColor || item.danger
-          ? withAlpha(itemAccent, 0.12)
+        : hasItemColor
+          ? withAlpha(itemAccent, 0.18)
           : theme.colors.accentSoft;
 
     const pillStyle = [
@@ -143,11 +147,9 @@ export function SegmentedPills({
       // In a fixed (non-scrolling) row, pills share the width equally so the row
       // reads as a segmented control, matching the existing Join/Create tabs.
       !scrollable ? styles.pillFlex : null,
-      isActive
-        ? { backgroundColor: activeBg }
-        : { backgroundColor: theme.colors.surface3 },
+      { backgroundColor: isActive ? activeBg : theme.colors.surface3 },
       // A subtle border on the active tinted pill reads better on light skins
-      // where accentSoft alone is faint.
+      // where the tint alone is faint.
       isActive && variant === 'tinted' ? { borderColor: itemAccent } : null,
     ];
 

--- a/components/ui/SegmentedPills.tsx
+++ b/components/ui/SegmentedPills.tsx
@@ -31,7 +31,7 @@ import { useTheme } from '@/theme';
 import * as Skin from '@/theme/skins/geometry';
 import { useCenteredPillScroll } from '@/hooks/useCenteredPillScroll';
 
-export type SegmentedPillsVariant = 'tinted' | 'solid';
+export type SegmentedPillsVariant = 'tinted' | 'solid' | 'segmented';
 
 export interface SegmentedPillItem {
   /** Stable identifier; also the value passed to onChange. */
@@ -68,6 +68,9 @@ interface BaseSegmentedPillsProps {
   variant?: SegmentedPillsVariant;
   /** Horizontal scroll (default) vs a fixed flex row that fits the width. */
   scrollable?: boolean;
+  /** Wrap pills onto multiple lines instead of equal-width fitting. Implies a
+   *  fixed (non-scrolling) row; pills size to content and wrap. */
+  wrap?: boolean;
   /** Auto-scroll the tapped pill toward centre (scrollable rows only). */
   centerOnSelect?: boolean;
   /** Tapping the active pill calls onChange with the same key (caller may
@@ -75,6 +78,10 @@ interface BaseSegmentedPillsProps {
   allowReselect?: boolean;
   /** Accessibility role for each pill: 'tab' for tab bars, 'button' for filters. */
   itemRole?: 'tab' | 'button';
+  /** Pill outline: 'rounded' = fully-rounded pill (default), 'rect' = squarer
+   *  rounded rectangle for tab-bar-style rows. The 'segmented' variant is always
+   *  rect (lifted card). */
+  pillShape?: 'rounded' | 'rect';
   /** Font size for `item.emoji` glyphs (default 16; emoji-tab rows use ~22). */
   emojiSize?: number;
   /** Icon size for `item.icon` glyphs (default 16). */
@@ -97,9 +104,11 @@ export function SegmentedPills({
   onChange,
   variant = 'tinted',
   scrollable = true,
+  wrap = false,
   centerOnSelect = true,
   allowReselect = false,
   itemRole = 'tab',
+  pillShape = 'rounded',
   emojiSize = 16,
   iconSize = 16,
   hapticFeedback = true,
@@ -111,12 +120,16 @@ export function SegmentedPills({
   const styles = makeStyles(theme);
   const pills = useCenteredPillScroll();
 
+  // `wrap` is a fixed (non-scrolling) layout where pills size to content and
+  // wrap onto multiple lines, so it overrides `scrollable`.
+  const isScrollable = scrollable && !wrap;
+
   const handlePress = (item: SegmentedPillItem) => {
     const isActive = item.key === activeKey;
     if (isActive && !allowReselect) return;
     if (hapticFeedback) Haptics.selectionAsync();
     onChange(item.key);
-    if (scrollable && centerOnSelect) pills.center(item.key);
+    if (isScrollable && centerOnSelect) pills.center(item.key);
   };
 
   const renderPill = (item: SegmentedPillItem) => {
@@ -127,63 +140,58 @@ export function SegmentedPills({
     // brand accentColor; danger uses the danger color.
     const hasItemColor = Boolean(item.accentColor) || Boolean(item.danger);
 
-    // 'solid' variant: the active pill is a loud solid fill with white text; the
-    // rest sit as a dimmed wash of their own color (chain identity at rest). The
-    // strong difference in *kind* (solid vs dim) makes the selection unmistakable.
-    // 'tinted' variant: the gentler accentSoft look used by tab bars.
-    const fg =
-      variant === 'solid'
-        ? isActive
-          ? theme.colors.surface0 // white text on the solid fill
-          : hasItemColor
-            ? itemAccent
-            : theme.colors.textMuted
-        : hasItemColor
-          ? itemAccent
-          : isActive
-            ? itemAccent
-            : theme.colors.textMuted;
+    // Per-variant foreground / background / border. Three looks:
+    //  - 'solid': active = loud solid fill (item/chain color) + white text; rest
+    //    = neutral grey + muted text. The color appears ONLY on the active pill.
+    //  - 'tinted': active = accentSoft (or low-alpha own color) + accent text +
+    //    border; rest = flat grey (or transparent for colored pills).
+    //  - 'segmented': iOS lifted-card on a grey track. Active = raised card
+    //    (`background`) + strong text; rest = transparent on the track + muted
+    //    text. No accent color; the track lives on the row container.
+    let fg: string;
+    let bg: string;
+    let borderColor: string | undefined;
+    let subtitleColor: string = theme.colors.textMuted;
 
-    const bg =
-      variant === 'solid'
+    if (variant === 'solid') {
+      fg = isActive ? theme.colors.surface0 : theme.colors.textMuted;
+      bg = isActive ? itemAccent : theme.colors.surface3;
+      borderColor = isActive ? itemAccent : undefined;
+      if (isActive) subtitleColor = withAlpha(theme.colors.surface0, 0.8);
+    } else if (variant === 'segmented') {
+      fg = isActive ? theme.colors.textStrong : theme.colors.textMuted;
+      bg = isActive ? theme.colors.background : 'transparent';
+      borderColor = undefined;
+    } else {
+      // tinted
+      fg = hasItemColor ? itemAccent : isActive ? itemAccent : theme.colors.textMuted;
+      bg = hasItemColor
         ? isActive
-          ? itemAccent // full solid color
-          : hasItemColor
-            ? withAlpha(itemAccent, 0.12) // dimmed own-color wash at rest
-            : theme.colors.surface3
-        : hasItemColor
-          ? isActive
-            ? withAlpha(itemAccent, 0.15)
-            : 'transparent'
-          : isActive
-            ? theme.colors.accentSoft
-            : theme.colors.surface3;
-
-    const borderColor =
-      variant === 'solid'
+          ? withAlpha(itemAccent, 0.15)
+          : 'transparent'
+        : isActive
+          ? theme.colors.accentSoft
+          : theme.colors.surface3;
+      borderColor = !hasItemColor
         ? isActive
           ? itemAccent
           : undefined
-        : !hasItemColor
-          ? isActive
-            ? itemAccent
-            : undefined
-          : isActive
-            ? itemAccent
-            : withAlpha(itemAccent, 0.5);
-
-    // Subtitle sits one step quieter than the main label: a translucent white on
-    // the active solid fill, otherwise the muted text color.
-    const subtitleColor =
-      variant === 'solid' && isActive
-        ? withAlpha(theme.colors.surface0, 0.8)
-        : theme.colors.textMuted;
+        : isActive
+          ? itemAccent
+          : withAlpha(itemAccent, 0.5);
+    }
 
     const pillStyle = [
       styles.pill,
-      // In a fixed (non-scrolling) row, pills share the width equally so the row
-      // reads as a segmented control, matching the existing Join/Create tabs.
-      !scrollable ? styles.pillFlex : null,
+      // Squarer corners for tab-bar-style rows; the segmented variant is always
+      // a rounded rectangle (lifted card).
+      pillShape === 'rect' || variant === 'segmented' ? styles.roundedRect : null,
+      // In a fixed (non-scrolling, non-wrapping) row, pills share the width
+      // equally so the row reads as a segmented control (e.g. Join/Create). In a
+      // wrapping row they size to content instead.
+      !isScrollable && !wrap ? styles.pillFlex : null,
+      // Segmented cards sit flush in the track with a slightly tighter radius.
+      variant === 'segmented' ? styles.segmentedPill : null,
       { backgroundColor: bg },
       borderColor ? { borderColor } : null,
     ];
@@ -216,7 +224,10 @@ export function SegmentedPills({
             </Text>
           </View>
         ) : item.label ? (
-          <Text style={[styles.label, { color: fg }]} numberOfLines={1}>
+          <Text
+            style={[styles.label, variant === 'segmented' && isActive && styles.labelBold, { color: fg }]}
+            numberOfLines={1}
+          >
             {item.label}
           </Text>
         ) : null}
@@ -228,9 +239,18 @@ export function SegmentedPills({
     );
   };
 
-  if (!scrollable) {
+  if (!isScrollable) {
     return (
-      <View style={[styles.fixedRow, style, contentContainerStyle]} testID={testID}>
+      <View
+        style={[
+          styles.fixedRow,
+          wrap && styles.wrapRow,
+          variant === 'segmented' && styles.track,
+          style,
+          contentContainerStyle,
+        ]}
+        testID={testID}
+      >
         {items.map(renderPill)}
       </View>
     );
@@ -280,6 +300,20 @@ const makeStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
       flexDirection: 'row',
       gap: Skin.space(8),
     },
+    wrapRow: {
+      flexWrap: 'wrap',
+    },
+    // 'segmented' variant: a grey rounded track that holds the cards flush
+    // (no gap), iOS-segmented-control style.
+    track: {
+      gap: 0,
+      backgroundColor: theme.colors.surface2,
+      borderRadius: Skin.radius(12),
+      // 1px inset so the card's own padding + this = the standard pill height
+      // (8 padding + 1 border per side), keeping segmented rows the same height
+      // as pill rows that sit near them.
+      padding: Skin.space(1),
+    },
     pill: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -287,12 +321,27 @@ const makeStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
       gap: Skin.space(6),
       paddingVertical: Skin.space(8),
       paddingHorizontal: Skin.space(12),
-      borderRadius: Skin.radius(8),
+      // Fully-rounded pill shape by default (it's a "pill" component). Tab-bar /
+      // segmented use cases opt into a squarer radius via the `pillShape` prop.
+      borderRadius: theme.radii.pill,
       borderWidth: Skin.border(1),
       borderColor: 'transparent',
     },
+    // Squarer rounded-rectangle radius for tab-bar-style rows.
+    roundedRect: {
+      borderRadius: Skin.radius(8),
+    },
     pillFlex: {
       flex: 1,
+    },
+    // Card inside the segmented track: no border, same vertical padding as a
+    // standard pill so (track inset 1 + padding 8) matches the pill's (padding 8
+    // + border 1) and the two row types line up in height.
+    segmentedPill: {
+      borderRadius: Skin.radius(9),
+      borderWidth: 0,
+      paddingVertical: Skin.space(8),
+      paddingHorizontal: Skin.space(10),
     },
     pressed: {
       opacity: 0.7,
@@ -304,6 +353,10 @@ const makeStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
       fontSize: Skin.font(13),
       fontFamily: theme.fonts.medium.fontFamily,
       fontWeight: theme.fonts.medium.fontWeight,
+    },
+    labelBold: {
+      fontFamily: theme.fonts.bold.fontFamily,
+      fontWeight: theme.fonts.bold.fontWeight,
     },
     subtitle: {
       fontSize: Skin.font(10),

--- a/components/ui/SegmentedPills.tsx
+++ b/components/ui/SegmentedPills.tsx
@@ -38,6 +38,8 @@ export interface SegmentedPillItem {
   key: string;
   /** Text label (omit for icon-only / emoji-only chips). */
   label?: string;
+  /** Optional second line under the label (e.g. "KAS only" on a chain pill). */
+  subtitle?: string;
   /** Icon glyph rendered left of the label (or alone if no label). */
   icon?: IconSymbolName;
   /** Emoji glyph rendered left of the label/count (for reaction pills). */
@@ -125,32 +127,65 @@ export function SegmentedPills({
     // brand accentColor; danger uses the danger color.
     const hasItemColor = Boolean(item.accentColor) || Boolean(item.danger);
 
-    // Foreground (text + icon) color.
-    const fg = isActive
-      ? variant === 'solid'
-        ? theme.colors.surface0
-        : itemAccent
-      : theme.colors.textMuted;
-
-    // Background: inactive pills stay flat (surface3); only the active pill gets
-    // a brighter tinted wash. Colored pills (chains/danger) tint in their own
-    // color; plain pills follow the app accent (accentSoft).
-    const activeBg =
+    // 'solid' variant: the active pill is a loud solid fill with white text; the
+    // rest sit as a dimmed wash of their own color (chain identity at rest). The
+    // strong difference in *kind* (solid vs dim) makes the selection unmistakable.
+    // 'tinted' variant: the gentler accentSoft look used by tab bars.
+    const fg =
       variant === 'solid'
-        ? itemAccent
+        ? isActive
+          ? theme.colors.surface0 // white text on the solid fill
+          : hasItemColor
+            ? itemAccent
+            : theme.colors.textMuted
         : hasItemColor
-          ? withAlpha(itemAccent, 0.18)
-          : theme.colors.accentSoft;
+          ? itemAccent
+          : isActive
+            ? itemAccent
+            : theme.colors.textMuted;
+
+    const bg =
+      variant === 'solid'
+        ? isActive
+          ? itemAccent // full solid color
+          : hasItemColor
+            ? withAlpha(itemAccent, 0.12) // dimmed own-color wash at rest
+            : theme.colors.surface3
+        : hasItemColor
+          ? isActive
+            ? withAlpha(itemAccent, 0.15)
+            : 'transparent'
+          : isActive
+            ? theme.colors.accentSoft
+            : theme.colors.surface3;
+
+    const borderColor =
+      variant === 'solid'
+        ? isActive
+          ? itemAccent
+          : undefined
+        : !hasItemColor
+          ? isActive
+            ? itemAccent
+            : undefined
+          : isActive
+            ? itemAccent
+            : withAlpha(itemAccent, 0.5);
+
+    // Subtitle sits one step quieter than the main label: a translucent white on
+    // the active solid fill, otherwise the muted text color.
+    const subtitleColor =
+      variant === 'solid' && isActive
+        ? withAlpha(theme.colors.surface0, 0.8)
+        : theme.colors.textMuted;
 
     const pillStyle = [
       styles.pill,
       // In a fixed (non-scrolling) row, pills share the width equally so the row
       // reads as a segmented control, matching the existing Join/Create tabs.
       !scrollable ? styles.pillFlex : null,
-      { backgroundColor: isActive ? activeBg : theme.colors.surface3 },
-      // A subtle border on the active tinted pill reads better on light skins
-      // where the tint alone is faint.
-      isActive && variant === 'tinted' ? { borderColor: itemAccent } : null,
+      { backgroundColor: bg },
+      borderColor ? { borderColor } : null,
     ];
 
     return (
@@ -171,7 +206,16 @@ export function SegmentedPills({
         ) : item.emoji ? (
           <Text style={[styles.emoji, { fontSize: Skin.font(emojiSize) }]}>{item.emoji}</Text>
         ) : null}
-        {item.label ? (
+        {item.label && item.subtitle ? (
+          <View style={styles.labelColumn}>
+            <Text style={[styles.label, { color: fg }]} numberOfLines={1}>
+              {item.label}
+            </Text>
+            <Text style={[styles.subtitle, { color: subtitleColor }]} numberOfLines={1}>
+              {item.subtitle}
+            </Text>
+          </View>
+        ) : item.label ? (
           <Text style={[styles.label, { color: fg }]} numberOfLines={1}>
             {item.label}
           </Text>
@@ -253,10 +297,18 @@ const makeStyles = (theme: ReturnType<typeof useTheme>['theme']) =>
     pressed: {
       opacity: 0.7,
     },
+    labelColumn: {
+      alignItems: 'center',
+    },
     label: {
       fontSize: Skin.font(13),
       fontFamily: theme.fonts.medium.fontFamily,
       fontWeight: theme.fonts.medium.fontWeight,
+    },
+    subtitle: {
+      fontSize: Skin.font(10),
+      marginTop: Skin.space(2),
+      fontFamily: theme.fonts.regular.fontFamily,
     },
     count: {
       fontSize: Skin.font(13),

--- a/components/wallet/ReceiveModal.tsx
+++ b/components/wallet/ReceiveModal.tsx
@@ -122,6 +122,7 @@ export default function ReceiveModal({ visible, onClose, defaultChain }: Receive
           style={styles.chainSelectorScroll}
           contentContainerStyle={styles.chainSelector}
           variant="solid"
+          pillShape="rect"
           itemRole="button"
           items={(['ethereum', 'bitcoin', 'solana', 'kaspa', 'bittensor'] as ChainOption[]).map<SegmentedPillItem>((chain) => ({
             key: chain,

--- a/components/wallet/ReceiveModal.tsx
+++ b/components/wallet/ReceiveModal.tsx
@@ -4,6 +4,7 @@
 
 import { BaseModal } from '@/components/shared';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useWalletAddresses } from '@/hooks/useWallet';
 import { useWalletSelection } from '@/hooks/useWalletSelection';
 import { getChainName } from '@/services/wallet/balanceService';
@@ -117,34 +118,20 @@ export default function ReceiveModal({ visible, onClose, defaultChain }: Receive
         {selectedChain === 'ethereum' && <WalletSelector />}
 
         {/* Chain Selector */}
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
+        <SegmentedPills
           style={styles.chainSelectorScroll}
           contentContainerStyle={styles.chainSelector}
-        >
-          {(['ethereum', 'bitcoin', 'solana', 'kaspa', 'bittensor'] as ChainOption[]).map((chain) => (
-            <TouchableOpacity
-              key={chain}
-              style={[
-                styles.chainOption,
-                selectedChain === chain && styles.chainOptionActive,
-                selectedChain === chain && { borderColor: getChainColor(chain) },
-              ]}
-              onPress={() => setSelectedChain(chain)}
-            >
-              <Text
-                style={[
-                  styles.chainOptionText,
-                  selectedChain === chain && { color: getChainColor(chain) },
-                ]}
-              >
-                {chain === 'ethereum' ? 'EVM' : chain.charAt(0).toUpperCase() + chain.slice(1)}
-              </Text>
-              <Text style={styles.chainOptionSubtext}>{getChainDescription(chain)}</Text>
-            </TouchableOpacity>
-          ))}
-        </ScrollView>
+          variant="solid"
+          itemRole="button"
+          items={(['ethereum', 'bitcoin', 'solana', 'kaspa', 'bittensor'] as ChainOption[]).map<SegmentedPillItem>((chain) => ({
+            key: chain,
+            label: chain === 'ethereum' ? 'EVM' : chain.charAt(0).toUpperCase() + chain.slice(1),
+            subtitle: getChainDescription(chain),
+            accentColor: getChainColor(chain),
+          }))}
+          activeKey={selectedChain}
+          onChange={(key) => setSelectedChain(key as ChainOption)}
+        />
 
         {/* QR Code */}
         {address && (
@@ -224,32 +211,7 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
       marginBottom: Skin.space(24),
     },
     chainSelector: {
-      flexDirection: 'row',
-      gap: Skin.space(8),
       paddingHorizontal: Skin.space(20),
-    },
-    chainOption: {
-      paddingVertical: Skin.space(12),
-      paddingHorizontal: Skin.space(16),
-      borderRadius: Skin.radius(12),
-      borderWidth: Skin.border(2),
-      borderColor: theme.colors.border,
-      alignItems: 'center',
-      minWidth: 80,
-    },
-    chainOptionActive: {
-      backgroundColor: theme.colors.surface2,
-    },
-    chainOptionText: {
-      fontSize: Skin.font(14),
-      fontFamily: theme.fonts.bold.fontFamily,
-      fontWeight: theme.fonts.bold.fontWeight,
-      color: theme.colors.textMuted,
-    },
-    chainOptionSubtext: {
-      fontSize: Skin.font(10),
-      color: theme.colors.textMuted,
-      marginTop: Skin.space(2),
     },
     qrContainer: {
       alignItems: 'center',

--- a/components/wallet/SwapModal.tsx
+++ b/components/wallet/SwapModal.tsx
@@ -1834,6 +1834,7 @@ export default function SwapModal({ visible, onClose, initialBuyToken }: SwapMod
                   <Text style={styles.manualEntryLabel}>Chain</Text>
                   <SegmentedPills
                     style={styles.chainSelector}
+                    variant="solid"
                     itemRole="button"
                     items={(sellAsset?.chain === 'solana'
                       ? ['solana']

--- a/components/wallet/SwapModal.tsx
+++ b/components/wallet/SwapModal.tsx
@@ -1842,9 +1842,6 @@ export default function SwapModal({ visible, onClose, initialBuyToken }: SwapMod
                       key: chain,
                       label: getChainName(chain),
                       accentColor: getChainColor(chain),
-                      leading: (
-                        <View style={[styles.chainChipDot, { backgroundColor: getChainColor(chain) }]} />
-                      ),
                     }))}
                     activeKey={manualChain}
                     onChange={setManualChain}
@@ -2475,10 +2472,5 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
     },
     chainSelector: {
       marginBottom: Skin.space(8),
-    },
-    chainChipDot: {
-      width: 8,
-      height: 8,
-      borderRadius: Skin.radius(4),
     },
   });

--- a/components/wallet/SwapModal.tsx
+++ b/components/wallet/SwapModal.tsx
@@ -82,6 +82,7 @@ import React from 'react';
 import { ActivityIndicator, Alert, InteractionManager, Keyboard, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Skin from '@/theme/skins/geometry';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 
 interface SwapModalProps {
   visible: boolean;
@@ -1831,24 +1832,23 @@ export default function SwapModal({ visible, onClose, initialBuyToken }: SwapMod
                 <View style={styles.manualEntryContainer}>
                   {/* Chain Selector */}
                   <Text style={styles.manualEntryLabel}>Chain</Text>
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false} style={styles.chainSelector}>
-                    {(sellAsset?.chain === 'solana' ? ['solana'] : ['ethereum', 'base', 'arbitrum', 'optimism', 'polygon', 'hyperevm']).map((chain) => (
-                      <TouchableOpacity
-                        key={chain}
-                        style={[
-                          styles.chainChip,
-                          manualChain === chain && styles.chainChipActive,
-                          { borderColor: getChainColor(chain) }
-                        ]}
-                        onPress={() => setManualChain(chain)}
-                      >
+                  <SegmentedPills
+                    style={styles.chainSelector}
+                    itemRole="button"
+                    items={(sellAsset?.chain === 'solana'
+                      ? ['solana']
+                      : ['ethereum', 'base', 'arbitrum', 'optimism', 'polygon', 'hyperevm']
+                    ).map<SegmentedPillItem>((chain) => ({
+                      key: chain,
+                      label: getChainName(chain),
+                      accentColor: getChainColor(chain),
+                      leading: (
                         <View style={[styles.chainChipDot, { backgroundColor: getChainColor(chain) }]} />
-                        <Text style={[styles.chainChipText, manualChain === chain && styles.chainChipTextActive]}>
-                          {getChainName(chain)}
-                        </Text>
-                      </TouchableOpacity>
-                    ))}
-                  </ScrollView>
+                      ),
+                    }))}
+                    activeKey={manualChain}
+                    onChange={setManualChain}
+                  />
 
                   {/* Contract Address */}
                   <Text style={styles.manualEntryLabel}>Contract Address</Text>
@@ -2474,35 +2474,11 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
       color: '#fff',
     },
     chainSelector: {
-      flexDirection: 'row',
       marginBottom: Skin.space(8),
-    },
-    chainChip: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      backgroundColor: theme.colors.surface1,
-      borderWidth: Skin.border(1),
-      borderRadius: Skin.radius(16),
-      paddingHorizontal: Skin.space(12),
-      paddingVertical: Skin.space(6),
-      marginRight: Skin.space(8),
-      gap: Skin.space(6),
-    },
-    chainChipActive: {
-      backgroundColor: isDark ? 'rgba(255,255,255,0.1)' : 'rgba(0,0,0,0.05)',
     },
     chainChipDot: {
       width: 8,
       height: 8,
       borderRadius: Skin.radius(4),
-    },
-    chainChipText: {
-      fontSize: Skin.font(12),
-      color: theme.colors.textMuted,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    chainChipTextActive: {
-      color: theme.colors.textMain,
     },
   });

--- a/hooks/useCenteredPillScroll.ts
+++ b/hooks/useCenteredPillScroll.ts
@@ -1,0 +1,73 @@
+// useCenteredPillScroll — headless behaviour for a horizontal selector row that
+// scrolls the tapped item toward the centre of the viewport.
+//
+// Kept separate from the visual <SegmentedPills> so non-pill selectors (e.g.
+// underline-style tab rows) can adopt centring without inheriting pill styling.
+//
+// Usage:
+//   const pills = useCenteredPillScroll();
+//   <ScrollView {...pills.scrollViewProps}>
+//     {items.map(it => (
+//       <Pressable
+//         key={it.key}
+//         onLayout={pills.onItemLayout(it.key)}
+//         onPress={() => { setActive(it.key); pills.center(it.key); }}
+//       />
+//     ))}
+//   </ScrollView>
+
+import { useCallback, useRef } from 'react';
+import type { LayoutChangeEvent, ScrollView } from 'react-native';
+
+export interface CenteredPillScroll {
+  /** Spread onto the horizontal ScrollView. Captures the ref + viewport width. */
+  scrollViewProps: {
+    ref: React.RefObject<ScrollView | null>;
+    horizontal: true;
+    showsHorizontalScrollIndicator: false;
+    onLayout: (e: LayoutChangeEvent) => void;
+  };
+  /** Spread onto each item: `onLayout={onItemLayout(key)}`. */
+  onItemLayout: (key: string) => (e: LayoutChangeEvent) => void;
+  /** Scroll so the item with `key` is centred in the viewport (animated). */
+  center: (key: string) => void;
+}
+
+export function useCenteredPillScroll(): CenteredPillScroll {
+  const scrollRef = useRef<ScrollView | null>(null);
+  const viewportWidth = useRef(0);
+  const layouts = useRef<Record<string, { x: number; width: number }>>({});
+
+  const onLayout = useCallback((e: LayoutChangeEvent) => {
+    viewportWidth.current = e.nativeEvent.layout.width;
+  }, []);
+
+  const onItemLayout = useCallback(
+    (key: string) => (e: LayoutChangeEvent) => {
+      const { x, width } = e.nativeEvent.layout;
+      layouts.current[key] = { x, width };
+    },
+    [],
+  );
+
+  const center = useCallback((key: string) => {
+    const item = layouts.current[key];
+    const sv = scrollRef.current;
+    if (!item || !sv) return;
+    // Target offset that puts the item's midpoint at the viewport midpoint.
+    // Clamp the lower bound to 0; RN clamps the upper bound to content width.
+    const target = item.x + item.width / 2 - viewportWidth.current / 2;
+    sv.scrollTo({ x: Math.max(0, target), animated: true });
+  }, []);
+
+  return {
+    scrollViewProps: {
+      ref: scrollRef,
+      horizontal: true,
+      showsHorizontalScrollIndicator: false,
+      onLayout,
+    },
+    onItemLayout,
+    center,
+  };
+}


### PR DESCRIPTION
## Summary

Adds a shared `SegmentedPills` component (`components/ui/SegmentedPills.tsx`) plus a `useCenteredPillScroll` hook, and migrates the many hand-rolled horizontal pill/filter/tab rows across the app onto it. One source of truth for these selectors instead of ~20 duplicated implementations.

### Why
The pill/filter rows were each hand-rolled with their own styles. The active selection was often hard to see, scrollable rows didn't bring the tapped item into view, and the styling was inconsistent (three different active-state treatments). This consolidates them.

### Component features
- **Variants:** `tinted` (soft accent active), `solid` (full color active + white text, neutral grey at rest), `segmented` (iOS lifted-card on a grey track for tab switchers).
- **Layouts:** scrollable (default, with tap-to-center), fixed equal-width, and `wrap` for multi-line rows.
- **`pillShape`:** `rounded` (default) vs `rect`, so each migrated row keeps its original corner radius.
- Per-item `accentColor` (chain brand colors), `subtitle` (two-line), `leading`/`trailing` slots, `count`, `danger`, full a11y, optional haptics.

### Migrated rows
Wallet (chain filters, Assets/Collectibles/Addresses/History tabs, wallet switcher), Receive & Swap chain selectors, Space Settings tabs, Space Join/Create, Reactions, Emoji categories, QNS Offers tabs, Discover categories, DM filters, Marketplace sort, Create Proposal scope/category, and the QNS token/chain selectors in Register/Auction/BuyName.

Underline-style tab bars (Governance, Profile/Casts) were intentionally left as-is — they're a different pattern.

### Also fixes
A latent bug in 3 QNS modals where the active background was set to the string literal `'theme.colors.accentSoft'` instead of the color value.

## Test plan
- [x] `tsc --noEmit` clean (no new errors)
- [x] `eslint` clean on all touched files
- [x] Device-tested the reachable selectors on Android
- Note: `CreateProposalSheet` is migrated but its parent `GovernanceView` is not currently rendered anywhere, so those pills are dormant (ready if wired up later).