### PR TITLE
fix: align mention wire format with desktop and extract mentions on send

### DIFF
--- a/components/Chat/MentionableText.tsx
+++ b/components/Chat/MentionableText.tsx
@@ -40,7 +40,8 @@ interface MentionableTextProps {
 
 // Regex patterns for @mentions, URLs, and :emoji:
 // Channel matching is done by looking up actual channel names, not regex
-const MENTION_REGEX = /@([a-zA-Z0-9_.\-]+)/g;
+// Group 1: bracketed canonical format @<address>, group 2: legacy bare @address
+const MENTION_REGEX = /@<([^>]+)>|@(everyone)|@([a-zA-Z0-9_.\-]+)/g;
 const EMOJI_REGEX = /:([a-zA-Z0-9_-]+):/g;
 // URL regex - matches http(s) URLs
 const URL_REGEX = /https?:\/\/[^\s<>"\])}]+/gi;
@@ -163,11 +164,22 @@ function MentionableTextBase({
 
     const matches: Match[] = [];
 
-    // Find @mentions
+    // Find @mentions and @everyone
+    // Group 1: @<address> (canonical), group 2: @everyone, group 3: @address (legacy)
     MENTION_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = MENTION_REGEX.exec(text)) !== null) {
-      const name = match[1].toLowerCase();
+      if (match[2] === 'everyone') {
+        matches.push({
+          type: 'mention',
+          start: match.index,
+          end: match.index + match[0].length,
+          content: match[0],
+          data: { userId: 'everyone', displayName: 'everyone', isSelf: false },
+        });
+        continue;
+      }
+      const name = (match[1] || match[3] || '').toLowerCase();
       const member = memberMap[name];
       if (member) {
         matches.push({
@@ -399,8 +411,13 @@ function MentionableTextBase({
     <Text style={effectiveStyle}>
       {parts.map((part, index) => {
         if (part.type === 'mention') {
-          const mStyle = part.isSelf ? selfMentionStyle : defaultMentionStyle;
-          if (onMentionPress && part.userId) {
+          const isEveryone = part.userId === 'everyone';
+          const mStyle = isEveryone
+            ? defaultMentionStyle
+            : part.isSelf
+            ? selfMentionStyle
+            : defaultMentionStyle;
+          if (!isEveryone && onMentionPress && part.userId) {
             return (
               <Text
                 key={`mention-${index}`}

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -416,8 +416,8 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
     const lastAtIndex = textUpToCursor.lastIndexOf('@');
     const textAfterCursor = value.slice(cursorPosition);
 
-    // Use address for the mention (MentionableText will render it as display name)
-    const newText = value.slice(0, lastAtIndex) + `@${member.address} ` + textAfterCursor;
+    // Use canonical @<address> format (matches desktop wire format)
+    const newText = value.slice(0, lastAtIndex) + `@<${member.address}> ` + textAfterCursor;
     onChangeText(newText);
     setAutocompleteType(null);
     setAutocompleteQuery('');

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -437,6 +437,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         text,
         repliesToMessageId: replyToMessage?.messageId,
         replyToAuthorAddress: replyToMessage?.authorId,
+        spaceChannels: channelsData?.map((c) => ({ channelId: c.channelId, channelName: c.channelName })),
       }, {
         onSettled: refocusInput,
       });

--- a/hooks/chat/useSendSpaceMessage.ts
+++ b/hooks/chat/useSendSpaceMessage.ts
@@ -23,6 +23,8 @@ export interface UseSendSpaceMessageParams {
   text: string;
   repliesToMessageId?: string;
   replyToAuthorAddress?: string;
+  spaceRoles?: Array<{ roleId: string; roleTag: string }>;
+  spaceChannels?: Array<{ channelId: string; channelName: string }>;
 }
 
 export function useSendSpaceMessage() {
@@ -47,6 +49,8 @@ export function useSendSpaceMessage() {
         senderAddress: user.address,
         repliesToMessageId: params.repliesToMessageId,
         replyToAuthorAddress: params.replyToAuthorAddress,
+        spaceRoles: params.spaceRoles,
+        spaceChannels: params.spaceChannels,
       });
 
       // Send via WebSocket
@@ -78,6 +82,8 @@ export function useSendSpaceMessage() {
           senderAddress: user.address,
           repliesToMessageId: params.repliesToMessageId,
           replyToAuthorAddress: params.replyToAuthorAddress,
+          spaceRoles: params.spaceRoles,
+          spaceChannels: params.spaceChannels,
         },
         tempId
       );

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -17,6 +17,7 @@ import { sha256 } from '@noble/hashes/sha2.js';
 import {
   bytesToHex,
   hexToBytes,
+  extractMentionsFromText,
   type EditMessage,
   type EmbedMessage,
   type Message,
@@ -93,6 +94,10 @@ export interface SendSpaceMessageParams {
   senderAddress: string;
   repliesToMessageId?: string;
   replyToAuthorAddress?: string;
+  /** Space roles, used to extract role mentions from the message text */
+  spaceRoles?: Array<{ roleId: string; roleTag: string }>;
+  /** Space channels, used to extract channel mentions from the message text */
+  spaceChannels?: Array<{ channelId: string; channelName: string }>;
 }
 
 export interface SendSpaceMessageResult {
@@ -234,7 +239,7 @@ function hexToNumberArray(hex: string): number[] {
 export async function sendSpaceMessage(
   params: SendSpaceMessageParams
 ): Promise<SendSpaceMessageResult> {
-  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress } = params;
+  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress, spaceRoles, spaceChannels } = params;
 
   const cryptoProvider = new NativeCryptoProvider();
   const timestamp = Date.now();
@@ -282,7 +287,7 @@ export async function sendSpaceMessage(
     lastModifiedHash: '',
     content: messageContent,
     reactions: [],
-    mentions: { memberIds: [], roleIds: [], channelIds: [] },
+    mentions: extractMentionsFromText(text, { spaceRoles, spaceChannels }),
     publicKey: inboxKey.publicKey,
     // Add reply metadata if this is a reply (used for display and notifications)
     ...(repliesToMessageId && replyToAuthorAddress
@@ -541,7 +546,7 @@ export function createOptimisticMessage(
   params: SendSpaceMessageParams,
   tempMessageId: string
 ): Message {
-  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress } = params;
+  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress, spaceRoles, spaceChannels } = params;
   const timestamp = Date.now();
 
   return {
@@ -560,7 +565,7 @@ export function createOptimisticMessage(
       repliesToMessageId,
     },
     reactions: [],
-    mentions: { memberIds: [], roleIds: [], channelIds: [] },
+    mentions: extractMentionsFromText(text, { spaceRoles, spaceChannels }),
     sendStatus: 'sending',
     // Add reply metadata if this is a reply (for display purposes)
     ...(repliesToMessageId && replyToAuthorAddress


### PR DESCRIPTION
## What

Mobile mentions were broken cross-platform in two ways:

1. **Compose inserted bare `@address`** — desktop expects `@<address>` (angle-bracket canonical format). Stored messages on desktop never matched the mobile regex, so mobile→desktop mentions showed as literal text and never highlighted.

2. **`extractMentionsFromText` was never called** — the `mentions` field on every mobile-sent message was hardcoded `{ memberIds: [], roleIds: [], channelIds: [] }`. This meant desktop never fired notifications for mobile-authored `@mentions`.

3. **`MentionableText` couldn't parse the canonical format** — desktop→mobile messages containing `@<address>` rendered as plain text (regex only matched bare `@address`).

## Changes

- **`MessageInput.tsx`** — compose inserts `@<address>` (canonical)
- **`spaceMessageService.ts`** — call `extractMentionsFromText` on `sendSpaceMessage` and `createOptimisticMessage`; add optional `spaceRoles`/`spaceChannels` to `SendSpaceMessageParams`
- **`useSendSpaceMessage.ts`** — thread `spaceRoles`/`spaceChannels` through
- **`SpaceChatArea.tsx`** — pass `spaceChannels` at the call site
- **`MentionableText.tsx`** — regex now matches `@<address>` (canonical) AND `@address` (legacy, for messages already in storage); adds `@everyone` as a non-tappable highlight pill

## Notes

- iOS-unverified (reviewed only; pure JS/regex change, no platform-specific code paths)
- Legacy bare-format messages in storage still render correctly (backward-compatible regex)
- `spaceRoles` threading is wired but not yet populated at the call site (no role data flows into `SpaceChatArea` yet — role mention extraction will work once that's added in a follow-up)