### PR TITLE
Fix composer emoji-panel transitions and tab bar edge cases

### DIFF
--- a/components/Chat/ChatKeyboardScrollView.tsx
+++ b/components/Chat/ChatKeyboardScrollView.tsx
@@ -32,7 +32,7 @@ import React, { forwardRef } from 'react';
 import type { ScrollViewProps } from 'react-native';
 import { KeyboardChatScrollView } from 'react-native-keyboard-controller';
 import { useDerivedValue, type SharedValue } from 'react-native-reanimated';
-import { composerFootprintSV, composerPanelFootprintSV } from '@/services/ui/composerFootprint';
+import { composerFootprintSV, composerPanelFootprintSV, composerListFreezeSV } from '@/services/ui/composerFootprint';
 
 export interface ChatKeyboardScrollViewExtraProps {
   /** Minimum bottom-inset floor (resting composer + tab-bar clearance). The
@@ -74,6 +74,12 @@ export const ChatKeyboardScrollView = forwardRef<any, Props>(
         contentInsetAdjustmentBehavior="never"
         blankSpace={blankSpace}
         extraContentPadding={extraContentPadding ?? composerExtra}
+        // Freeze the keyboard-driven auto-scroll while the emoji panel is open:
+        // opening the panel dismisses the keyboard, which the library would
+        // otherwise chase by scrolling the list down (the panel replaces that
+        // space, so the list must hold). The scrollable range still grows for the
+        // panel via contentInset (not gated by freeze). See composerListFreezeSV.
+        freeze={composerListFreezeSV}
         onContentInsetChange={onContentInsetChange}
         {...props}
       />

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -57,6 +57,7 @@ const SF_TO_TABLER = {
   // Status & flags
   'flag': tabler('IconFlag', 'IconFlagFilled'),
   'flag.fill': tabler('IconFlag', 'IconFlagFilled'),
+  'flask': tabler('IconFlask'),
   'nosign': tabler('IconBan'),
   'ellipsis': tabler('IconDots'),
   'ellipsis.vertical': tabler('IconDotsVertical'),

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -1,18 +1,25 @@
 /**
  * tablerIconRegistry — GENERATED. Do not edit by hand.
  *
- * Explicit deep-imports of ONLY the Tabler icons IconSymbol.tsx references.
+ * Explicit deep-imports of ONLY the Tabler icons the app can render. Built from
+ * TWO sources (see scripts/gen-tabler-registry.mjs):
+ *   1. every IconXxx token referenced in components/ui/IconSymbol.tsx, and
+ *   2. the shared channel-icon-picker vocabulary (ICON_OPTIONS + FILLED_ICONS),
+ *      resolved through IconSymbol's runtime logic so picker cells never blank.
+ *
  * IconSymbol previously imported the whole @tabler/icons-react-native barrel
  * (~6000 icons), which Metro can't tree-shake in dev — every route bundled
  * ~14k modules and OOM-crashed the dev server. This keeps the graph small.
  *
- * Regenerate after changing IconSymbol's icon map:
+ * Regenerate after changing IconSymbol's map OR when the shared picker
+ * vocabulary grows:
  *   node scripts/gen-tabler-registry.mjs   (npm run gen:icons)
  *
  * Names not listed here resolve to null in IconSymbol (its documented
  * "unknown names render null" behavior).
  */
 
+import IconAi from '@tabler/icons-react-native/IconAi';
 import IconAlertCircle from '@tabler/icons-react-native/IconAlertCircle';
 import IconAlertCircleFilled from '@tabler/icons-react-native/IconAlertCircleFilled';
 import IconAlertTriangle from '@tabler/icons-react-native/IconAlertTriangle';
@@ -27,17 +34,25 @@ import IconArrowUpRight from '@tabler/icons-react-native/IconArrowUpRight';
 import IconArrowsExchange from '@tabler/icons-react-native/IconArrowsExchange';
 import IconArrowsUpDown from '@tabler/icons-react-native/IconArrowsUpDown';
 import IconAt from '@tabler/icons-react-native/IconAt';
+import IconBadge from '@tabler/icons-react-native/IconBadge';
+import IconBadgeFilled from '@tabler/icons-react-native/IconBadgeFilled';
 import IconBan from '@tabler/icons-react-native/IconBan';
 import IconBell from '@tabler/icons-react-native/IconBell';
 import IconBellFilled from '@tabler/icons-react-native/IconBellFilled';
 import IconBellOff from '@tabler/icons-react-native/IconBellOff';
 import IconBolt from '@tabler/icons-react-native/IconBolt';
 import IconBoltFilled from '@tabler/icons-react-native/IconBoltFilled';
+import IconBook from '@tabler/icons-react-native/IconBook';
+import IconBookFilled from '@tabler/icons-react-native/IconBookFilled';
 import IconBookmark from '@tabler/icons-react-native/IconBookmark';
 import IconBookmarkFilled from '@tabler/icons-react-native/IconBookmarkFilled';
 import IconBookmarkOff from '@tabler/icons-react-native/IconBookmarkOff';
+import IconBriefcase from '@tabler/icons-react-native/IconBriefcase';
+import IconBriefcaseFilled from '@tabler/icons-react-native/IconBriefcaseFilled';
 import IconBroadcast from '@tabler/icons-react-native/IconBroadcast';
 import IconBrush from '@tabler/icons-react-native/IconBrush';
+import IconBug from '@tabler/icons-react-native/IconBug';
+import IconBugFilled from '@tabler/icons-react-native/IconBugFilled';
 import IconBuildingBank from '@tabler/icons-react-native/IconBuildingBank';
 import IconBuildingStore from '@tabler/icons-react-native/IconBuildingStore';
 import IconCalendar from '@tabler/icons-react-native/IconCalendar';
@@ -88,6 +103,8 @@ import IconCurrencyBitcoin from '@tabler/icons-react-native/IconCurrencyBitcoin'
 import IconCurrencyDollar from '@tabler/icons-react-native/IconCurrencyDollar';
 import IconDeviceDesktop from '@tabler/icons-react-native/IconDeviceDesktop';
 import IconDeviceDesktopFilled from '@tabler/icons-react-native/IconDeviceDesktopFilled';
+import IconDeviceFloppy from '@tabler/icons-react-native/IconDeviceFloppy';
+import IconDeviceFloppyFilled from '@tabler/icons-react-native/IconDeviceFloppyFilled';
 import IconDeviceGamepad from '@tabler/icons-react-native/IconDeviceGamepad';
 import IconDeviceMobile from '@tabler/icons-react-native/IconDeviceMobile';
 import IconDots from '@tabler/icons-react-native/IconDots';
@@ -100,6 +117,9 @@ import IconEyeFilled from '@tabler/icons-react-native/IconEyeFilled';
 import IconEyeOff from '@tabler/icons-react-native/IconEyeOff';
 import IconFaceId from '@tabler/icons-react-native/IconFaceId';
 import IconFile from '@tabler/icons-react-native/IconFile';
+import IconFileCode from '@tabler/icons-react-native/IconFileCode';
+import IconFileCodeFilled from '@tabler/icons-react-native/IconFileCodeFilled';
+import IconFileFilled from '@tabler/icons-react-native/IconFileFilled';
 import IconFileText from '@tabler/icons-react-native/IconFileText';
 import IconFileTextFilled from '@tabler/icons-react-native/IconFileTextFilled';
 import IconFlag from '@tabler/icons-react-native/IconFlag';
@@ -107,6 +127,9 @@ import IconFlagFilled from '@tabler/icons-react-native/IconFlagFilled';
 import IconFlame from '@tabler/icons-react-native/IconFlame';
 import IconFlameFilled from '@tabler/icons-react-native/IconFlameFilled';
 import IconFlask from '@tabler/icons-react-native/IconFlask';
+import IconFlaskFilled from '@tabler/icons-react-native/IconFlaskFilled';
+import IconFolder from '@tabler/icons-react-native/IconFolder';
+import IconFolderFilled from '@tabler/icons-react-native/IconFolderFilled';
 import IconGift from '@tabler/icons-react-native/IconGift';
 import IconGiftFilled from '@tabler/icons-react-native/IconGiftFilled';
 import IconGripVertical from '@tabler/icons-react-native/IconGripVertical';
@@ -115,6 +138,8 @@ import IconHandStop from '@tabler/icons-react-native/IconHandStop';
 import IconHandTwoFingers from '@tabler/icons-react-native/IconHandTwoFingers';
 import IconHash from '@tabler/icons-react-native/IconHash';
 import IconHeadphones from '@tabler/icons-react-native/IconHeadphones';
+import IconHeadset from '@tabler/icons-react-native/IconHeadset';
+import IconHeadsetFilled from '@tabler/icons-react-native/IconHeadsetFilled';
 import IconHeart from '@tabler/icons-react-native/IconHeart';
 import IconHeartFilled from '@tabler/icons-react-native/IconHeartFilled';
 import IconHelpCircle from '@tabler/icons-react-native/IconHelpCircle';
@@ -125,8 +150,10 @@ import IconHomeFilled from '@tabler/icons-react-native/IconHomeFilled';
 import IconInfoCircle from '@tabler/icons-react-native/IconInfoCircle';
 import IconInfoCircleFilled from '@tabler/icons-react-native/IconInfoCircleFilled';
 import IconKey from '@tabler/icons-react-native/IconKey';
+import IconKeyFilled from '@tabler/icons-react-native/IconKeyFilled';
 import IconKeyboard from '@tabler/icons-react-native/IconKeyboard';
 import IconLayoutGrid from '@tabler/icons-react-native/IconLayoutGrid';
+import IconLeaf from '@tabler/icons-react-native/IconLeaf';
 import IconLifebuoy from '@tabler/icons-react-native/IconLifebuoy';
 import IconLink from '@tabler/icons-react-native/IconLink';
 import IconLinkPlus from '@tabler/icons-react-native/IconLinkPlus';
@@ -142,14 +169,23 @@ import IconMenu2 from '@tabler/icons-react-native/IconMenu2';
 import IconMessage from '@tabler/icons-react-native/IconMessage';
 import IconMessageFilled from '@tabler/icons-react-native/IconMessageFilled';
 import IconMessages from '@tabler/icons-react-native/IconMessages';
+import IconMessagesFilled from '@tabler/icons-react-native/IconMessagesFilled';
 import IconMicrophone from '@tabler/icons-react-native/IconMicrophone';
 import IconMicrophoneFilled from '@tabler/icons-react-native/IconMicrophoneFilled';
 import IconMicrophoneOff from '@tabler/icons-react-native/IconMicrophoneOff';
 import IconMinimize from '@tabler/icons-react-native/IconMinimize';
 import IconMinus from '@tabler/icons-react-native/IconMinus';
+import IconMoodHappy from '@tabler/icons-react-native/IconMoodHappy';
+import IconMoodHappyFilled from '@tabler/icons-react-native/IconMoodHappyFilled';
 import IconMoodSmile from '@tabler/icons-react-native/IconMoodSmile';
 import IconMoodSmileFilled from '@tabler/icons-react-native/IconMoodSmileFilled';
+import IconMoon from '@tabler/icons-react-native/IconMoon';
+import IconMoonFilled from '@tabler/icons-react-native/IconMoonFilled';
+import IconPalette from '@tabler/icons-react-native/IconPalette';
+import IconPaletteFilled from '@tabler/icons-react-native/IconPaletteFilled';
 import IconPaperclip from '@tabler/icons-react-native/IconPaperclip';
+import IconPaw from '@tabler/icons-react-native/IconPaw';
+import IconPawFilled from '@tabler/icons-react-native/IconPawFilled';
 import IconPencil from '@tabler/icons-react-native/IconPencil';
 import IconPhone from '@tabler/icons-react-native/IconPhone';
 import IconPhoneFilled from '@tabler/icons-react-native/IconPhoneFilled';
@@ -159,6 +195,7 @@ import IconPhotoFilled from '@tabler/icons-react-native/IconPhotoFilled';
 import IconPin from '@tabler/icons-react-native/IconPin';
 import IconPinFilled from '@tabler/icons-react-native/IconPinFilled';
 import IconPinnedOff from '@tabler/icons-react-native/IconPinnedOff';
+import IconPlane from '@tabler/icons-react-native/IconPlane';
 import IconPlayerPause from '@tabler/icons-react-native/IconPlayerPause';
 import IconPlayerPauseFilled from '@tabler/icons-react-native/IconPlayerPauseFilled';
 import IconPlayerPlay from '@tabler/icons-react-native/IconPlayerPlay';
@@ -169,10 +206,13 @@ import IconQuestionMark from '@tabler/icons-react-native/IconQuestionMark';
 import IconQuote from '@tabler/icons-react-native/IconQuote';
 import IconRefresh from '@tabler/icons-react-native/IconRefresh';
 import IconRepeat from '@tabler/icons-react-native/IconRepeat';
+import IconRobot from '@tabler/icons-react-native/IconRobot';
 import IconRosetteDiscountCheck from '@tabler/icons-react-native/IconRosetteDiscountCheck';
 import IconRosetteDiscountCheckFilled from '@tabler/icons-react-native/IconRosetteDiscountCheckFilled';
 import IconScan from '@tabler/icons-react-native/IconScan';
 import IconSearch from '@tabler/icons-react-native/IconSearch';
+import IconSeedling from '@tabler/icons-react-native/IconSeedling';
+import IconSeedlingFilled from '@tabler/icons-react-native/IconSeedlingFilled';
 import IconSend from '@tabler/icons-react-native/IconSend';
 import IconSendFilled from '@tabler/icons-react-native/IconSendFilled';
 import IconServer from '@tabler/icons-react-native/IconServer';
@@ -189,22 +229,32 @@ import IconShieldX from '@tabler/icons-react-native/IconShieldX';
 import IconSparkles from '@tabler/icons-react-native/IconSparkles';
 import IconSparklesFilled from '@tabler/icons-react-native/IconSparklesFilled';
 import IconSpeakerphone from '@tabler/icons-react-native/IconSpeakerphone';
+import IconSquare from '@tabler/icons-react-native/IconSquare';
+import IconSquareFilled from '@tabler/icons-react-native/IconSquareFilled';
+import IconStack from '@tabler/icons-react-native/IconStack';
 import IconStack2 from '@tabler/icons-react-native/IconStack2';
 import IconStack2Filled from '@tabler/icons-react-native/IconStack2Filled';
+import IconStackFilled from '@tabler/icons-react-native/IconStackFilled';
 import IconStar from '@tabler/icons-react-native/IconStar';
 import IconStarFilled from '@tabler/icons-react-native/IconStarFilled';
+import IconSun from '@tabler/icons-react-native/IconSun';
+import IconSunFilled from '@tabler/icons-react-native/IconSunFilled';
+import IconSword from '@tabler/icons-react-native/IconSword';
 import IconTag from '@tabler/icons-react-native/IconTag';
 import IconTagFilled from '@tabler/icons-react-native/IconTagFilled';
 import IconTagOff from '@tabler/icons-react-native/IconTagOff';
+import IconTarget from '@tabler/icons-react-native/IconTarget';
 import IconThumbDown from '@tabler/icons-react-native/IconThumbDown';
 import IconThumbDownFilled from '@tabler/icons-react-native/IconThumbDownFilled';
 import IconThumbUp from '@tabler/icons-react-native/IconThumbUp';
 import IconThumbUpFilled from '@tabler/icons-react-native/IconThumbUpFilled';
 import IconTicket from '@tabler/icons-react-native/IconTicket';
 import IconTicketFilled from '@tabler/icons-react-native/IconTicketFilled';
+import IconTools from '@tabler/icons-react-native/IconTools';
 import IconToolsKitchen2 from '@tabler/icons-react-native/IconToolsKitchen2';
 import IconTrash from '@tabler/icons-react-native/IconTrash';
 import IconTrashFilled from '@tabler/icons-react-native/IconTrashFilled';
+import IconTree from '@tabler/icons-react-native/IconTree';
 import IconTrophy from '@tabler/icons-react-native/IconTrophy';
 import IconTrophyFilled from '@tabler/icons-react-native/IconTrophyFilled';
 import IconUser from '@tabler/icons-react-native/IconUser';
@@ -224,6 +274,7 @@ import IconWorld from '@tabler/icons-react-native/IconWorld';
 import IconX from '@tabler/icons-react-native/IconX';
 
 export const TablerIcons = {
+  IconAi,
   IconAlertCircle,
   IconAlertCircleFilled,
   IconAlertTriangle,
@@ -238,17 +289,25 @@ export const TablerIcons = {
   IconArrowsExchange,
   IconArrowsUpDown,
   IconAt,
+  IconBadge,
+  IconBadgeFilled,
   IconBan,
   IconBell,
   IconBellFilled,
   IconBellOff,
   IconBolt,
   IconBoltFilled,
+  IconBook,
+  IconBookFilled,
   IconBookmark,
   IconBookmarkFilled,
   IconBookmarkOff,
+  IconBriefcase,
+  IconBriefcaseFilled,
   IconBroadcast,
   IconBrush,
+  IconBug,
+  IconBugFilled,
   IconBuildingBank,
   IconBuildingStore,
   IconCalendar,
@@ -299,6 +358,8 @@ export const TablerIcons = {
   IconCurrencyDollar,
   IconDeviceDesktop,
   IconDeviceDesktopFilled,
+  IconDeviceFloppy,
+  IconDeviceFloppyFilled,
   IconDeviceGamepad,
   IconDeviceMobile,
   IconDots,
@@ -311,6 +372,9 @@ export const TablerIcons = {
   IconEyeOff,
   IconFaceId,
   IconFile,
+  IconFileCode,
+  IconFileCodeFilled,
+  IconFileFilled,
   IconFileText,
   IconFileTextFilled,
   IconFlag,
@@ -318,6 +382,9 @@ export const TablerIcons = {
   IconFlame,
   IconFlameFilled,
   IconFlask,
+  IconFlaskFilled,
+  IconFolder,
+  IconFolderFilled,
   IconGift,
   IconGiftFilled,
   IconGripVertical,
@@ -326,6 +393,8 @@ export const TablerIcons = {
   IconHandTwoFingers,
   IconHash,
   IconHeadphones,
+  IconHeadset,
+  IconHeadsetFilled,
   IconHeart,
   IconHeartFilled,
   IconHelpCircle,
@@ -336,8 +405,10 @@ export const TablerIcons = {
   IconInfoCircle,
   IconInfoCircleFilled,
   IconKey,
+  IconKeyFilled,
   IconKeyboard,
   IconLayoutGrid,
+  IconLeaf,
   IconLifebuoy,
   IconLink,
   IconLinkPlus,
@@ -353,14 +424,23 @@ export const TablerIcons = {
   IconMessage,
   IconMessageFilled,
   IconMessages,
+  IconMessagesFilled,
   IconMicrophone,
   IconMicrophoneFilled,
   IconMicrophoneOff,
   IconMinimize,
   IconMinus,
+  IconMoodHappy,
+  IconMoodHappyFilled,
   IconMoodSmile,
   IconMoodSmileFilled,
+  IconMoon,
+  IconMoonFilled,
+  IconPalette,
+  IconPaletteFilled,
   IconPaperclip,
+  IconPaw,
+  IconPawFilled,
   IconPencil,
   IconPhone,
   IconPhoneFilled,
@@ -370,6 +450,7 @@ export const TablerIcons = {
   IconPin,
   IconPinFilled,
   IconPinnedOff,
+  IconPlane,
   IconPlayerPause,
   IconPlayerPauseFilled,
   IconPlayerPlay,
@@ -380,10 +461,13 @@ export const TablerIcons = {
   IconQuote,
   IconRefresh,
   IconRepeat,
+  IconRobot,
   IconRosetteDiscountCheck,
   IconRosetteDiscountCheckFilled,
   IconScan,
   IconSearch,
+  IconSeedling,
+  IconSeedlingFilled,
   IconSend,
   IconSendFilled,
   IconServer,
@@ -400,22 +484,32 @@ export const TablerIcons = {
   IconSparkles,
   IconSparklesFilled,
   IconSpeakerphone,
+  IconSquare,
+  IconSquareFilled,
+  IconStack,
   IconStack2,
   IconStack2Filled,
+  IconStackFilled,
   IconStar,
   IconStarFilled,
+  IconSun,
+  IconSunFilled,
+  IconSword,
   IconTag,
   IconTagFilled,
   IconTagOff,
+  IconTarget,
   IconThumbDown,
   IconThumbDownFilled,
   IconThumbUp,
   IconThumbUpFilled,
   IconTicket,
   IconTicketFilled,
+  IconTools,
   IconToolsKitchen2,
   IconTrash,
   IconTrashFilled,
+  IconTree,
   IconTrophy,
   IconTrophyFilled,
   IconUser,

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -91,6 +91,7 @@ import IconDeviceDesktopFilled from '@tabler/icons-react-native/IconDeviceDeskto
 import IconDeviceGamepad from '@tabler/icons-react-native/IconDeviceGamepad';
 import IconDeviceMobile from '@tabler/icons-react-native/IconDeviceMobile';
 import IconDots from '@tabler/icons-react-native/IconDots';
+import IconDotsVertical from '@tabler/icons-react-native/IconDotsVertical';
 import IconDownload from '@tabler/icons-react-native/IconDownload';
 import IconEdit from '@tabler/icons-react-native/IconEdit';
 import IconExternalLink from '@tabler/icons-react-native/IconExternalLink';
@@ -105,6 +106,7 @@ import IconFlag from '@tabler/icons-react-native/IconFlag';
 import IconFlagFilled from '@tabler/icons-react-native/IconFlagFilled';
 import IconFlame from '@tabler/icons-react-native/IconFlame';
 import IconFlameFilled from '@tabler/icons-react-native/IconFlameFilled';
+import IconFlask from '@tabler/icons-react-native/IconFlask';
 import IconGift from '@tabler/icons-react-native/IconGift';
 import IconGiftFilled from '@tabler/icons-react-native/IconGiftFilled';
 import IconGripVertical from '@tabler/icons-react-native/IconGripVertical';
@@ -300,6 +302,7 @@ export const TablerIcons = {
   IconDeviceGamepad,
   IconDeviceMobile,
   IconDots,
+  IconDotsVertical,
   IconDownload,
   IconEdit,
   IconExternalLink,
@@ -314,6 +317,7 @@ export const TablerIcons = {
   IconFlagFilled,
   IconFlame,
   IconFlameFilled,
+  IconFlask,
   IconGift,
   IconGiftFilled,
   IconGripVertical,

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -5,10 +5,12 @@ import {
   useReanimatedKeyboardAnimation,
 } from 'react-native-keyboard-controller';
 import {
+  Easing,
   runOnJS,
   useAnimatedReaction,
   useDerivedValue,
   useSharedValue,
+  withTiming,
   type DerivedValue,
   type SharedValue,
 } from 'react-native-reanimated';
@@ -141,6 +143,15 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // 1 while the in-panel search field is focused. Drives the panel "lift" so it
   // rides above the keyboard the search field summons (see spacer worklet).
   const searchFocusedSV = useSharedValue(0);
+  // Cold-open slide progress (0 → 1). When the panel is opened with NO keyboard
+  // up, there's no OS keyboard slide to provide motion, so the spacer would snap
+  // from the resting chrome straight to the panel height in one frame (the panel
+  // just "appears"). We animate this 0→1 with a timing curve on a cold open and
+  // interpolate the spacer between the resting chrome and the panel height by it,
+  // so the panel slides up like a keyboard would. When opening FROM a keyboard
+  // it's set to 1 immediately so the existing reveal-as-the-keyboard-slides
+  // behaviour is unchanged (animating there would fight the OS keyboard).
+  const coldOpenSV = useSharedValue(1);
   // Keyboard up/down, flipped at animation start so the panel can be preloaded
   // in the keyboard's footprint and revealed when the keyboard dismisses.
   const [keyboardVisible, setKeyboardVisible] = useState(false);
@@ -211,7 +222,13 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
       // keyboard height) so the keyboard DISMISS that happens during open
       // doesn't transiently inflate the panel.
       const searchLift = searchFocusedSV.value === 1 ? liveKeyboardHeight : 0;
-      return Math.max(lastKeyboardHeight.value + searchLift, restingFootprint);
+      const target = Math.max(lastKeyboardHeight.value + searchLift, restingFootprint);
+      // Cold open (no keyboard to provide the slide): ramp from the resting
+      // chrome up to the panel target by coldOpenSV so the panel slides in. When
+      // opened from a keyboard, coldOpenSV is already 1 → returns the full target
+      // immediately (the keyboard slide does the motion). The Math.max floor
+      // keeps it from ever dropping below the resting chrome mid-ramp.
+      return Math.max(restingFootprint + (target - restingFootprint) * coldOpenSV.value, restingFootprint);
     }
     if (closingSV.value === 1) {
       // Closing the panel by summoning the keyboard back: hold the panel
@@ -225,13 +242,40 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     return Math.max(liveKeyboardHeight, restingFootprint);
   });
 
-  // Publish the panel's below-pill footprint (the spacer height) WHILE the panel
-  // is open, else 0. The chat list's KeyboardChatScrollView adds this to its
-  // `extraContentPadding` so that opening the emoji panel (keyboard down, so the
-  // library's own keyboard lift is 0) still lifts the list to clear panel + pill.
-  // UI-thread only (writes a shared value), so it never hits a React re-render.
+  // Publish the panel's below-pill footprint that the chat list must clear, on
+  // top of (and NOT double-counting) the keyboard. The list inset is
+  // `max(blankSpace, keyboardPadding + composerFootprint + composerPanelFootprint)`,
+  // so the panel footprint and the keyboard padding both cover the SAME bottom
+  // zone — publishing the full panel height while the keyboard is still up (or
+  // rising) double-counts it and the list jumps:
+  //   - open from keyboard: keyboardPadding animates kb→0 while the panel
+  //     footprint would snap to full instantly → transient ~double inset, then
+  //     settle → the list visibly scrolls DOWN as it settles. (#2)
+  //   - re-summon keyboard from panel: footprint snaps to 0 the instant the
+  //     panel closes, before the keyboard has risen → inset dips then the
+  //     rising keyboard overshoots → empty space below the last message. (#3)
+  // Fix: publish `max(0, panelHeight - liveKeyboard)`. As the keyboard slides
+  // out the footprint ramps in by exactly the amount the keyboard padding drops
+  // (and vice versa on re-summon), so `keyboardPadding + panelFootprint` stays
+  // continuous through the whole swap — no jump in either direction. Published
+  // while the panel is open OR mid closing-hand-off so the close stays
+  // continuous too. UI-thread only (writes a shared value), no React re-render.
   useAnimatedReaction(
-    () => (panelOpenSV.value === 1 ? spacerHeight.value : 0),
+    () => {
+      const active = panelOpenSV.value === 1 || closingSV.value === 1;
+      if (!active) return 0;
+      const liveKeyboardHeight = Math.max(-keyboardHeight.value, 0);
+      // panelHeight is what the spacer holds for the panel (last keyboard height,
+      // clamped to the resting chrome). Subtract the live keyboard so the two
+      // never stack over the same zone.
+      const restingFootprint = restingChromeHeight + bottomInset;
+      const panelHeight = Math.max(lastKeyboardHeight.value, restingFootprint);
+      // On a cold open the spacer ramps the panel in by coldOpenSV — track the
+      // SAME ramp here so the list lift stays in lockstep with the sliding panel
+      // (no gap between the last message and the rising panel during the slide).
+      const rampedPanel = restingFootprint + (panelHeight - restingFootprint) * coldOpenSV.value;
+      return Math.max(0, rampedPanel - liveKeyboardHeight);
+    },
     (panelFootprint) => {
       composerPanelFootprintSV.value = panelFootprint;
     },
@@ -301,7 +345,16 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     // the tab bar hidden across the whole panel↔keyboard hand-off (no flicker).
     composerBottomBusySV.value = 1;
     // Remember whether a keyboard was up at open time — drives the close path.
-    openedWithKeyboardRef.current = KeyboardController.isVisible();
+    const keyboardWasUp = KeyboardController.isVisible();
+    openedWithKeyboardRef.current = keyboardWasUp;
+    // Cold open (no keyboard to slide): animate the spacer in. Opened from a
+    // keyboard: jump to 1 so the keyboard's own slide reveals the panel.
+    if (keyboardWasUp) {
+      coldOpenSV.value = 1;
+    } else {
+      coldOpenSV.value = 0;
+      coldOpenSV.value = withTiming(1, { duration: 220, easing: Easing.out(Easing.cubic) });
+    }
     onVisibilityRef.current?.(true);
     setPanelOpen(true);
     // keepFocus keeps the caret + insertion point while hiding the keyboard.

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -237,6 +237,42 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     },
   );
 
+  // Self-correcting tab-bar guard. The tab bar hides itself purely off
+  // `composerBottomBusySV` (opacity 1/0), which `openPanel` sets to 1 and which
+  // every exit path must clear. Two hand-off paths (onInputFocus, the keyboard
+  // branch of closePanelAndRestoreKeyboard) DON'T clear it directly — they rely
+  // on the summoned keyboard's `onEnd(height>0)` firing. If that settle never
+  // arrives (focus race, keyboard already up so no fresh onEnd, OS quirk), the
+  // flag stays 1 and the tab bar is stuck HIDDEN (reported on the prod build,
+  // non-deterministic). This reaction makes the flag impossible to leave stuck:
+  // once the panel is closed AND no keyboard hand-off is in flight, nothing can
+  // legitimately own the bottom, so force-release it. Runs on the UI thread, so
+  // it self-heals within a frame of the racing state settling — no React lag,
+  // and it never fights a legitimate hold (panel open or mid hand-off both keep
+  // one of the two flags set). Mirror of the channels "bar visible above panel"
+  // bug — same flag, opposite direction — so this hardens both.
+  useAnimatedReaction(
+    () => {
+      if (panelOpenSV.value === 1) return false; // panel open → legitimately busy
+      if (closingSV.value === 0) return true; // closed, no hand-off → must be idle
+      // A hand-off is armed (closingSV===1). It's legitimate ONLY while the
+      // summoned keyboard is rising. Once the keyboard is essentially fully up,
+      // the hand-off is effectively complete even if onEnd hasn't fired — so the
+      // bottom can be released. This covers the "onEnd(height>0) never arrives"
+      // race that otherwise leaves both flags stuck and the tab bar hidden.
+      const liveKb = Math.max(-keyboardHeight.value, 0);
+      const kbTarget = lastKeyboardHeight.value;
+      return kbTarget > 0 && liveKb >= kbTarget * 0.9;
+    },
+    (shouldRelease) => {
+      if (shouldRelease && composerBottomBusySV.value !== 0) {
+        composerBottomBusySV.value = 0;
+        // Disarm the hand-off too so it can't re-trigger a stuck state.
+        if (closingSV.value !== 0) closingSV.value = 0;
+      }
+    },
+  );
+
   // Whether the emoji panel should be PAINTED (1) or hidden (0), on the UI
   // thread so it tracks the keyboard with no React lag. Painted when:
   //   - the panel is open; or
@@ -256,13 +292,16 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
 
   const openPanel = useCallback(() => {
     closingSV.value = 0;
+    // Mark the panel open BEFORE arming the bottom-busy flag so the
+    // self-correcting guard's "idle" condition (panel closed && not closing) is
+    // already false — it can never clear the flag we're about to set.
+    panelOpenRef.current = true;
+    panelOpenSV.value = 1;
     // The composer owns the bottom from now until the keyboard settles — keeps
     // the tab bar hidden across the whole panel↔keyboard hand-off (no flicker).
     composerBottomBusySV.value = 1;
     // Remember whether a keyboard was up at open time — drives the close path.
     openedWithKeyboardRef.current = KeyboardController.isVisible();
-    panelOpenRef.current = true;
-    panelOpenSV.value = 1;
     onVisibilityRef.current?.(true);
     setPanelOpen(true);
     // keepFocus keeps the caret + insertion point while hiding the keyboard.

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -140,6 +140,13 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // keyboard hand-off — there's no keyboard coming back, so the spacer should
   // collapse to 0 rather than hold the footprint forever (which leaves a gap).
   const openedWithKeyboardRef = useRef(false);
+  // UI-thread mirror of openedWithKeyboardRef, so worklets can branch on it.
+  // Gates the chat-list freeze: we only freeze the list's auto-scroll when the
+  // panel is opened FROM a keyboard (to suppress the library chasing the
+  // dismissing keyboard). On a COLD open (no keyboard) there's nothing to chase,
+  // and freezing would also block the extra-padding lift that should scroll the
+  // list up to clear the panel — so freeze must stay off in that case.
+  const openedWithKeyboardSV = useSharedValue(0);
   // 1 while the in-panel search field is focused. Drives the panel "lift" so it
   // rides above the keyboard the search field summons (see spacer worklet).
   const searchFocusedSV = useSharedValue(0);
@@ -287,16 +294,22 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     },
   );
 
-  // Freeze the chat list's keyboard-driven auto-scroll WHILE the panel is open.
-  // Opening the panel dismisses the keyboard; the keyboard library reads that as
-  // a plain keyboard close and scrolls the list down to chase the descending
-  // keyboard (the variable "scrolls down a little / a lot" on emoji-open). Since
-  // the panel takes the keyboard's place, the list shouldn't move at all. Freeze
-  // suppresses that chase (the scrollable range still grows for the panel via the
-  // contentInset path, which is not gated by freeze). Scoped to panelOpen only so
-  // a re-summoned keyboard is handled normally the instant the panel closes.
+  // Freeze the chat list's keyboard-driven auto-scroll while the panel is open
+  // AND was opened FROM a keyboard. That's the only case that needs it: opening
+  // from a keyboard dismisses it, and the keyboard library reads that as a plain
+  // close and scrolls the list down to chase the descending keyboard (the
+  // variable "scrolls down a little / a lot" on emoji-open). The panel takes the
+  // keyboard's place, so the list shouldn't move — freeze suppresses the chase.
+  //
+  // On a COLD open (no keyboard up) there's nothing to chase, and we WANT the
+  // list to scroll up to clear the newly-grown panel footprint — that lift is
+  // driven by the extra-padding scroll correction, which freeze also blocks. So
+  // freeze must stay OFF for a cold open, or the last message stays hidden behind
+  // the panel (the keyboard scrolls up, the cold panel didn't). Gating on
+  // openedWithKeyboardSV gives the keyboard path no-chase and the cold path a
+  // proper lift.
   useAnimatedReaction(
-    () => panelOpenSV.value === 1,
+    () => panelOpenSV.value === 1 && openedWithKeyboardSV.value === 1,
     (frozen) => {
       composerListFreezeSV.value = frozen;
     },
@@ -368,6 +381,7 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     // Remember whether a keyboard was up at open time — drives the close path.
     const keyboardWasUp = KeyboardController.isVisible();
     openedWithKeyboardRef.current = keyboardWasUp;
+    openedWithKeyboardSV.value = keyboardWasUp ? 1 : 0;
     // Cold open (no keyboard to slide): animate the spacer in. Opened from a
     // keyboard: jump to 1 so the keyboard's own slide reveals the panel.
     if (keyboardWasUp) {

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -182,8 +182,14 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
           // value during render (which Reanimated strict mode warns about).
           runOnJS(rememberSessionKeyboardHeight)(e.height);
           // Keyboard is up and covering the bottom — the hand-off is done; the
-          // tab bar's own keyboard check now keeps it hidden.
-          composerBottomBusySV.value = 0;
+          // tab bar's own keyboard check now keeps it hidden. BUT only release
+          // the bottom if the panel isn't holding it: in a slow (channel)
+          // subtree the keyboard's settle event can arrive AFTER the user has
+          // already tapped emoji to open the panel; releasing here then would
+          // leave the tab bar visible OVER the open panel for as long as it's
+          // open (the persistent channels bug). Guarded exactly like the
+          // height==0 branch below.
+          if (panelOpenSV.value !== 1) composerBottomBusySV.value = 0;
         } else {
           // Keyboard fully hidden — nothing to bridge to.
           closingSV.value = 0;

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -15,7 +15,7 @@ import {
   type SharedValue,
 } from 'react-native-reanimated';
 import { composerBottomBusySV } from '@/services/ui/composerPanelVisible';
-import { composerPanelFootprintSV } from '@/services/ui/composerFootprint';
+import { composerPanelFootprintSV, composerListFreezeSV } from '@/services/ui/composerFootprint';
 
 export interface ComposerPanelOptions {
   /** Bottom safe-area inset to leave below the pill when nothing is open. */
@@ -278,6 +278,21 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
     },
     (panelFootprint) => {
       composerPanelFootprintSV.value = panelFootprint;
+    },
+  );
+
+  // Freeze the chat list's keyboard-driven auto-scroll WHILE the panel is open.
+  // Opening the panel dismisses the keyboard; the keyboard library reads that as
+  // a plain keyboard close and scrolls the list down to chase the descending
+  // keyboard (the variable "scrolls down a little / a lot" on emoji-open). Since
+  // the panel takes the keyboard's place, the list shouldn't move at all. Freeze
+  // suppresses that chase (the scrollable range still grows for the panel via the
+  // contentInset path, which is not gated by freeze). Scoped to panelOpen only so
+  // a re-summoned keyboard is handled normally the instant the panel closes.
+  useAnimatedReaction(
+    () => panelOpenSV.value === 1,
+    (frozen) => {
+      composerListFreezeSV.value = frozen;
     },
   );
 

--- a/scripts/gen-tabler-registry.mjs
+++ b/scripts/gen-tabler-registry.mjs
@@ -1,12 +1,24 @@
-// Regenerates components/ui/tablerIconRegistry.ts from the icon names
-// referenced in components/ui/IconSymbol.tsx.
+// Regenerates components/ui/tablerIconRegistry.ts.
 //
 // Why this exists: importing the @tabler/icons-react-native barrel pulls all
 // ~6000 icons into every Metro bundle (no dev tree-shaking), inflating each
 // route to ~14k modules and OOM-crashing the dev server. The registry
-// deep-imports ONLY the icons we use.
+// deep-imports ONLY the icons we actually use.
 //
-// Run after adding/removing an icon in IconSymbol's SF_TO_TABLER map:
+// TWO sources feed the registry — keep BOTH or the channel icon picker blanks:
+//   1. Every `IconXxx` token literally referenced in components/ui/IconSymbol.tsx
+//      (the SF_TO_TABLER table + any direct references).
+//   2. The shared channel/group icon-picker vocabulary (`ICON_OPTIONS` +
+//      `FILLED_ICONS` in @quilibrium/quorum-shared). The picker renders those
+//      SEMANTIC names (e.g. `robot`, `leaf`), which IconSymbol resolves to a
+//      Tabler component at RUNTIME via its SF_TO_TABLER map or a PascalCase
+//      fallback (`robot` -> IconRobot). Those names never appear as `IconXxx`
+//      tokens in source, so source-scraping alone (source 1) MISSES them and
+//      the picker shows blank cells. We resolve the vocabulary here with the
+//      SAME logic IconSymbol uses, so "the picker can offer it" always implies
+//      "the registry contains it" — including filled variants.
+//
+// Run after changing IconSymbol's map OR when shared's picker vocabulary grows:
 //   node scripts/gen-tabler-registry.mjs   (or: npm run gen:icons)
 
 import fs from 'node:fs';
@@ -17,7 +29,12 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const SRC = path.join(root, 'components/ui/IconSymbol.tsx');
 const OUT = path.join(root, 'components/ui/tablerIconRegistry.ts');
 const ICONS_DIR = path.join(root, 'node_modules/@tabler/icons-react-native/dist/esm/icons');
+const VOCAB = path.join(
+  root,
+  'node_modules/@quilibrium/quorum-shared/src/primitives/Icon/pickerVocabulary.ts',
+);
 
+// The set of Tabler component names that actually exist in the installed package.
 const have = new Set(
   fs
     .readdirSync(ICONS_DIR)
@@ -27,20 +44,95 @@ const have = new Set(
 
 const src = fs.readFileSync(SRC, 'utf8');
 const names = new Set();
+
+// --- Source 1: every IconXxx token referenced in IconSymbol.tsx ---------------
 for (const m of src.matchAll(/\bIcon[A-Za-z0-9]+\b/g)) {
   if (have.has(m[0])) names.add(m[0]);
 }
+
+// --- Resolution helpers, mirroring IconSymbol.tsx's resolveTablerComponent -----
+// Parse the SF_TO_TABLER / picker-vocabulary entries:  'name': tabler('IconBase'[, 'IconFilled']),
+const sfToTabler = {};
+for (const m of src.matchAll(
+  /'([a-z0-9.\-]+)':\s*tabler\('(Icon[A-Za-z0-9]+)'(?:\s*,\s*'(Icon[A-Za-z0-9]+)')?\)/g,
+)) {
+  const [, key, base, filled] = m;
+  if (!(key in sfToTabler)) sfToTabler[key] = { base, filled };
+}
+
+function pascalCase(s) {
+  return s
+    .split(/[-.]/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join('');
+}
+
+// Resolve a semantic name to its OUTLINE Tabler component, the same way
+// IconSymbol does: SF_TO_TABLER base, else `Icon${PascalCase}`.
+function resolveBase(name) {
+  const entry = sfToTabler[name];
+  if (entry) return entry.base;
+  return `Icon${pascalCase(name)}`;
+}
+
+// Resolve a semantic name to its FILLED Tabler component (if any): SF_TO_TABLER's
+// explicit `filled`, else `${base}Filled`. Returns null when no filled form exists.
+function resolveFilled(name) {
+  const entry = sfToTabler[name];
+  if (entry && entry.filled) return entry.filled;
+  const base = resolveBase(name);
+  return `${base}Filled`;
+}
+
+// --- Source 2: the shared icon-picker vocabulary ------------------------------
+// Read pickerVocabulary.ts SOURCE directly (not via require — the package's ESM
+// exports map can't be loaded by a plain Node script, confirmed 2026-06-20).
+const missingFromPackage = [];
+if (fs.existsSync(VOCAB)) {
+  const vocab = fs.readFileSync(VOCAB, 'utf8');
+
+  // ICON_OPTIONS entries:  { name: 'robot', tier: 5, category: 'Sci-Fi' },
+  const optionNames = [...vocab.matchAll(/name:\s*'([a-z0-9.\-]+)'/g)].map((m) => m[1]);
+  // FILLED_ICONS set members (semantic names whose filled form the picker renders).
+  const filledBlock = (vocab.match(/FILLED_ICONS[^[]*\[([\s\S]*?)\]/) || [])[1] || '';
+  const filledNames = [...filledBlock.matchAll(/'([a-z0-9.\-]+)'/g)].map((m) => m[1]);
+
+  for (const name of optionNames) {
+    const base = resolveBase(name);
+    if (have.has(base)) names.add(base);
+    else missingFromPackage.push(`${name} -> ${base} (outline)`);
+  }
+  for (const name of filledNames) {
+    const filled = resolveFilled(name);
+    if (have.has(filled)) names.add(filled);
+    else missingFromPackage.push(`${name} -> ${filled} (filled)`);
+  }
+} else {
+  console.warn(
+    `WARNING: shared picker vocabulary not found at\n  ${VOCAB}\n` +
+      `Registry built from IconSymbol.tsx only — picker icons may render blank. ` +
+      `Is @quilibrium/quorum-shared installed?`,
+  );
+}
+
 const sorted = [...names].sort();
 
 const header = `/**
  * tablerIconRegistry — GENERATED. Do not edit by hand.
  *
- * Explicit deep-imports of ONLY the Tabler icons IconSymbol.tsx references.
+ * Explicit deep-imports of ONLY the Tabler icons the app can render. Built from
+ * TWO sources (see scripts/gen-tabler-registry.mjs):
+ *   1. every IconXxx token referenced in components/ui/IconSymbol.tsx, and
+ *   2. the shared channel-icon-picker vocabulary (ICON_OPTIONS + FILLED_ICONS),
+ *      resolved through IconSymbol's runtime logic so picker cells never blank.
+ *
  * IconSymbol previously imported the whole @tabler/icons-react-native barrel
  * (~6000 icons), which Metro can't tree-shake in dev — every route bundled
  * ~14k modules and OOM-crashed the dev server. This keeps the graph small.
  *
- * Regenerate after changing IconSymbol's icon map:
+ * Regenerate after changing IconSymbol's map OR when the shared picker
+ * vocabulary grows:
  *   node scripts/gen-tabler-registry.mjs   (npm run gen:icons)
  *
  * Names not listed here resolve to null in IconSymbol (its documented
@@ -53,3 +145,15 @@ const registry = `export const TablerIcons = {\n${sorted.map((n) => `  ${n},`).j
 
 fs.writeFileSync(OUT, header + imports + '\n\n' + registry);
 console.log(`Wrote ${path.relative(root, OUT)} with ${sorted.length} icons.`);
+
+// Surface any picker name that resolved to a Tabler component NOT present in the
+// installed package — those would still blank. (Expected: none. If this prints,
+// the name needs an explicit SF_TO_TABLER mapping in IconSymbol.tsx.)
+if (missingFromPackage.length) {
+  console.warn(
+    `\nWARNING: ${missingFromPackage.length} picker icon(s) resolved to a Tabler ` +
+      `component that does NOT exist in @tabler/icons-react-native — these will ` +
+      `render blank until given an explicit mapping in IconSymbol.tsx:\n` +
+      missingFromPackage.map((x) => `  ${x}`).join('\n'),
+  );
+}

--- a/services/ui/composerFootprint.ts
+++ b/services/ui/composerFootprint.ts
@@ -42,3 +42,21 @@ export const composerFootprintSV: SharedValue<number> = makeMutable(60);
  * mirroring how it clears `keyboard + pill` when the keyboard is up.
  */
 export const composerPanelFootprintSV: SharedValue<number> = makeMutable(0);
+
+/**
+ * composerListFreezeSV — `true` while the emoji panel is open (keyboard down,
+ * panel showing). Fed to KeyboardChatScrollView's `freeze` prop.
+ *
+ * Why: tapping the emoji button DISMISSES the keyboard to reveal the panel. From
+ * the keyboard library's point of view that's just a keyboard CLOSE, so its
+ * onMove handler actively `scrollTo`s the list down to follow the descending
+ * keyboard — the panel is replacing that space, so the list shouldn't move at
+ * all. `freeze` is the library's purpose-built switch for exactly this ("useful
+ * when dismissing the keyboard to open a bottom sheet — prevents visual
+ * disruption while the sheet is visible"). It suppresses the keyboard-driven
+ * AND extra-padding-driven auto-scroll while still letting the scrollable range
+ * (contentInset) grow for the panel, so the list holds position through the swap.
+ * Set true the instant the panel opens (before the dismiss starts) and false the
+ * instant it closes, so a returning keyboard is handled normally.
+ */
+export const composerListFreezeSV: SharedValue<boolean> = makeMutable(false);


### PR DESCRIPTION
Fixes several edge cases in the chat composer's keyboard ↔ emoji-panel interaction, reported on device.

## Fixes
- **Tab bar could vanish after using the emoji panel.** The tab bar hides itself off a single flag that every exit path had to clear; a missed clear on a hand-off path left it stuck hidden. Added a self-correcting guard so the flag can no longer get stuck.
- **Tab bar could appear over the emoji panel (channels).** Root cause: the keyboard's settle event could land after the panel had already opened (slower in channels) and release the "hide" flag while the panel was open. Guarded the release so a keyboard settle never reveals the bar while the panel owns the bottom.
- **Message list scrolled down when opening the panel from the keyboard.** The list was chasing the dismissing keyboard. Used the keyboard library's freeze switch to hold the list still during the swap (gated so a cold open still lifts the list).
- **Empty space below the last message when bringing the keyboard back from the panel**, and the reverse scroll jump — fixed by keeping the panel footprint and keyboard padding from double-counting the same space.
- **Emoji panel now slides in when opened from rest** (it used to just appear); opening from the keyboard is unchanged (the keyboard slide reveals it).
- **`flask` and `ellipsis.vertical` icons now render** (were missing from the icon registry).

## Testing
Verified on a physical Android device (Motorola Edge 50 Fusion) in both Space channels and DMs. One known minor: the cold-open list lift has a small lag vs the panel slide; acceptable.