### PR TITLE
feat: profile pill navigation

### DIFF
--- a/app/(tabs)/account/index.tsx
+++ b/app/(tabs)/account/index.tsx
@@ -26,7 +26,7 @@ export default function ProfileAccountScreen() {
       <Stack.Screen
         options={{
           headerShown: true,
-          title: 'Profile',
+          title: 'Account',
           // Override layout-level transparent header on iOS — see the
           // comment in profile/index.tsx for the rationale.
           headerTransparent: false,

--- a/app/(tabs)/feed/index.tsx
+++ b/app/(tabs)/feed/index.tsx
@@ -27,6 +27,9 @@ export default function FeedScreen() {
      *  profile screen instead of a thread. */
     profileFid?: string;
     profileUsername?: string;
+    /** Unique per navigation so re-opening the same profile re-triggers the
+     *  feed modal's nav effect even when the tab is already mounted. */
+    profileNonce?: string;
   }>();
 
   // Imperative handle to SocialFeedModal — driven by the
@@ -117,7 +120,7 @@ export default function FeedScreen() {
   const initialProfile = (() => {
     const fid = params.profileFid ? parseInt(params.profileFid, 10) : NaN;
     if (!Number.isFinite(fid) || fid <= 0) return undefined;
-    return { fid, username: params.profileUsername };
+    return { fid, username: params.profileUsername, nonce: params.profileNonce };
   })();
 
   if (fcState.kind === 'checking') {

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -121,7 +121,17 @@ interface ProfileModalProps {
   onOpenMarketplace?: () => void;
   onOpenAuctions?: () => void;
   onOpenOffers?: () => void;
+  /** When set, the parent (UnifiedProfileScreen pill row) drives which section
+   *  is shown; ProfileModal's own inner tab state is ignored. */
+  activeSection?: ProfileSection;
+  /** Hide ProfileModal's built-in Profile/Premium/Settings tab bar — used when
+   *  the parent renders the pill row instead. */
+  hideTabBar?: boolean;
 }
+
+/** The selectable sections of the profile body. 'farcaster' only applies when a
+ *  Farcaster account is connected (the parent gates the pill). */
+export type ProfileSection = 'profile' | 'premium' | 'settings' | 'farcaster';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
@@ -311,6 +321,8 @@ export default function ProfileModal({
   onOpenMarketplace,
   onOpenAuctions,
   onOpenOffers,
+  activeSection,
+  hideTabBar = false,
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
@@ -319,7 +331,11 @@ export default function ProfileModal({
   const { allowSync, setAllowSync, isLoading: isSyncLoading } = useSyncSettings();
   const queryClient = useQueryClient();
   const insets = useSafeAreaInsets();
-  const [activeTab, setActiveTab] = React.useState<'profile' | 'premium' | 'settings'>('profile');
+  const [internalTab, setInternalTab] = React.useState<ProfileSection>('profile');
+  // When the parent drives selection (pill row), follow activeSection; otherwise
+  // use the modal's own tab state.
+  const activeTab = activeSection ?? internalTab;
+  const setActiveTab = setInternalTab;
   const [usernameSearch, setUsernameSearch] = React.useState('');
   const [inviteCode, setInviteCode] = React.useState('');
   // Reset App Data — type-to-confirm (T3: the only catastrophic op; wipes keys).
@@ -1573,27 +1589,29 @@ export default function ProfileModal({
         </View>
       )}
 
-      {/* Tabs */}
-      <View style={styles.tabs}>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'profile' && styles.tabActive]}
-          onPress={() => setActiveTab('profile')}
-        >
-          <Text style={[styles.tabText, activeTab === 'profile' && styles.tabTextActive]}>Profile</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'premium' && styles.tabActive]}
-          onPress={() => setActiveTab('premium')}
-        >
-          <Text style={[styles.tabText, activeTab === 'premium' && styles.tabTextActive]}>Premium</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.tab, activeTab === 'settings' && styles.tabActive]}
-          onPress={() => setActiveTab('settings')}
-        >
-          <Text style={[styles.tabText, activeTab === 'settings' && styles.tabTextActive]}>Settings</Text>
-        </TouchableOpacity>
-      </View>
+      {/* Tabs — hidden when the parent renders the pill row instead */}
+      {!hideTabBar && (
+        <View style={styles.tabs}>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'profile' && styles.tabActive]}
+            onPress={() => setActiveTab('profile')}
+          >
+            <Text style={[styles.tabText, activeTab === 'profile' && styles.tabTextActive]}>Profile</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'premium' && styles.tabActive]}
+            onPress={() => setActiveTab('premium')}
+          >
+            <Text style={[styles.tabText, activeTab === 'premium' && styles.tabTextActive]}>Premium</Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            style={[styles.tab, activeTab === 'settings' && styles.tabActive]}
+            onPress={() => setActiveTab('settings')}
+          >
+            <Text style={[styles.tabText, activeTab === 'settings' && styles.tabTextActive]}>Settings</Text>
+          </TouchableOpacity>
+        </View>
+      )}
 
       <ScrollView
         showsVerticalScrollIndicator={false}
@@ -2106,182 +2124,6 @@ export default function ProfileModal({
               </TouchableOpacity>
             </View>
 
-            {/* Farcaster */}
-            <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Farcaster</Text>
-              {user?.farcaster ? (
-                // Connected state
-                <>
-                  <View style={styles.farcasterConnected}>
-                    <View style={styles.farcasterInfo}>
-                      <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
-                      <View style={styles.farcasterDetails}>
-                        <Text style={styles.farcasterUsername}>@{user.farcaster.username}</Text>
-                        <Text style={styles.farcasterFid}>FID: {user.farcaster.fid}</Text>
-                      </View>
-                    </View>
-                    <TouchableOpacity
-                      style={styles.farcasterDisconnectButton}
-                      onPress={handleDisconnectFarcaster}
-                    >
-                      <Text style={styles.farcasterDisconnectText}>Disconnect</Text>
-                    </TouchableOpacity>
-                  </View>
-                  {/* Feed display preferences — Farcaster-only (drive useFarcasterFeed).
-                      Plain settingRow → uniform 8px marginBottom like every card. */}
-                  <View style={styles.settingRow}>
-                    <View style={styles.settingLeft}>
-                      <Text style={styles.settingLabel}>Show replies in main feed</Text>
-                      <Text style={styles.settingDescription}>
-                        Include reply casts in your main feed (thread views always show replies)
-                      </Text>
-                    </View>
-                    <Switch
-                      value={showRepliesInFeed}
-                      onValueChange={setShowRepliesInFeed}
-                      trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
-                      thumbColor={showRepliesInFeed ? '#ffffff' : '#f4f3f4'}
-                    />
-                  </View>
-                  <View style={styles.settingRow}>
-                    <View style={styles.settingLeft}>
-                      <Text style={styles.settingLabel}>Show replies from non-followed in main feed</Text>
-                      <Text style={styles.settingDescription}>
-                        Include replies from people you don't follow in your main feed
-                      </Text>
-                    </View>
-                    <Switch
-                      value={showNonFollowReplies}
-                      onValueChange={setShowNonFollowReplies}
-                      disabled={!showRepliesInFeed}
-                      trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
-                      thumbColor={showNonFollowReplies ? '#ffffff' : '#f4f3f4'}
-                    />
-                  </View>
-                  {/* Hypersnap signer opt-in */}
-                  <View style={styles.farcasterConnected}>
-                    <View style={{ flex: 1, marginRight: Skin.space(12) }}>
-                      <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>Hypersnap Signer</Text>
-                      <Text style={{ fontSize: Skin.font(12), color: theme.colors.textMuted, marginTop: Skin.space(2) }}>
-                        Post and react through Quilibrium's hub to earn $SNAP
-                      </Text>
-                    </View>
-                    {hypersnapBusy ? (
-                      <ActivityIndicator size="small" color={theme.colors.primary} />
-                    ) : (
-                      <Switch
-                        value={hypersnapEnabled}
-                        onValueChange={handleToggleHypersnap}
-                        trackColor={{ true: theme.colors.primary }}
-                      />
-                    )}
-                  </View>
-                  {/* Warpcast Wallet Import */}
-                  {hasWarpcastWallet && !hasImportedWarpcastWallet && onOpenWarpcastImport && (
-                    <TouchableOpacity
-                      style={[styles.actionButton, { alignItems: 'flex-start' }]}
-                      onPress={() => {
-                        if (isRouteMode) {
-                          // In route mode, just open the import modal directly (no need to close ProfileModal)
-                          onOpenWarpcastImport();
-                        } else {
-                          // In modal mode, close ProfileModal first then open import modal
-                          onClose();
-                          setTimeout(onOpenWarpcastImport, 300);
-                        }
-                      }}
-                    >
-                      <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
-                      <View style={{ flex: 1 }}>
-                        <Text style={styles.actionButtonText}>Import Warpcast Wallet</Text>
-                        <Text style={[styles.settingDescription, { marginTop: Skin.space(4), marginLeft: Skin.space(12) }]}>
-                          Import your Warpcast embedded wallet to use alongside your Quorum wallet
-                        </Text>
-                      </View>
-                      <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} style={{ marginTop: Skin.space(2) }} />
-                    </TouchableOpacity>
-                  )}
-                  {hasImportedWarpcastWallet && importedWallet && (
-                    <View style={styles.farcasterConnected}>
-                      <View style={styles.farcasterInfo}>
-                        <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} />
-                        <View style={styles.farcasterDetails}>
-                          <Text style={styles.farcasterUsername}>Warpcast Wallet</Text>
-                          <Text style={styles.farcasterFid}>
-                            {importedWallet.address.slice(0, 10)}...{importedWallet.address.slice(-6)}
-                          </Text>
-                        </View>
-                      </View>
-                      <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
-                    </View>
-                  )}
-                </>
-              ) : !showFarcasterImport ? (
-                // Not connected state
-                <TouchableOpacity
-                  style={styles.actionButton}
-                  onPress={() => setShowFarcasterImport(true)}
-                >
-                  <IconSymbol name="person.badge.plus" size={20} color={theme.colors.textMain} />
-                  <Text style={styles.actionButtonText}>Import Farcaster Account</Text>
-                  <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
-                </TouchableOpacity>
-              ) : (
-                // Import state
-                <View style={styles.farcasterImportContainer}>
-                  <Text style={styles.farcasterImportDescription}>
-                    Enter your Farcaster recovery phrase (12 or 24 words) to import your account.
-                  </Text>
-                  <TextInput
-                    style={styles.farcasterMnemonicInput}
-                    value={farcasterMnemonic}
-                    onChangeText={(text) => {
-                      setFarcasterMnemonic(text);
-                      setFarcasterError(null);
-                    }}
-                    placeholder="Enter recovery phrase..."
-                    placeholderTextColor={theme.colors.textMuted}
-                    multiline
-                    numberOfLines={3}
-                    textAlignVertical="top"
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    editable={!farcasterImporting}
-                  />
-                  {farcasterError && (
-                    <View style={styles.farcasterErrorContainer}>
-                      <IconSymbol name="exclamationmark.circle.fill" size={16} color={theme.colors.danger} />
-                      <Text style={styles.farcasterErrorText}>{farcasterError}</Text>
-                    </View>
-                  )}
-                  <View style={styles.farcasterImportActions}>
-                    <TouchableOpacity
-                      style={styles.farcasterCancelButton}
-                      onPress={() => {
-                        setShowFarcasterImport(false);
-                        setFarcasterMnemonic('');
-                        setFarcasterError(null);
-                      }}
-                      disabled={farcasterImporting}
-                    >
-                      <Text style={styles.farcasterCancelText}>Cancel</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      style={[styles.farcasterImportButton, farcasterImporting && styles.farcasterImportButtonDisabled]}
-                      onPress={handleImportFarcaster}
-                      disabled={farcasterImporting}
-                    >
-                      {farcasterImporting ? (
-                        <ActivityIndicator size="small" color="#fff" />
-                      ) : (
-                        <Text style={styles.farcasterImportButtonText}>Import</Text>
-                      )}
-                    </TouchableOpacity>
-                  </View>
-                </View>
-              )}
-            </View>
-
             {/* Account Actions */}
             <AccountRecoverySection
               styles={styles}
@@ -2324,6 +2166,183 @@ export default function ProfileModal({
               </TouchableOpacity>
             </View>
           </>
+        )}
+
+        {activeTab === 'farcaster' && (
+          <View style={styles.section}>
+            <Text style={styles.sectionTitle}>Farcaster</Text>
+            {user?.farcaster ? (
+              // Connected state
+              <>
+                <View style={styles.farcasterConnected}>
+                  <View style={styles.farcasterInfo}>
+                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
+                    <View style={styles.farcasterDetails}>
+                      <Text style={styles.farcasterUsername}>@{user.farcaster.username}</Text>
+                      <Text style={styles.farcasterFid}>FID: {user.farcaster.fid}</Text>
+                    </View>
+                  </View>
+                  <TouchableOpacity
+                    style={styles.farcasterDisconnectButton}
+                    onPress={handleDisconnectFarcaster}
+                  >
+                    <Text style={styles.farcasterDisconnectText}>Disconnect</Text>
+                  </TouchableOpacity>
+                </View>
+                {/* Feed display preferences — Farcaster-only (drive useFarcasterFeed).
+                    Plain settingRow → uniform 8px marginBottom like every card. */}
+                <View style={styles.settingRow}>
+                  <View style={styles.settingLeft}>
+                    <Text style={styles.settingLabel}>Show replies in main feed</Text>
+                    <Text style={styles.settingDescription}>
+                      Include reply casts in your main feed (thread views always show replies)
+                    </Text>
+                  </View>
+                  <Switch
+                    value={showRepliesInFeed}
+                    onValueChange={setShowRepliesInFeed}
+                    trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+                    thumbColor={showRepliesInFeed ? '#ffffff' : '#f4f3f4'}
+                  />
+                </View>
+                <View style={styles.settingRow}>
+                  <View style={styles.settingLeft}>
+                    <Text style={styles.settingLabel}>Show replies from non-followed in main feed</Text>
+                    <Text style={styles.settingDescription}>
+                      Include replies from people you don&apos;t follow in your main feed
+                    </Text>
+                  </View>
+                  <Switch
+                    value={showNonFollowReplies}
+                    onValueChange={setShowNonFollowReplies}
+                    disabled={!showRepliesInFeed}
+                    trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+                    thumbColor={showNonFollowReplies ? '#ffffff' : '#f4f3f4'}
+                  />
+                </View>
+                {/* Hypersnap signer opt-in */}
+                <View style={styles.farcasterConnected}>
+                  <View style={{ flex: 1, marginRight: Skin.space(12) }}>
+                    <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>Hypersnap Signer</Text>
+                    <Text style={{ fontSize: Skin.font(12), color: theme.colors.textMuted, marginTop: Skin.space(2) }}>
+                      Post and react through Quilibrium&apos;s hub to earn $SNAP
+                    </Text>
+                  </View>
+                  {hypersnapBusy ? (
+                    <ActivityIndicator size="small" color={theme.colors.primary} />
+                  ) : (
+                    <Switch
+                      value={hypersnapEnabled}
+                      onValueChange={handleToggleHypersnap}
+                      trackColor={{ true: theme.colors.primary }}
+                    />
+                  )}
+                </View>
+                {/* Warpcast Wallet Import */}
+                {hasWarpcastWallet && !hasImportedWarpcastWallet && onOpenWarpcastImport && (
+                  <TouchableOpacity
+                    style={[styles.actionButton, { alignItems: 'flex-start' }]}
+                    onPress={() => {
+                      if (isRouteMode) {
+                        // In route mode, just open the import modal directly (no need to close ProfileModal)
+                        onOpenWarpcastImport();
+                      } else {
+                        // In modal mode, close ProfileModal first then open import modal
+                        onClose();
+                        setTimeout(onOpenWarpcastImport, 300);
+                      }
+                    }}
+                  >
+                    <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                    <View style={{ flex: 1 }}>
+                      <Text style={styles.actionButtonText}>Import Warpcast Wallet</Text>
+                      <Text style={[styles.settingDescription, { marginTop: Skin.space(4), marginLeft: Skin.space(12) }]}>
+                        Import your Warpcast embedded wallet to use alongside your Quorum wallet
+                      </Text>
+                    </View>
+                    <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} style={{ marginTop: Skin.space(2) }} />
+                  </TouchableOpacity>
+                )}
+                {hasImportedWarpcastWallet && importedWallet && (
+                  <View style={styles.farcasterConnected}>
+                    <View style={styles.farcasterInfo}>
+                      <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} />
+                      <View style={styles.farcasterDetails}>
+                        <Text style={styles.farcasterUsername}>Warpcast Wallet</Text>
+                        <Text style={styles.farcasterFid}>
+                          {importedWallet.address.slice(0, 10)}...{importedWallet.address.slice(-6)}
+                        </Text>
+                      </View>
+                    </View>
+                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
+                  </View>
+                )}
+              </>
+            ) : !showFarcasterImport ? (
+              // Not connected state
+              <TouchableOpacity
+                style={styles.actionButton}
+                onPress={() => setShowFarcasterImport(true)}
+              >
+                <IconSymbol name="person.badge.plus" size={20} color={theme.colors.textMain} />
+                <Text style={styles.actionButtonText}>Import Farcaster Account</Text>
+                <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+              </TouchableOpacity>
+            ) : (
+              // Import state
+              <View style={styles.farcasterImportContainer}>
+                <Text style={styles.farcasterImportDescription}>
+                  Enter your Farcaster recovery phrase (12 or 24 words) to import your account.
+                </Text>
+                <TextInput
+                  style={styles.farcasterMnemonicInput}
+                  value={farcasterMnemonic}
+                  onChangeText={(text) => {
+                    setFarcasterMnemonic(text);
+                    setFarcasterError(null);
+                  }}
+                  placeholder="Enter recovery phrase..."
+                  placeholderTextColor={theme.colors.textMuted}
+                  multiline
+                  numberOfLines={3}
+                  textAlignVertical="top"
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  editable={!farcasterImporting}
+                />
+                {farcasterError && (
+                  <View style={styles.farcasterErrorContainer}>
+                    <IconSymbol name="exclamationmark.circle.fill" size={16} color={theme.colors.danger} />
+                    <Text style={styles.farcasterErrorText}>{farcasterError}</Text>
+                  </View>
+                )}
+                <View style={styles.farcasterImportActions}>
+                  <TouchableOpacity
+                    style={styles.farcasterCancelButton}
+                    onPress={() => {
+                      setShowFarcasterImport(false);
+                      setFarcasterMnemonic('');
+                      setFarcasterError(null);
+                    }}
+                    disabled={farcasterImporting}
+                  >
+                    <Text style={styles.farcasterCancelText}>Cancel</Text>
+                  </TouchableOpacity>
+                  <TouchableOpacity
+                    style={[styles.farcasterImportButton, farcasterImporting && styles.farcasterImportButtonDisabled]}
+                    onPress={handleImportFarcaster}
+                    disabled={farcasterImporting}
+                  >
+                    {farcasterImporting ? (
+                      <ActivityIndicator size="small" color="#fff" />
+                    ) : (
+                      <Text style={styles.farcasterImportButtonText}>Import</Text>
+                    )}
+                  </TouchableOpacity>
+                </View>
+              </View>
+            )}
+          </View>
         )}
       </ScrollView>
     </>
@@ -3929,7 +3948,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
         <View style={styles.settingRow}>
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Show Online Status</Text>
-            <Text style={styles.settingDescription}>Let others see when you're active</Text>
+            <Text style={styles.settingDescription}>Let others see when you&apos;re active</Text>
           </View>
           <Switch
             value={true}

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -127,6 +127,9 @@ interface ProfileModalProps {
   /** Hide ProfileModal's built-in Profile/Premium/Settings tab bar — used when
    *  the parent renders the pill row instead. */
   hideTabBar?: boolean;
+  /** Open the current user's own cast feed (their ProfileView). Surfaced as a
+   *  "My Casts" row in the Farcaster section. */
+  onViewMyCasts?: () => void;
 }
 
 /** The selectable sections of the profile body. 'farcaster' only applies when a
@@ -323,6 +326,7 @@ export default function ProfileModal({
   onOpenOffers,
   activeSection,
   hideTabBar = false,
+  onViewMyCasts,
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
@@ -2170,13 +2174,17 @@ export default function ProfileModal({
 
         {activeTab === 'farcaster' && (
           <View style={styles.section}>
-            <Text style={styles.sectionTitle}>Farcaster</Text>
+            {/* The pill already labels this "Farcaster"; only show the heading in
+                the standalone tab-bar mode to avoid a redundant title. */}
+            {!hideTabBar && <Text style={styles.sectionTitle}>Farcaster</Text>}
             {user?.farcaster ? (
               // Connected state
               <>
-                <View style={styles.farcasterConnected}>
-                  <View style={styles.farcasterInfo}>
-                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
+                {/* Account card with Disconnect — first item. Icon top-aligned
+                    to match the Warpcast import row. */}
+                <View style={[styles.farcasterConnected, { alignItems: 'flex-start' }]}>
+                  <View style={[styles.farcasterInfo, { alignItems: 'flex-start' }]}>
+                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} style={{ marginTop: Skin.space(2) }} />
                     <View style={styles.farcasterDetails}>
                       <Text style={styles.farcasterUsername}>@{user.farcaster.username}</Text>
                       <Text style={styles.farcasterFid}>FID: {user.farcaster.fid}</Text>
@@ -2189,6 +2197,15 @@ export default function ProfileModal({
                     <Text style={styles.farcasterDisconnectText}>Disconnect</Text>
                   </TouchableOpacity>
                 </View>
+                {/* My Casts — opens the user's own ProfileView (their cast feed).
+                    Replaces the former dedicated Casts pill. */}
+                {onViewMyCasts && (
+                  <TouchableOpacity style={styles.actionButton} onPress={onViewMyCasts}>
+                    <IconSymbol name="feather" size={20} color={theme.colors.primary} />
+                    <Text style={styles.actionButtonText}>My Casts</Text>
+                    <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+                  </TouchableOpacity>
+                )}
                 {/* Feed display preferences — Farcaster-only (drive useFarcasterFeed).
                     Plain settingRow → uniform 8px marginBottom like every card. */}
                 <View style={styles.settingRow}>
@@ -2352,7 +2369,10 @@ export default function ProfileModal({
   if (isRouteMode) {
     return (
       <>
-        <View style={[styles.routeContainer, { paddingTop: insets.top, backgroundColor: theme.colors.background }]}>
+        {/* When embedded under the pill row (hideHeader), the parent screen
+            already covers the status-bar safe area — adding insets.top here
+            would double up and leave a large gap below the pills. */}
+        <View style={[styles.routeContainer, { paddingTop: hideHeader ? 0 : insets.top, backgroundColor: theme.colors.background }]}>
           {profileContent}
         </View>
 
@@ -2761,7 +2781,9 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
     },
     scrollContent: {
       paddingHorizontal: Skin.space(20),
-      paddingTop: Skin.space(20),
+      // Modest top gap below the pill row (the former tab-bar-era 20 was too
+      // much once the duplicated safe-area inset was removed).
+      paddingTop: Skin.space(16),
     },
     // Trailing space so the last section (e.g. Danger Zone) scrolls clear of
     // the blur tab bar instead of butting against it. Lives on the scroll

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -4586,6 +4586,9 @@ interface SocialFeedModalProps {
   initialProfile?: {
     fid: number;
     username?: string;
+    /** Changes per navigation request so re-opening the same profile re-fires
+     *  the nav effect even when this modal is already mounted on the feed. */
+    nonce?: string;
   };
   /** When true, renders as a full screen without modal animation (for route-based navigation) */
   isRouteMode?: boolean;
@@ -5279,6 +5282,28 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
     }
     return [{ type: 'feed' }];
   });
+
+  // After mount, a new initialProfile request (keyed by fid + nonce) re-navigates
+  // to that profile. The lazy initializer above only runs once, so without this
+  // a second "My Casts"/deep-link tap into a profile while the feed tab is
+  // already mounted would be ignored. The nonce makes same-fid re-pushes fire.
+  const initialProfileKey = initialProfile
+    ? `${initialProfile.fid}:${initialProfile.nonce ?? ''}`
+    : null;
+  // Remember the key the lazy initializer already consumed at mount, so the
+  // effect below doesn't re-navigate for it. null when the tab mounted without
+  // a profile request (then the first real request must NOT be skipped).
+  const seededProfileKeyRef = useRef<string | null>(initialProfileKey);
+  useEffect(() => {
+    if (!initialProfile || initialProfileKey === null) return;
+    if (initialProfileKey === seededProfileKeyRef.current) return; // already shown
+    seededProfileKeyRef.current = initialProfileKey;
+    setNavStack([
+      { type: 'feed' },
+      { type: 'profile', fid: initialProfile.fid, username: initialProfile.username },
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialProfileKey]);
 
   const { openMiniapp } = useMiniappOverlay();
   // Tip flow — one TipModal mounted at this level serves every surface
@@ -6094,6 +6119,15 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
     return m;
   }, [governanceCasts]);
 
+  // Drop optimistic pending top-level casts once the server feed includes
+  // them (matched by the confirmed hash set after the background submit).
+  // Must run before the `if (!rendered)` early return so hook order stays
+  // consistent across renders (react-hooks/rules-of-hooks).
+  useEffect(() => {
+    if (posts && posts.length) optimistic.reconcilePendingByHash(posts.map((p) => p.hash));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [posts, optimistic.reconcilePendingByHash]);
+
   if (!rendered) {
     return null;
   }
@@ -6126,13 +6160,6 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
   const handleRemoveImage = (index: number) => {
     setSelectedImages(prev => prev.filter((_, i) => i !== index));
   };
-
-  // Drop optimistic pending top-level casts once the server feed includes
-  // them (matched by the confirmed hash set after the background submit).
-  useEffect(() => {
-    if (posts && posts.length) optimistic.reconcilePendingByHash(posts.map((p) => p.hash));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [posts, optimistic.reconcilePendingByHash]);
 
   const handleSubmitCast = async () => {
     if (!canPost) {

--- a/components/UnifiedProfileHeader.tsx
+++ b/components/UnifiedProfileHeader.tsx
@@ -1,5 +1,7 @@
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { QuorumLogoIcon } from '@/components/SocialFeed/content/QuorumLogoIcon';
 import type { UserInfo } from '@/context/AuthContext';
 import type { ProfileAuthor } from '@/hooks/useFarcasterProfile';
 import { truncateAddress } from '@/utils/formatAddress';
@@ -156,6 +158,9 @@ function QuorumCard({
   const displayName = user.displayName || user.primaryUsername || 'Unnamed';
   return (
     <TouchableOpacity style={styles.card} activeOpacity={0.85} onPress={onEdit}>
+      <View style={styles.cardEditBadge}>
+        <IconSymbol name="pencil" size={11} color="#fff" />
+      </View>
       <CachedAvatar
         source={user.profileImage ? { uri: user.profileImage } : null}
         style={styles.cardAvatar}
@@ -163,7 +168,7 @@ function QuorumCard({
       />
       <View style={styles.cardText}>
         <View style={styles.cardLabelRow}>
-          <IconSymbol name="shield.fill" size={10} color={theme.colors.accent} />
+          <QuorumLogoIcon size={11} />
           <Text style={[styles.cardLabel, { color: theme.colors.accent }]}>Quorum</Text>
         </View>
         <Text style={styles.cardDisplayName} numberOfLines={1}>{displayName}</Text>
@@ -193,6 +198,9 @@ function FarcasterCard({
   const avatarUri = profile?.pfp?.url || user.farcaster?.pfpUrl;
   return (
     <TouchableOpacity style={styles.card} activeOpacity={0.85} onPress={onEdit}>
+      <View style={styles.cardEditBadge}>
+        <IconSymbol name="pencil" size={11} color="#fff" />
+      </View>
       <CachedAvatar
         source={avatarUri ? { uri: avatarUri } : null}
         style={styles.cardAvatar}
@@ -200,7 +208,7 @@ function FarcasterCard({
       />
       <View style={styles.cardText}>
         <View style={styles.cardLabelRow}>
-          <IconSymbol name="person.2.fill" size={10} color={theme.colors.textMuted} />
+          <FarcasterLogoIcon size={11} color={theme.colors.textMuted} />
           <Text style={[styles.cardLabel, { color: theme.colors.textMuted }]}>Farcaster</Text>
         </View>
         <Text style={styles.cardDisplayName} numberOfLines={1}>{displayName}</Text>
@@ -282,6 +290,7 @@ function createStyles(theme: AppTheme) {
       flex: 1,
       flexDirection: 'row',
       alignItems: 'center',
+      position: 'relative',
       paddingVertical: Skin.space(10),
       paddingHorizontal: Skin.space(10),
       borderRadius: Skin.radius(12),
@@ -297,7 +306,7 @@ function createStyles(theme: AppTheme) {
     cardLabelRow: {
       flexDirection: 'row',
       alignItems: 'center',
-      gap: Skin.space(3),
+      gap: Skin.space(5),
     },
     cardLabel: {
       fontSize: Skin.font(10),
@@ -310,6 +319,20 @@ function createStyles(theme: AppTheme) {
       height: 40,
       borderRadius: Skin.radius(20),
       backgroundColor: theme.colors.surface2,
+    },
+    // Pencil badge in the top-right corner of the split-mode card — signals the
+    // card is tappable to edit, mirroring the merged/Quorum-only header's badge.
+    cardEditBadge: {
+      position: 'absolute',
+      top: Skin.space(6),
+      right: Skin.space(6),
+      width: 18,
+      height: 18,
+      borderRadius: Skin.radius(9),
+      alignItems: 'center',
+      justifyContent: 'center',
+      backgroundColor: theme.colors.accent,
+      zIndex: 1,
     },
     cardDisplayName: {
       fontSize: Skin.font(14),

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -5,7 +5,6 @@ import BuyNameModal from '@/components/qns/BuyNameModal';
 import MarketplaceModal from '@/components/qns/MarketplaceModal';
 import OffersModal from '@/components/qns/OffersModal';
 import type { ResaleListing } from '@/services/api/qnsClient';
-import { ProfileView } from '@/components/SocialFeedModal';
 import UnifiedProfileHeader from '@/components/UnifiedProfileHeader';
 import UnifiedProfileEditModal from '@/components/UnifiedProfileEditModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -18,7 +17,7 @@ import {
 } from '@/services/profile/profilePrefs';
 import { useTheme, type AppTheme } from '@/theme';
 import { useRouter } from 'expo-router';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -42,7 +41,6 @@ export default function UnifiedProfileScreen({
   const [decisionModalVisible, setDecisionModalVisible] = useState(false);
   const [editTarget, setEditTarget] = useState<EditTarget>(null);
   const [editPickerVisible, setEditPickerVisible] = useState(false);
-  const [castLikeStates] = useState<Map<string, { liked: boolean; count: number }>>(() => new Map());
   // Marketplace-family modals are rendered at this level (not inside ProfileModal)
   // so dismissing them doesn't leave the embedded ProfileModal unable to receive
   // touches.
@@ -69,29 +67,48 @@ export default function UnifiedProfileScreen({
   // One flat pill row replaces the old two-level nav. Profile / Premium /
   // Settings always show; Farcaster + Casts only when a Farcaster account is
   // connected (config / feed that don't apply to Quorum-only users).
-  type ProfilePill = ProfileSection | 'casts';
   const pills = useMemo<SegmentedPillItem[]>(() => {
     const list: SegmentedPillItem[] = [
       { key: 'profile', label: 'Profile' },
       { key: 'premium', label: 'Premium' },
       { key: 'settings', label: 'Settings' },
     ];
+    // The Farcaster pill (account, feed prefs, Hypersnap, Warpcast, "My Casts")
+    // only applies when a Farcaster account is connected.
     if (hasFarcaster) {
       list.push({ key: 'farcaster', label: 'Farcaster' });
-      list.push({ key: 'casts', label: 'Casts' });
     }
     return list;
   }, [hasFarcaster]);
 
-  const [activePill, setActivePill] = useState<ProfilePill>('profile');
+  const [activePill, setActivePill] = useState<ProfileSection>('profile');
 
   // If the active pill becomes unavailable (e.g. Farcaster disconnected while on
-  // the Farcaster/Casts pill), fall back to Profile.
+  // the Farcaster pill), fall back to Profile.
   useEffect(() => {
-    if (!hasFarcaster && (activePill === 'farcaster' || activePill === 'casts')) {
+    if (!hasFarcaster && activePill === 'farcaster') {
       setActivePill('profile');
     }
   }, [hasFarcaster, activePill]);
+
+  // Open the current user's own cast feed (their ProfileView) via the feed tab's
+  // existing profileFid deep-link. Surfaced from the Farcaster section's
+  // "My Casts" row instead of a dedicated pill.
+  const handleViewMyCasts = useCallback(() => {
+    const fid = user?.farcaster?.fid;
+    if (!fid) return;
+    router.push({
+      pathname: '/(tabs)/feed',
+      params: {
+        profileFid: String(fid),
+        profileUsername: user?.farcaster?.username ?? '',
+        // Unique per tap so the feed tab (already mounted) re-navigates to the
+        // profile even when the same fid is pushed again. Without it,
+        // useLocalSearchParams returns identical params and nothing re-fires.
+        profileNonce: String(Date.now()),
+      },
+    });
+  }, [router, user?.farcaster?.fid, user?.farcaster?.username]);
 
   const handleEditRequest = () => {
     if (!hasFarcaster) {
@@ -127,7 +144,7 @@ export default function UnifiedProfileScreen({
       <SegmentedPills
         items={pills}
         activeKey={activePill}
-        onChange={(key) => setActivePill(key as ProfilePill)}
+        onChange={(key) => setActivePill(key as ProfileSection)}
         variant="solid"
         scrollable
         centerOnSelect
@@ -136,45 +153,19 @@ export default function UnifiedProfileScreen({
       />
 
       <View style={styles.content}>
-        {activePill === 'casts' ? (
-          user.farcaster?.fid ? (
-            <ProfileView
-              fid={user.farcaster.fid}
-              token={farcasterAuthToken ?? undefined}
-              theme={theme}
-              currentUserFid={user.farcaster.fid}
-              hideBackButton={true}
-              onClose={() => {}}
-              onOpenThread={(username, hashPrefix) =>
-                router.push({
-                  pathname: '/(tabs)/feed',
-                  params: { username, castHashPrefix: hashPrefix },
-                })
-              }
-              onOpenMiniApp={(url) => router.push({ pathname: '/browser', params: { url } })}
-              onOpenProfile={() => router.push('/(tabs)/feed')}
-              onOpenChannel={() => router.push('/(tabs)/feed')}
-              likeStates={castLikeStates}
-              onLikeToggle={() => {
-                // Like handling is owned by the feed tab; ignore in profile view.
-              }}
-              bottomInset={insets.bottom}
-            />
-          ) : null
-        ) : (
-          <ProfileModal
-            visible={true}
-            onClose={() => {}}
-            onOpenWarpcastImport={onOpenWarpcastImport}
-            isRouteMode={true}
-            hideHeader={true}
-            hideTabBar={true}
-            activeSection={activePill}
-            onOpenMarketplace={() => setMarketplaceModalVisible(true)}
-            onOpenAuctions={() => setAuctionsModalVisible(true)}
-            onOpenOffers={() => setOffersModalVisible(true)}
-          />
-        )}
+        <ProfileModal
+          visible={true}
+          onClose={() => {}}
+          onOpenWarpcastImport={onOpenWarpcastImport}
+          isRouteMode={true}
+          hideHeader={true}
+          hideTabBar={true}
+          activeSection={activePill}
+          onViewMyCasts={handleViewMyCasts}
+          onOpenMarketplace={() => setMarketplaceModalVisible(true)}
+          onOpenAuctions={() => setAuctionsModalVisible(true)}
+          onOpenOffers={() => setOffersModalVisible(true)}
+        />
       </View>
 
       {/* Decision modal (first-time prompt) */}
@@ -310,7 +301,8 @@ function createStyles(theme: AppTheme) {
     },
     pillRow: {
       flexGrow: 0,
-      paddingVertical: Skin.space(8),
+      paddingTop: Skin.space(8),
+      paddingBottom: Skin.space(4),
     },
     pillRowContent: {
       paddingHorizontal: Skin.space(16),

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -1,4 +1,4 @@
-import ProfileModal from '@/components/ProfileModal';
+import ProfileModal, { type ProfileSection } from '@/components/ProfileModal';
 import ProfileSplitModeModal from '@/components/ProfileSplitModeModal';
 import AuctionsModal from '@/components/qns/AuctionsModal';
 import BuyNameModal from '@/components/qns/BuyNameModal';
@@ -9,6 +9,7 @@ import { ProfileView } from '@/components/SocialFeedModal';
 import UnifiedProfileHeader from '@/components/UnifiedProfileHeader';
 import UnifiedProfileEditModal from '@/components/UnifiedProfileEditModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useAuth } from '@/context/AuthContext';
 import { useFarcasterProfile } from '@/hooks/useFarcasterProfile';
 import {
@@ -17,8 +18,8 @@ import {
 } from '@/services/profile/profilePrefs';
 import { useTheme, type AppTheme } from '@/theme';
 import { useRouter } from 'expo-router';
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { NativeScrollEvent, NativeSyntheticEvent, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
+import React, { useEffect, useMemo, useState } from 'react';
+import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
@@ -35,7 +36,6 @@ export default function UnifiedProfileScreen({
   const { theme } = useTheme();
   const { user, farcasterAuthToken } = useAuth();
   const insets = useSafeAreaInsets();
-  const { width } = useWindowDimensions();
   const router = useRouter();
 
   const [splitMode] = useProfileSplitMode();
@@ -44,8 +44,8 @@ export default function UnifiedProfileScreen({
   const [editPickerVisible, setEditPickerVisible] = useState(false);
   const [castLikeStates] = useState<Map<string, { liked: boolean; count: number }>>(() => new Map());
   // Marketplace-family modals are rendered at this level (not inside ProfileModal)
-  // so they don't sit inside the horizontal pager's ScrollView, which can leave
-  // the pager's active page unable to receive touches after dismiss.
+  // so dismissing them doesn't leave the embedded ProfileModal unable to receive
+  // touches.
   const [marketplaceModalVisible, setMarketplaceModalVisible] = useState(false);
   const [auctionsModalVisible, setAuctionsModalVisible] = useState(false);
   const [offersModalVisible, setOffersModalVisible] = useState(false);
@@ -66,33 +66,32 @@ export default function UnifiedProfileScreen({
     enabled: hasFarcaster,
   });
 
-  // Page indices - dynamically built based on farcaster presence
-  const pages = useMemo(() => {
-    const pageList: { key: string; label: string }[] = [{ key: 'quorum', label: 'Account' }];
+  // One flat pill row replaces the old two-level nav. Profile / Premium /
+  // Settings always show; Farcaster + Casts only when a Farcaster account is
+  // connected (config / feed that don't apply to Quorum-only users).
+  type ProfilePill = ProfileSection | 'casts';
+  const pills = useMemo<SegmentedPillItem[]>(() => {
+    const list: SegmentedPillItem[] = [
+      { key: 'profile', label: 'Profile' },
+      { key: 'premium', label: 'Premium' },
+      { key: 'settings', label: 'Settings' },
+    ];
     if (hasFarcaster) {
-      pageList.push({ key: 'casts', label: 'Casts' });
+      list.push({ key: 'farcaster', label: 'Farcaster' });
+      list.push({ key: 'casts', label: 'Casts' });
     }
-    return pageList;
+    return list;
   }, [hasFarcaster]);
 
-  const [activePageIndex, setActivePageIndex] = useState(0);
-  const scrollRef = useRef<ScrollView | null>(null);
+  const [activePill, setActivePill] = useState<ProfilePill>('profile');
 
-  const handleScroll = useCallback(
-    (e: NativeSyntheticEvent<NativeScrollEvent>) => {
-      const offsetX = e.nativeEvent.contentOffset.x;
-      const idx = Math.round(offsetX / width);
-      if (idx !== activePageIndex && idx >= 0 && idx < pages.length) {
-        setActivePageIndex(idx);
-      }
-    },
-    [activePageIndex, pages.length, width],
-  );
-
-  const goToPage = (i: number) => {
-    setActivePageIndex(i);
-    scrollRef.current?.scrollTo({ x: i * width, animated: true });
-  };
+  // If the active pill becomes unavailable (e.g. Farcaster disconnected while on
+  // the Farcaster/Casts pill), fall back to Profile.
+  useEffect(() => {
+    if (!hasFarcaster && (activePill === 'farcaster' || activePill === 'casts')) {
+      setActivePill('profile');
+    }
+  }, [hasFarcaster, activePill]);
 
   const handleEditRequest = () => {
     if (!hasFarcaster) {
@@ -114,8 +113,7 @@ export default function UnifiedProfileScreen({
     // The host (profile tab) renders an opaque Stack header above us
     // that already covers the status-bar safe area, so we don't add
     // another `insets.top` here — that would double up and leave a
-    // visible gap between the header and the Quorum/Farcaster segment
-    // selector.
+    // visible gap between the header and the pill row.
     <View style={[styles.root, { backgroundColor: theme.colors.background }]}>
       <UnifiedProfileHeader
         user={user}
@@ -126,78 +124,58 @@ export default function UnifiedProfileScreen({
         onEditUnified={handleEditRequest}
       />
 
-      {pages.length > 1 && (
-        <View style={styles.segmentBar}>
-          {pages.map((page, i) => (
-            <TouchableOpacity
-              key={page.key}
-              style={[styles.segment, i === activePageIndex && styles.segmentActive]}
-              onPress={() => goToPage(i)}
-              activeOpacity={0.7}
-            >
-              <Text
-                style={[
-                  styles.segmentLabel,
-                  i === activePageIndex && { color: theme.colors.accent, fontWeight: '600' },
-                ]}
-              >
-                {page.label}
-              </Text>
-            </TouchableOpacity>
-          ))}
-        </View>
-      )}
+      <SegmentedPills
+        items={pills}
+        activeKey={activePill}
+        onChange={(key) => setActivePill(key as ProfilePill)}
+        variant="solid"
+        scrollable
+        centerOnSelect
+        style={styles.pillRow}
+        contentContainerStyle={styles.pillRowContent}
+      />
 
-      <ScrollView
-        ref={scrollRef}
-        horizontal
-        pagingEnabled
-        showsHorizontalScrollIndicator={false}
-        onMomentumScrollEnd={handleScroll}
-        scrollEventThrottle={16}
-        style={styles.pager}
-      >
-        {pages.map((page) => (
-          <View key={page.key} style={{ width }}>
-            {page.key === 'quorum' && (
-              <ProfileModal
-                visible={true}
-                onClose={() => {}}
-                onOpenWarpcastImport={onOpenWarpcastImport}
-                isRouteMode={true}
-                hideHeader={true}
-                onOpenMarketplace={() => setMarketplaceModalVisible(true)}
-                onOpenAuctions={() => setAuctionsModalVisible(true)}
-                onOpenOffers={() => setOffersModalVisible(true)}
-              />
-            )}
-            {page.key === 'casts' && user.farcaster?.fid && (
-              <ProfileView
-                fid={user.farcaster.fid}
-                token={farcasterAuthToken ?? undefined}
-                theme={theme}
-                currentUserFid={user.farcaster.fid}
-                hideBackButton={true}
-                onClose={() => {}}
-                onOpenThread={(username, hashPrefix) =>
-                  router.push({
-                    pathname: '/(tabs)/feed',
-                    params: { username, castHashPrefix: hashPrefix },
-                  })
-                }
-                onOpenMiniApp={(url) => router.push({ pathname: '/browser', params: { url } })}
-                onOpenProfile={() => router.push('/(tabs)/feed')}
-                onOpenChannel={() => router.push('/(tabs)/feed')}
-                likeStates={castLikeStates}
-                onLikeToggle={() => {
-                  // Like handling is owned by the feed tab; ignore in profile view.
-                }}
-                bottomInset={insets.bottom}
-              />
-            )}
-          </View>
-        ))}
-      </ScrollView>
+      <View style={styles.content}>
+        {activePill === 'casts' ? (
+          user.farcaster?.fid ? (
+            <ProfileView
+              fid={user.farcaster.fid}
+              token={farcasterAuthToken ?? undefined}
+              theme={theme}
+              currentUserFid={user.farcaster.fid}
+              hideBackButton={true}
+              onClose={() => {}}
+              onOpenThread={(username, hashPrefix) =>
+                router.push({
+                  pathname: '/(tabs)/feed',
+                  params: { username, castHashPrefix: hashPrefix },
+                })
+              }
+              onOpenMiniApp={(url) => router.push({ pathname: '/browser', params: { url } })}
+              onOpenProfile={() => router.push('/(tabs)/feed')}
+              onOpenChannel={() => router.push('/(tabs)/feed')}
+              likeStates={castLikeStates}
+              onLikeToggle={() => {
+                // Like handling is owned by the feed tab; ignore in profile view.
+              }}
+              bottomInset={insets.bottom}
+            />
+          ) : null
+        ) : (
+          <ProfileModal
+            visible={true}
+            onClose={() => {}}
+            onOpenWarpcastImport={onOpenWarpcastImport}
+            isRouteMode={true}
+            hideHeader={true}
+            hideTabBar={true}
+            activeSection={activePill}
+            onOpenMarketplace={() => setMarketplaceModalVisible(true)}
+            onOpenAuctions={() => setAuctionsModalVisible(true)}
+            onOpenOffers={() => setOffersModalVisible(true)}
+          />
+        )}
+      </View>
 
       {/* Decision modal (first-time prompt) */}
       <ProfileSplitModeModal
@@ -330,27 +308,14 @@ function createStyles(theme: AppTheme) {
     root: {
       flex: 1,
     },
-    segmentBar: {
-      flexDirection: 'row',
-      borderBottomWidth: Skin.border(1),
-      borderBottomColor: theme.colors.surface3,
+    pillRow: {
+      flexGrow: 0,
+      paddingVertical: Skin.space(8),
+    },
+    pillRowContent: {
       paddingHorizontal: Skin.space(16),
     },
-    segment: {
-      flex: 1,
-      paddingVertical: Skin.space(12),
-      alignItems: 'center',
-      borderBottomWidth: Skin.border(2),
-      borderBottomColor: 'transparent',
-    },
-    segmentActive: {
-      borderBottomColor: theme.colors.accent,
-    },
-    segmentLabel: {
-      fontSize: Skin.font(14),
-      color: theme.colors.textMuted,
-    },
-    pager: {
+    content: {
       flex: 1,
     },
   });

--- a/components/ui/FarcasterLogoIcon.tsx
+++ b/components/ui/FarcasterLogoIcon.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import Svg, { Path } from 'react-native-svg';
+
+interface FarcasterLogoIconProps {
+  /** Render size in px (square). */
+  size?: number;
+  /** Fill color. Defaults to the muted Farcaster purple used in brand contexts. */
+  color?: string;
+  opacity?: number;
+}
+
+/**
+ * Farcaster brand mark as a react-native-svg component (the web `.jsx` icon in
+ * assets/icons/iconset is plain HTML SVG and won't render in RN). Path data is
+ * the same arch glyph, ported into a `<Path>` with a tintable `fill`.
+ */
+export function FarcasterLogoIcon({ size = 20, color = '#855DCD', opacity = 1 }: FarcasterLogoIconProps) {
+  return (
+    <Svg width={size} height={size} viewBox="0 0 32 32" fill="none" opacity={opacity}>
+      <Path
+        d="M5.507 0.072L26.097 0.072L26.097 4.167L31.952 4.167L30.725 8.263L29.686 8.263L29.686 24.833C30.207 24.833 30.63 25.249 30.63 25.763L30.63 26.88L30.819 26.88C31.341 26.88 31.764 27.297 31.764 27.811L31.764 28.928L21.185 28.928L21.185 27.811C21.185 27.297 21.608 26.88 22.13 26.88L22.319 26.88L22.319 25.763C22.319 25.316 22.639 24.943 23.065 24.853L23.045 15.71C22.711 12.057 19.596 9.194 15.802 9.194C12.008 9.194 8.893 12.057 8.559 15.71L8.539 24.845C9.043 24.919 9.663 25.302 9.663 25.763L9.663 26.88L9.852 26.88C10.373 26.88 10.796 27.297 10.796 27.811L10.796 28.928L0.218 28.928L0.218 27.811C0.218 27.297 0.641 26.88 1.162 26.88L1.351 26.88L1.351 25.763C1.351 25.249 1.774 24.833 2.296 24.833L2.296 8.263L1.257 8.263L0.029 4.167L5.507 4.167L5.507 0.072Z"
+        fill={color}
+      />
+    </Svg>
+  );
+}
+
+export default FarcasterLogoIcon;

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -254,6 +254,7 @@ const SF_TO_TABLER = {
   // Edit
   'square.and.pencil': tabler('IconEdit'),
   'pencil': tabler('IconPencil'),
+  'feather': tabler('IconFeather'),
   'hammer': tabler('IconHammer'),
   'hammer.fill': tabler('IconHammer'),
 

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -116,6 +116,7 @@ import IconEye from '@tabler/icons-react-native/IconEye';
 import IconEyeFilled from '@tabler/icons-react-native/IconEyeFilled';
 import IconEyeOff from '@tabler/icons-react-native/IconEyeOff';
 import IconFaceId from '@tabler/icons-react-native/IconFaceId';
+import IconFeather from '@tabler/icons-react-native/IconFeather';
 import IconFile from '@tabler/icons-react-native/IconFile';
 import IconFileCode from '@tabler/icons-react-native/IconFileCode';
 import IconFileCodeFilled from '@tabler/icons-react-native/IconFileCodeFilled';
@@ -371,6 +372,7 @@ export const TablerIcons = {
   IconEyeFilled,
   IconEyeOff,
   IconFaceId,
+  IconFeather,
   IconFile,
   IconFileCode,
   IconFileCodeFilled,


### PR DESCRIPTION
Replace the two-level profile navigation (Account/Casts pager + Profile/Premium/Settings inner tabs) with a single horizontal pill row, plus related profile-screen polish.

- One pill row driven by the shared SegmentedPills: Profile, Premium, Settings always; Farcaster only when a Farcaster account is connected
- Move all Farcaster config (account, feed reply prefs, Hypersnap, Warpcast wallet) out of Settings into its own Farcaster section
- Add a 'My Casts' row in the Farcaster section that opens the user's own cast feed (replaces the former Casts pill); reliable re-open via nonce-keyed nav
- Add a visible edit affordance (pencil badge) and brand icons to the split profile cards
- Add the feather icon and use it for My Casts
- Account Info grouped into one card; consistent 8px card spacing; section styling aligned
- Export Recovery Key uses the custom confirmation dialog; device list collapses behind 'Show more'
- Rename the screen title to Account