### PR TITLE
feat: profile screen rework + Farcaster surface polish

### DIFF
--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -8,6 +8,7 @@
 import { useFloatingTabBarPadding } from '@/hooks/useFloatingTabBarPadding';
 import { FloatingTabScreen } from '@/components/ui/FloatingTabScreen';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAuth } from '@/context/AuthContext';
 import type { Conversation } from '@/hooks/chat';
@@ -76,10 +77,7 @@ const InboxRow = React.memo(function InboxRow({ item, styles, theme, onPress }: 
         )}
         {item.isFarcaster && (
           <View style={styles.farcasterBadge}>
-            <Image
-              source={require('@/assets/images/farcaster.png')}
-              style={styles.farcasterLogo}
-            />
+            <FarcasterLogoIcon size={8} color="#fff" />
           </View>
         )}
       </View>
@@ -391,14 +389,11 @@ const createStyles = (theme: AppTheme, isDark: boolean, listPadding: number) =>
       width: 18,
       height: 18,
       borderRadius: Skin.radius(9),
-      backgroundColor: theme.colors.surface1,
+      backgroundColor: '#855DCD', // Farcaster brand purple
+      borderWidth: Skin.border(2),
+      borderColor: theme.colors.surface1,
       alignItems: 'center',
       justifyContent: 'center',
-    },
-    farcasterLogo: {
-      width: 14,
-      height: 14,
-      borderRadius: Skin.radius(7),
     },
     rowContent: {
       flex: 1,

--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -5,6 +5,7 @@
 
 import type { AppTheme } from '@/theme';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import type { Conversation } from '@/hooks/chat';
 import React, { useCallback, useMemo } from 'react';
@@ -13,9 +14,6 @@ import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { SegmentedPills } from '@/components/ui/SegmentedPills';
 import { FlashList } from '@shopify/flash-list';
 import * as Skin from '@/theme/skins/geometry';
-
-// Farcaster logo for non-E2EE indicator
-const FarcasterLogo = require('@/assets/images/farcaster.png');
 
 type DMFilter = 'all' | 'favorites' | 'unknown' | 'muted';
 
@@ -160,7 +158,7 @@ const DMConversationItem = React.memo(function DMConversationItem({
         {hasUnread && <View style={styles.unreadBadge} />}
         {isFarcaster && (
           <View style={styles.farcasterBadge}>
-            <Image source={FarcasterLogo} style={styles.farcasterIcon} />
+            <FarcasterLogoIcon size={10} color="#fff" />
           </View>
         )}
       </View>
@@ -461,11 +459,6 @@ const createStyles = (theme: AppTheme) =>
       borderColor: theme.colors.surface1,
       alignItems: 'center',
       justifyContent: 'center',
-    },
-    farcasterIcon: {
-      width: 10,
-      height: 10,
-      tintColor: '#fff',
     },
     conversationContent: {
       flex: 1,

--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -158,7 +158,7 @@ const DMConversationItem = React.memo(function DMConversationItem({
         {hasUnread && <View style={styles.unreadBadge} />}
         {isFarcaster && (
           <View style={styles.farcasterBadge}>
-            <FarcasterLogoIcon size={10} color="#fff" />
+            <FarcasterLogoIcon size={8} color="#fff" />
           </View>
         )}
       </View>
@@ -454,7 +454,7 @@ const createStyles = (theme: AppTheme) =>
       width: 18,
       height: 18,
       borderRadius: Skin.radius(9),
-      backgroundColor: '#8B5CF6', // Farcaster purple
+      backgroundColor: '#855DCD', // Farcaster brand purple
       borderWidth: Skin.border(2),
       borderColor: theme.colors.surface1,
       alignItems: 'center',

--- a/components/Chat/FarcasterDirectMessageView.tsx
+++ b/components/Chat/FarcasterDirectMessageView.tsx
@@ -9,10 +9,10 @@ import {
   View,
   Text,
   StyleSheet,
-  Image,
   Dimensions,
   Alert,
 } from 'react-native';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { MessagesList } from './MessagesList';
 import { MessageInput, type MessageInputHandle, type ReplyToMessage } from './MessageInput';
 import { ChatBottomChrome, useChatListBottomInset } from './ChatBottomChrome';
@@ -33,7 +33,6 @@ import * as Skin from '@/theme/skins/geometry';
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
 
 // Farcaster logo
-const FarcasterLogo = require('@/assets/images/farcaster.png');
 
 interface FarcasterDirectMessageViewProps {
   conversation: Conversation;
@@ -266,7 +265,7 @@ export function FarcasterDirectMessageView({
     <View style={styles.container}>
       {/* Security warning banner */}
       <View style={styles.warningBanner}>
-        <Image source={FarcasterLogo} style={styles.warningIcon} />
+        <FarcasterLogoIcon size={14} color="#855DCD" />
         <Text style={styles.warningText}>
           Farcaster messages are not end-to-end encrypted
         </Text>
@@ -329,11 +328,6 @@ const createStyles = (theme: AppTheme) =>
       paddingHorizontal: Skin.space(12),
       gap: Skin.space(8),
       width: SCREEN_WIDTH,
-    },
-    warningIcon: {
-      width: 14,
-      height: 14,
-      tintColor: '#8B5CF6',
     },
     warningText: {
       fontSize: Skin.font(12),

--- a/components/MiniAppsModal.tsx
+++ b/components/MiniAppsModal.tsx
@@ -108,7 +108,10 @@ const localToMiniApp = (e: {
 }): MiniApp => ({
   id: e.domain,
   name: e.name ?? e.domain,
-  description: e.domain,
+  // Use the domain as a subtitle only when there's a distinct display name;
+  // otherwise it duplicates the name line (domain shown twice). Discovery
+  // enrichment fills a real description when the app is known.
+  description: e.name && e.name !== e.domain ? e.domain : '',
   category: 'social',
   url: e.url,
   icon: e.iconUrl ? { uri: e.iconUrl } : null,
@@ -330,16 +333,45 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
     };
   }, [visible, farcasterAuthToken, frameToMiniApp]);
 
+  // Discovery apps (top-frames + featured) carry full metadata: real name,
+  // icon, and requiresFarcaster. Locally-added / recent / sparse-favorite
+  // entries often only have a domain, so enrich them from discovery when the
+  // domain (id) matches — backfilling name, icon, and the Farcaster flag the
+  // saved/recent rows would otherwise be missing.
+  const discoveryById = useMemo(() => {
+    const map = new Map<string, MiniApp>();
+    for (const a of miniApps) map.set(a.id, a);
+    return map;
+  }, [miniApps]);
+
+  const enrichFromDiscovery = useCallback((app: MiniApp): MiniApp => {
+    const rich = discoveryById.get(app.id);
+    if (!rich) return app;
+    return {
+      ...app,
+      // Prefer the entry's own real name; fall back to discovery when the entry
+      // only had its domain (name === domain) or nothing.
+      name: app.name && app.name !== app.id ? app.name : rich.name,
+      icon: app.icon ?? rich.icon,
+      requiresFarcaster: app.requiresFarcaster || rich.requiresFarcaster,
+      isQNative: app.isQNative || rich.isQNative,
+      description: app.description && app.description !== app.id ? app.description : rich.description,
+    };
+  }, [discoveryById]);
+
   // Saved = favorites first (richer metadata), then locally-added apps not
-  // already represented, deduped by domain (id).
+  // already represented, deduped by domain (id). All enriched from discovery.
   const savedApps = useMemo(() => {
     const byId = new Map<string, MiniApp>();
     for (const a of favoriteApps) byId.set(a.id, a);
     for (const a of localAdded.map(localToMiniApp)) if (!byId.has(a.id)) byId.set(a.id, a);
-    return Array.from(byId.values());
-  }, [favoriteApps, localAdded]);
+    return Array.from(byId.values()).map(enrichFromDiscovery);
+  }, [favoriteApps, localAdded, enrichFromDiscovery]);
 
-  const recentApps = useMemo(() => recentList.map(localToMiniApp), [recentList]);
+  const recentApps = useMemo(
+    () => recentList.map(localToMiniApp).map(enrichFromDiscovery),
+    [recentList, enrichFromDiscovery],
+  );
 
   // Use search results if searching, otherwise show all apps
   const isSearchMode = debouncedQuery.length > 0;
@@ -386,7 +418,9 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
         )}
       </View>
       <Text style={styles.appName} numberOfLines={2}>{app.name}</Text>
-      <Text style={styles.appDescription} numberOfLines={2}>{app.description}</Text>
+      {app.description ? (
+        <Text style={styles.appDescription} numberOfLines={2}>{app.description}</Text>
+      ) : null}
     </TouchableOpacity>
   );
 
@@ -591,9 +625,11 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
                   )}
                 </View>
                 <Text style={styles.appName} numberOfLines={2}>{app.name}</Text>
-                <Text style={styles.appDescription} numberOfLines={2}>
-                  {app.description}
-                </Text>
+                {app.description ? (
+                  <Text style={styles.appDescription} numberOfLines={2}>
+                    {app.description}
+                  </Text>
+                ) : null}
               </TouchableOpacity>
             ))}
           </View>

--- a/components/MiniAppsModal.tsx
+++ b/components/MiniAppsModal.tsx
@@ -1,5 +1,6 @@
 import { BaseModal } from '@/components/shared';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { SegmentedPills } from '@/components/ui/SegmentedPills';
 import { useAuth } from '@/context';
 import { useFloatingTabBarPadding } from '@/hooks/useFloatingTabBarPadding';
@@ -366,24 +367,21 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
       style={styles.appCard}
       onPress={() => handleAppPress(app)}
     >
+      {(app.requiresFarcaster || app.isQNative) && (
+        <View style={styles.appCardBadge}>
+          {app.requiresFarcaster ? (
+            <FarcasterLogoIcon size={14} color={theme.colors.textMuted} />
+          ) : (
+            <IconSymbol name="lock.fill" size={13} color={theme.colors.textMuted} />
+          )}
+        </View>
+      )}
       <View style={styles.appIconContainer}>
         {app.icon ? (
           <Image source={app.icon} style={styles.appIcon} />
         ) : (
           <View style={styles.appIconPlaceholder}>
             <Text style={styles.iconPlaceholderText}>{app.name.charAt(0)}</Text>
-          </View>
-        )}
-        {(app.requiresFarcaster || app.isQNative) && (
-          <View style={[styles.appIconBadge, app.isQNative && styles.appIconBadgeQNative]}>
-            {app.requiresFarcaster ? (
-              <Image
-                source={require('../assets/images/farcaster.png')}
-                style={styles.appIconBadgeIcon}
-              />
-            ) : (
-              <IconSymbol name="lock.fill" size={8} color="#ffffff" />
-            )}
           </View>
         )}
       </View>
@@ -542,10 +540,7 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
                           <View style={styles.featuredAuthBadge}>
                             <View style={[styles.authBadge, app.isQNative && styles.authBadgeQNative]}>
                               {app.requiresFarcaster ? (
-                                <Image
-                                  source={require('../assets/images/farcaster.png')}
-                                  style={styles.authBadgeIcon}
-                                />
+                                <FarcasterLogoIcon size={8} color="#fff" />
                               ) : (
                                 <IconSymbol
                                   name="lock.fill"
@@ -577,28 +572,21 @@ export default function MiniAppsModal({ visible, onClose, onOpenMiniApp, isRoute
                 style={styles.appCard}
                 onPress={() => handleAppPress(app)}
               >
+                {(app.requiresFarcaster || app.isQNative) && (
+                  <View style={styles.appCardBadge}>
+                    {app.requiresFarcaster ? (
+                      <FarcasterLogoIcon size={14} color={theme.colors.textMuted} />
+                    ) : (
+                      <IconSymbol name="lock.fill" size={13} color={theme.colors.textMuted} />
+                    )}
+                  </View>
+                )}
                 <View style={styles.appIconContainer}>
                   {app.icon ? (
                     <Image source={app.icon} style={styles.appIcon} />
                   ) : (
                     <View style={styles.appIconPlaceholder}>
                       <Text style={styles.iconPlaceholderText}>{app.name.charAt(0)}</Text>
-                    </View>
-                  )}
-                  {(app.requiresFarcaster || app.isQNative) && (
-                    <View style={[styles.appIconBadge, app.isQNative && styles.appIconBadgeQNative]}>
-                      {app.requiresFarcaster ? (
-                        <Image
-                          source={require('../assets/images/farcaster.png')}
-                          style={styles.appIconBadgeIcon}
-                        />
-                      ) : (
-                        <IconSymbol
-                          name="lock.fill"
-                          size={8}
-                          color="#ffffff"
-                        />
-                      )}
                     </View>
                   )}
                 </View>
@@ -856,22 +844,34 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       padding: Skin.space(12),
       alignItems: 'center',
       justifyContent: 'center',
+      position: 'relative',
+    },
+    // Farcaster / lock badge pinned to the top-right of the whole app card.
+    // Bare Farcaster/lock glyph (theme-muted) pinned to the card's bottom-right.
+    // No circle background — a repeated row of purple circles read too heavy.
+    appCardBadge: {
+      position: 'absolute',
+      bottom: Skin.space(8),
+      right: Skin.space(8),
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1,
     },
     appIconContainer: {
-      width: 48,
-      height: 48,
+      width: 56,
+      height: 56,
       marginBottom: Skin.space(10),
       position: 'relative',
     },
     appIcon: {
-      width: 48,
-      height: 48,
-      borderRadius: Skin.radius(12),
+      width: 56,
+      height: 56,
+      borderRadius: Skin.radius(14),
     },
     appIconPlaceholder: {
-      width: 48,
-      height: 48,
-      borderRadius: Skin.radius(12),
+      width: 56,
+      height: 56,
+      borderRadius: Skin.radius(14),
       backgroundColor: theme.colors.surface4,
       alignItems: 'center',
       justifyContent: 'center',
@@ -898,27 +898,8 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       textAlign: 'center',
       lineHeight: Skin.font(17),
     },
-    appIconBadge: {
-      position: 'absolute',
-      top: -2,
-      right: -2,
-      width: 16,
-      height: 16,
-      borderRadius: Skin.radius(8),
-      backgroundColor: '#8B5CF6',
-      alignItems: 'center',
-      justifyContent: 'center',
-      borderWidth: Skin.border(1),
-      borderColor: theme.colors.background,
-    },
     appIconBadgeQNative: {
       backgroundColor: theme.colors.info,
-    },
-    appIconBadgeIcon: {
-      width: 10,
-      height: 10,
-      padding: Skin.space(1),
-      resizeMode: 'contain',
     },
     appStats: {
       flexDirection: 'row',
@@ -930,21 +911,15 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       color: theme.colors.textMuted,
     },
     authBadge: {
-      width: 14,
-      height: 14,
-      borderRadius: Skin.radius(7),
-      backgroundColor: '#8B5CF6',
+      width: 18,
+      height: 18,
+      borderRadius: Skin.radius(9),
+      backgroundColor: '#855DCD',
       alignItems: 'center',
       justifyContent: 'center',
     },
     authBadgeQNative: {
       backgroundColor: theme.colors.info,
-    },
-    authBadgeIcon: {
-      width: 10,
-      height: 10,
-      padding: Skin.space(1),
-      resizeMode: 'contain',
     },
     emptyState: {
       alignItems: 'center',

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -930,7 +930,7 @@ export default function ProfileModal({
       const ok = await confirm({
         title: 'Merge profiles',
         message:
-          'Your Quorum and Farcaster profiles will be combined into one. You can keep them separate again later.',
+          'You’ll see and edit one profile. From now on, editing your name, bio, or picture updates both Quorum and Farcaster at once. Until you edit, each keeps its current values. Usernames always stay separate. You can separate them again later.',
         confirmLabel: 'Merge',
       });
       if (!ok) return;
@@ -944,10 +944,10 @@ export default function ProfileModal({
     if (!onUnmergeProfiles) return;
     void (async () => {
       const ok = await confirm({
-        title: 'Keep profiles separate',
+        title: 'Separate profiles',
         message:
-          'Your Quorum and Farcaster profiles will be shown and edited separately again. Nothing is deleted.',
-        confirmLabel: 'Keep separate',
+          'Your Quorum and Farcaster profiles will be shown and edited separately again. Nothing is deleted or changed.',
+        confirmLabel: 'Separate',
       });
       if (!ok) return;
       onUnmergeProfiles();

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -152,7 +152,7 @@ interface ProfileModalProps {
   /** Called after a Farcaster account is successfully connected/imported, so the
    *  parent can redirect to the Farcaster pill. */
   onFarcasterConnected?: () => void;
-  /** Re-enter split mode (unmerge). Surfaced as a "Keep profiles separate" row in
+  /** Re-enter split mode (unmerge). Surfaced as a "Separate profiles" row in
    *  the Farcaster section when currently merged. */
   onUnmergeProfiles?: () => void;
 }
@@ -2504,7 +2504,7 @@ export default function ProfileModal({
                   <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleUnmergeProfiles}>
                     <IconSymbol name="split" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
                     <View style={styles.actionButtonContent}>
-                      <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Keep profiles separate</Text>
+                      <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Separate profiles</Text>
                       <Text style={styles.actionButtonSubtext}>Show and edit your Quorum and Farcaster profiles separately</Text>
                     </View>
                   </TouchableOpacity>

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -81,6 +81,10 @@ import {
   storeFarcasterCustodyKey,
   storeFarcasterFid,
   storeFarcasterSignerKey,
+  deleteFarcasterSignerKey,
+  deleteFarcasterCustodyKey,
+  deleteFarcasterAuthToken,
+  deleteFarcasterAuthTokenExpiresAt,
 } from '@/services/onboarding/secureStorage';
 import { maybeSendUpdateProfileMessage } from '@/services/space/spaceMessageService';
 import { isDevModeLocal, setDevModeLocal, getApiConfig } from '@/services/api/config';
@@ -517,6 +521,18 @@ export default function ProfileModal({
     }
   }, [visible, user]);
 
+  // Collapse the Connect-Farcaster import form when leaving Settings. In route
+  // mode `visible` never changes, so the open form would otherwise persist when
+  // the user navigates to another pill and back.
+  React.useEffect(() => {
+    if (activeTab !== 'settings') {
+      setShowFarcasterImport(false);
+      setFarcasterMnemonic('');
+      setFarcasterError(null);
+      setRevealMnemonic(false);
+    }
+  }, [activeTab]);
+
   // Toggle the Hypersnap signer opt-in. Enabling provisions immediately so
   // the user gets feedback here rather than waiting for the feed-mounted
   // lifecycle hook; disabling clears the local signer record (the on-chain
@@ -919,6 +935,19 @@ export default function ProfileModal({
       });
       if (!ok) return;
       updateProfile({ farcaster: undefined });
+      // Clear the Farcaster key material + signer record from secure storage so a
+      // disconnect leaves nothing behind (reconnecting re-provisions cleanly).
+      try {
+        await Promise.all([
+          deleteFarcasterSignerKey(),
+          deleteFarcasterCustodyKey(),
+          deleteFarcasterAuthToken(),
+          deleteFarcasterAuthTokenExpiresAt(),
+          forgetHypersnapSigner(),
+        ]);
+      } catch {
+        // Best-effort cleanup — the profile is already disconnected.
+      }
     })();
   };
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -81,10 +81,6 @@ import {
   storeFarcasterCustodyKey,
   storeFarcasterFid,
   storeFarcasterSignerKey,
-  deleteFarcasterSignerKey,
-  deleteFarcasterCustodyKey,
-  deleteFarcasterAuthToken,
-  deleteFarcasterAuthTokenExpiresAt,
 } from '@/services/onboarding/secureStorage';
 import { maybeSendUpdateProfileMessage } from '@/services/space/spaceMessageService';
 import { isDevModeLocal, setDevModeLocal, getApiConfig } from '@/services/api/config';
@@ -935,19 +931,6 @@ export default function ProfileModal({
       });
       if (!ok) return;
       updateProfile({ farcaster: undefined });
-      // Clear the Farcaster key material + signer record from secure storage so a
-      // disconnect leaves nothing behind (reconnecting re-provisions cleanly).
-      try {
-        await Promise.all([
-          deleteFarcasterSignerKey(),
-          deleteFarcasterCustodyKey(),
-          deleteFarcasterAuthToken(),
-          deleteFarcasterAuthTokenExpiresAt(),
-          forgetHypersnapSigner(),
-        ]);
-      } catch {
-        // Best-effort cleanup — the profile is already disconnected.
-      }
     })();
   };
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -8,6 +8,8 @@ import RegisterPaymentModal from '@/components/qns/RegisterPaymentModal';
 import { BaseModal, TypeToConfirmModal } from '@/components/shared';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
+import { QuorumLogoIcon } from '@/components/SocialFeed/content/QuorumLogoIcon';
 import { ApexAvatarRing, ApexIcon, APEX_GOLD } from '@/components/ui/ApexAvatarRing';
 import { useApexSubscription, type ApexSubscriptionState } from '@/hooks/useApex';
 import { SkinsModal } from '@/components/skins/SkinsModal';
@@ -130,6 +132,20 @@ interface ProfileModalProps {
   /** Open the current user's own cast feed (their ProfileView). Surfaced as a
    *  "My Casts" row in the Farcaster section. */
   onViewMyCasts?: () => void;
+  /** Re-open the merge/keep-separate chooser. Surfaced as a "Merge profiles" row
+   *  in the Farcaster section so the choice is reachable after first launch.
+   *  Only meaningful when the profiles are currently unmerged (split mode). */
+  onMergeProfiles?: () => void;
+  /** When set + active, the Profile section renders the Farcaster identity's
+   *  bio + account info (with the Farcaster icon on the headings) instead of the
+   *  Quorum ones. Driven by the header's identity switcher (unmerged layout). */
+  farcasterIdentity?: {
+    active: boolean;
+    displayName?: string;
+    bio?: string;
+    username?: string;
+    fid?: number;
+  };
 }
 
 /** The selectable sections of the profile body. 'farcaster' only applies when a
@@ -327,6 +343,8 @@ export default function ProfileModal({
   activeSection,
   hideTabBar = false,
   onViewMyCasts,
+  onMergeProfiles,
+  farcasterIdentity,
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
@@ -871,6 +889,22 @@ export default function ProfileModal({
       updateProfile({ farcaster: undefined });
     })();
   };
+
+  // Merge profiles — confirm first, then delegate to the parent (which flips the
+  // split-mode pref to merged).
+  const handleMergeProfiles = React.useCallback(() => {
+    if (!onMergeProfiles) return;
+    void (async () => {
+      const ok = await confirm({
+        title: 'Merge profiles',
+        message:
+          'Your Quorum and Farcaster profiles will be combined into one. You can keep them separate again later.',
+        confirmLabel: 'Merge',
+      });
+      if (!ok) return;
+      onMergeProfiles();
+    })();
+  }, [confirm, onMergeProfiles]);
 
   const handlePickImage = React.useCallback(async () => {
     if (!user?.address) return;
@@ -1638,6 +1672,7 @@ export default function ProfileModal({
             isApexActive={apexState.isActive}
             nameError={nameError}
             bioError={bioError}
+            farcasterIdentity={farcasterIdentity}
           />
         )}
 
@@ -2128,6 +2163,78 @@ export default function ProfileModal({
               </TouchableOpacity>
             </View>
 
+            {/* Connect Farcaster — only when NOT connected. Lives in Settings
+                (always reachable) so the connect/re-import path survives after a
+                Disconnect; once connected, all Farcaster config moves to the
+                Farcaster pill. */}
+            {!user?.farcaster && (
+              <View style={styles.section}>
+                <Text style={styles.sectionTitle}>Farcaster</Text>
+                {!showFarcasterImport ? (
+                  <TouchableOpacity
+                    style={styles.actionButton}
+                    onPress={() => setShowFarcasterImport(true)}
+                  >
+                    <IconSymbol name="person.badge.plus" size={20} color={theme.colors.textMain} />
+                    <Text style={styles.actionButtonText}>Connect Farcaster Account</Text>
+                    <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+                  </TouchableOpacity>
+                ) : (
+                  <View style={styles.farcasterImportContainer}>
+                    <Text style={styles.farcasterImportDescription}>
+                      Enter your Farcaster recovery phrase (12 or 24 words) to import your account.
+                    </Text>
+                    <TextInput
+                      style={styles.farcasterMnemonicInput}
+                      value={farcasterMnemonic}
+                      onChangeText={(text) => {
+                        setFarcasterMnemonic(text);
+                        setFarcasterError(null);
+                      }}
+                      placeholder="Enter recovery phrase..."
+                      placeholderTextColor={theme.colors.textMuted}
+                      multiline
+                      numberOfLines={3}
+                      textAlignVertical="top"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      editable={!farcasterImporting}
+                    />
+                    {farcasterError && (
+                      <View style={styles.farcasterErrorContainer}>
+                        <IconSymbol name="exclamationmark.circle.fill" size={16} color={theme.colors.danger} />
+                        <Text style={styles.farcasterErrorText}>{farcasterError}</Text>
+                      </View>
+                    )}
+                    <View style={styles.farcasterImportActions}>
+                      <TouchableOpacity
+                        style={styles.farcasterCancelButton}
+                        onPress={() => {
+                          setShowFarcasterImport(false);
+                          setFarcasterMnemonic('');
+                          setFarcasterError(null);
+                        }}
+                        disabled={farcasterImporting}
+                      >
+                        <Text style={styles.farcasterCancelText}>Cancel</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={[styles.farcasterImportButton, farcasterImporting && styles.farcasterImportButtonDisabled]}
+                        onPress={handleImportFarcaster}
+                        disabled={farcasterImporting}
+                      >
+                        {farcasterImporting ? (
+                          <ActivityIndicator size="small" color="#fff" />
+                        ) : (
+                          <Text style={styles.farcasterImportButtonText}>Import</Text>
+                        )}
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                )}
+              </View>
+            )}
+
             {/* Account Actions */}
             <AccountRecoverySection
               styles={styles}
@@ -2294,71 +2401,22 @@ export default function ProfileModal({
                     <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
                   </View>
                 )}
-              </>
-            ) : !showFarcasterImport ? (
-              // Not connected state
-              <TouchableOpacity
-                style={styles.actionButton}
-                onPress={() => setShowFarcasterImport(true)}
-              >
-                <IconSymbol name="person.badge.plus" size={20} color={theme.colors.textMain} />
-                <Text style={styles.actionButtonText}>Import Farcaster Account</Text>
-                <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
-              </TouchableOpacity>
-            ) : (
-              // Import state
-              <View style={styles.farcasterImportContainer}>
-                <Text style={styles.farcasterImportDescription}>
-                  Enter your Farcaster recovery phrase (12 or 24 words) to import your account.
-                </Text>
-                <TextInput
-                  style={styles.farcasterMnemonicInput}
-                  value={farcasterMnemonic}
-                  onChangeText={(text) => {
-                    setFarcasterMnemonic(text);
-                    setFarcasterError(null);
-                  }}
-                  placeholder="Enter recovery phrase..."
-                  placeholderTextColor={theme.colors.textMuted}
-                  multiline
-                  numberOfLines={3}
-                  textAlignVertical="top"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  editable={!farcasterImporting}
-                />
-                {farcasterError && (
-                  <View style={styles.farcasterErrorContainer}>
-                    <IconSymbol name="exclamationmark.circle.fill" size={16} color={theme.colors.danger} />
-                    <Text style={styles.farcasterErrorText}>{farcasterError}</Text>
-                  </View>
+                {/* Merge profiles — re-reachable entry to the merge chooser
+                    (only when currently unmerged; parent gates the callback). */}
+                {onMergeProfiles && (
+                  <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleMergeProfiles}>
+                    <IconSymbol name="merge" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                    <View style={styles.actionButtonContent}>
+                      <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Merge profiles</Text>
+                      <Text style={styles.actionButtonSubtext}>Combine your Quorum and Farcaster profiles into one</Text>
+                    </View>
+                  </TouchableOpacity>
                 )}
-                <View style={styles.farcasterImportActions}>
-                  <TouchableOpacity
-                    style={styles.farcasterCancelButton}
-                    onPress={() => {
-                      setShowFarcasterImport(false);
-                      setFarcasterMnemonic('');
-                      setFarcasterError(null);
-                    }}
-                    disabled={farcasterImporting}
-                  >
-                    <Text style={styles.farcasterCancelText}>Cancel</Text>
-                  </TouchableOpacity>
-                  <TouchableOpacity
-                    style={[styles.farcasterImportButton, farcasterImporting && styles.farcasterImportButtonDisabled]}
-                    onPress={handleImportFarcaster}
-                    disabled={farcasterImporting}
-                  >
-                    {farcasterImporting ? (
-                      <ActivityIndicator size="small" color="#fff" />
-                    ) : (
-                      <Text style={styles.farcasterImportButtonText}>Import</Text>
-                    )}
-                  </TouchableOpacity>
-                </View>
-              </View>
-            )}
+              </>
+            ) : null}
+            {/* The not-connected / import states live in Settings (Connect
+                Farcaster Account) so they survive a Disconnect — the Farcaster
+                pill only renders while connected. */}
           </View>
         )}
       </ScrollView>
@@ -2872,6 +2930,26 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       fontWeight: theme.fonts.bold.fontWeight,
       color: theme.colors.textMain,
       marginBottom: Skin.space(12),
+    },
+    // Brand-icon + title row (identity-aware Bio / Account Info headings). The
+    // row owns the bottom margin so the title's own margin is cancelled.
+    sectionTitleRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Skin.space(6),
+      marginBottom: Skin.space(12),
+    },
+    // Fixed box so the brand logo (whose SVG sits optically high) centers on the
+    // heading text instead of riding above it.
+    sectionTitleIcon: {
+      width: 16,
+      height: 16,
+      alignItems: 'center',
+      justifyContent: 'center',
+      marginTop: Skin.space(1),
+    },
+    sectionTitleNoMargin: {
+      marginBottom: 0,
     },
     bioContainer: {
       backgroundColor: theme.colors.surface2,
@@ -3777,6 +3855,7 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
   isApexActive,
   nameError,
   bioError,
+  farcasterIdentity,
 }: {
   styles: ProfileStyles;
   theme: AppTheme;
@@ -3794,7 +3873,21 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
   /** Inline validation errors (shared byte validators), shown under each field. */
   nameError?: string;
   bioError?: string;
+  /** When active, render the Farcaster identity's bio + account info instead of
+   *  the Quorum ones (driven by the header identity switcher). */
+  farcasterIdentity?: {
+    active: boolean;
+    displayName?: string;
+    bio?: string;
+    username?: string;
+    fid?: number;
+  };
 }) {
+  // Whether to show Farcaster fields (vs Quorum) in Bio + Account Info.
+  const showFarcaster = !!farcasterIdentity?.active;
+  // Brand icon prefixed to the Bio / Account Info headings so it's unmistakable
+  // which identity's fields are shown.
+  const HeadingIcon = showFarcaster ? FarcasterLogoIcon : QuorumLogoIcon;
   return (
     <>
       {/* Profile Header — hidden when parent supplies its own */}
@@ -3850,10 +3943,15 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
         </View>
       )}
 
-      {/* Bio Section */}
+      {/* Bio Section — Farcaster or Quorum bio depending on the selected identity */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Bio</Text>
-        {isEditing ? (
+        <View style={styles.sectionTitleRow}>
+          <View style={styles.sectionTitleIcon}>
+            <HeadingIcon size={16} />
+          </View>
+          <Text style={[styles.sectionTitle, styles.sectionTitleNoMargin]}>Bio</Text>
+        </View>
+        {isEditing && !showFarcaster ? (
           <>
             <TextInput
               style={styles.bioInput}
@@ -3875,7 +3973,9 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
         ) : (
           <View style={styles.bioContainer}>
             <Text style={styles.bioText}>
-              {user?.bio || 'No bio yet. Tap Edit to add one.'}
+              {showFarcaster
+                ? (farcasterIdentity?.bio || 'No Farcaster bio yet.')
+                : (user?.bio || 'No bio yet. Tap Edit to add one.')}
             </Text>
           </View>
         )}
@@ -3883,30 +3983,56 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
 
       {/* Account Info — a single card with internal dividers between rows */}
       <View style={styles.section}>
-        <Text style={styles.sectionTitle}>Account Info</Text>
-        <View style={styles.infoCard}>
-          <TouchableOpacity style={styles.infoRow} onPress={onCopyAddress}>
-            <Text style={styles.infoLabel}>Address</Text>
-            <View style={styles.infoValueRow}>
-              <Text style={[styles.infoValue, { maxWidth: undefined }]} numberOfLines={1}>
-                {user?.address ? truncateAddress(user.address) : 'N/A'}
-              </Text>
-              <IconSymbol name="doc.on.doc" size={14} color={theme.colors.textMuted} />
-            </View>
-          </TouchableOpacity>
-          <View style={[styles.infoRow, !user?.farcaster && styles.infoRowLast]}>
-            <Text style={styles.infoLabel}>Privacy Level</Text>
-            <Text style={styles.infoValue}>
-              {user?.privacyLevel ? user.privacyLevel.charAt(0).toUpperCase() + user.privacyLevel.slice(1) : 'Standard'}
-            </Text>
+        <View style={styles.sectionTitleRow}>
+          <View style={styles.sectionTitleIcon}>
+            <HeadingIcon size={16} />
           </View>
-          {user?.farcaster && (
-            <View style={[styles.infoRow, styles.infoRowLast]}>
-              <Text style={styles.infoLabel}>Farcaster</Text>
-              <Text style={styles.infoValue}>@{user.farcaster.username}</Text>
-            </View>
-          )}
+          <Text style={[styles.sectionTitle, styles.sectionTitleNoMargin]}>Account Info</Text>
         </View>
+        {showFarcaster ? (
+          <View style={styles.infoCard}>
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Username</Text>
+              <Text style={styles.infoValue}>
+                {farcasterIdentity?.username ? `@${farcasterIdentity.username}` : 'N/A'}
+              </Text>
+            </View>
+            <View style={styles.infoRow}>
+              <Text style={styles.infoLabel}>Display Name</Text>
+              <Text style={styles.infoValue} numberOfLines={1}>
+                {farcasterIdentity?.displayName || 'N/A'}
+              </Text>
+            </View>
+            <View style={[styles.infoRow, styles.infoRowLast]}>
+              <Text style={styles.infoLabel}>FID</Text>
+              <Text style={styles.infoValue}>{farcasterIdentity?.fid ?? 'N/A'}</Text>
+            </View>
+          </View>
+        ) : (
+          <View style={styles.infoCard}>
+            <TouchableOpacity style={styles.infoRow} onPress={onCopyAddress}>
+              <Text style={styles.infoLabel}>Address</Text>
+              <View style={styles.infoValueRow}>
+                <Text style={[styles.infoValue, { maxWidth: undefined }]} numberOfLines={1}>
+                  {user?.address ? truncateAddress(user.address) : 'N/A'}
+                </Text>
+                <IconSymbol name="doc.on.doc" size={14} color={theme.colors.textMuted} />
+              </View>
+            </TouchableOpacity>
+            <View style={[styles.infoRow, !user?.farcaster && styles.infoRowLast]}>
+              <Text style={styles.infoLabel}>Privacy Level</Text>
+              <Text style={styles.infoValue}>
+                {user?.privacyLevel ? user.privacyLevel.charAt(0).toUpperCase() + user.privacyLevel.slice(1) : 'Standard'}
+              </Text>
+            </View>
+            {user?.farcaster && (
+              <View style={[styles.infoRow, styles.infoRowLast]}>
+                <Text style={styles.infoLabel}>Farcaster</Text>
+                <Text style={styles.infoValue}>@{user.farcaster.username}</Text>
+              </View>
+            )}
+          </View>
+        )}
       </View>
     </>
   );

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -146,6 +146,9 @@ interface ProfileModalProps {
     username?: string;
     fid?: number;
   };
+  /** True when the header shows the identity switcher (unmerged + both profiles).
+   *  Drives the Bio heading's brand icon + the duplicated My Casts button. */
+  dualIdentity?: boolean;
 }
 
 /** The selectable sections of the profile body. 'farcaster' only applies when a
@@ -345,6 +348,7 @@ export default function ProfileModal({
   onViewMyCasts,
   onMergeProfiles,
   farcasterIdentity,
+  dualIdentity,
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
@@ -1673,6 +1677,8 @@ export default function ProfileModal({
             nameError={nameError}
             bioError={bioError}
             farcasterIdentity={farcasterIdentity}
+            onViewMyCasts={onViewMyCasts}
+            dualIdentity={dualIdentity}
           />
         )}
 
@@ -2136,6 +2142,7 @@ export default function ProfileModal({
               syncDisabled={isSyncLoading || isSyncToggling}
               notifications={notifications}
               onToggleNotifications={setNotifications}
+              privacyLevel={user?.privacyLevel}
             />
 
             {/* Appearance */}
@@ -3856,6 +3863,8 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
   nameError,
   bioError,
   farcasterIdentity,
+  onViewMyCasts,
+  dualIdentity,
 }: {
   styles: ProfileStyles;
   theme: AppTheme;
@@ -3882,11 +3891,17 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
     username?: string;
     fid?: number;
   };
+  /** Open the user's own cast feed — duplicated as a "My Casts" button below the
+   *  bio when the Farcaster identity is selected. */
+  onViewMyCasts?: () => void;
+  /** True only when there are two distinct identities to disambiguate (unmerged
+   *  with both profiles). Drives whether the Bio heading carries a brand icon. */
+  dualIdentity?: boolean;
 }) {
   // Whether to show Farcaster fields (vs Quorum) in Bio + Account Info.
   const showFarcaster = !!farcasterIdentity?.active;
-  // Brand icon prefixed to the Bio / Account Info headings so it's unmistakable
-  // which identity's fields are shown.
+  // Brand icon prefixed to the Bio heading so it's unmistakable which identity's
+  // bio is shown — but only when two identities exist (dual-identity switcher).
   const HeadingIcon = showFarcaster ? FarcasterLogoIcon : QuorumLogoIcon;
   return (
     <>
@@ -3945,12 +3960,16 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
 
       {/* Bio Section — Farcaster or Quorum bio depending on the selected identity */}
       <View style={styles.section}>
-        <View style={styles.sectionTitleRow}>
-          <View style={styles.sectionTitleIcon}>
-            <HeadingIcon size={16} />
+        {dualIdentity ? (
+          <View style={styles.sectionTitleRow}>
+            <View style={styles.sectionTitleIcon}>
+              <HeadingIcon size={16} />
+            </View>
+            <Text style={[styles.sectionTitle, styles.sectionTitleNoMargin]}>Bio</Text>
           </View>
-          <Text style={[styles.sectionTitle, styles.sectionTitleNoMargin]}>Bio</Text>
-        </View>
+        ) : (
+          <Text style={styles.sectionTitle}>Bio</Text>
+        )}
         {isEditing && !showFarcaster ? (
           <>
             <TextInput
@@ -3981,59 +4000,20 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
         )}
       </View>
 
-      {/* Account Info — a single card with internal dividers between rows */}
-      <View style={styles.section}>
-        <View style={styles.sectionTitleRow}>
-          <View style={styles.sectionTitleIcon}>
-            <HeadingIcon size={16} />
-          </View>
-          <Text style={[styles.sectionTitle, styles.sectionTitleNoMargin]}>Account Info</Text>
+      {/* My Casts — duplicated here (below the bio) on the Farcaster identity for
+          quick access to the user's own cast feed. Also lives in the Farcaster pill. */}
+      {showFarcaster && onViewMyCasts && (
+        <View style={styles.section}>
+          <TouchableOpacity style={styles.actionButton} onPress={onViewMyCasts}>
+            <IconSymbol name="feather" size={20} color={theme.colors.primary} />
+            <Text style={styles.actionButtonText}>My Casts</Text>
+            <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+          </TouchableOpacity>
         </View>
-        {showFarcaster ? (
-          <View style={styles.infoCard}>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>Username</Text>
-              <Text style={styles.infoValue}>
-                {farcasterIdentity?.username ? `@${farcasterIdentity.username}` : 'N/A'}
-              </Text>
-            </View>
-            <View style={styles.infoRow}>
-              <Text style={styles.infoLabel}>Display Name</Text>
-              <Text style={styles.infoValue} numberOfLines={1}>
-                {farcasterIdentity?.displayName || 'N/A'}
-              </Text>
-            </View>
-            <View style={[styles.infoRow, styles.infoRowLast]}>
-              <Text style={styles.infoLabel}>FID</Text>
-              <Text style={styles.infoValue}>{farcasterIdentity?.fid ?? 'N/A'}</Text>
-            </View>
-          </View>
-        ) : (
-          <View style={styles.infoCard}>
-            <TouchableOpacity style={styles.infoRow} onPress={onCopyAddress}>
-              <Text style={styles.infoLabel}>Address</Text>
-              <View style={styles.infoValueRow}>
-                <Text style={[styles.infoValue, { maxWidth: undefined }]} numberOfLines={1}>
-                  {user?.address ? truncateAddress(user.address) : 'N/A'}
-                </Text>
-                <IconSymbol name="doc.on.doc" size={14} color={theme.colors.textMuted} />
-              </View>
-            </TouchableOpacity>
-            <View style={[styles.infoRow, !user?.farcaster && styles.infoRowLast]}>
-              <Text style={styles.infoLabel}>Privacy Level</Text>
-              <Text style={styles.infoValue}>
-                {user?.privacyLevel ? user.privacyLevel.charAt(0).toUpperCase() + user.privacyLevel.slice(1) : 'Standard'}
-              </Text>
-            </View>
-            {user?.farcaster && (
-              <View style={[styles.infoRow, styles.infoRowLast]}>
-                <Text style={styles.infoLabel}>Farcaster</Text>
-                <Text style={styles.infoValue}>@{user.farcaster.username}</Text>
-              </View>
-            )}
-          </View>
-        )}
-      </View>
+      )}
+
+      {/* Account Info removed: identity fields (.q / address / @username / FID)
+          now live in the big profile card; Privacy Level moved to Settings. */}
     </>
   );
 });
@@ -4048,6 +4028,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
   syncDisabled,
   notifications,
   onToggleNotifications,
+  privacyLevel,
 }: {
   styles: ProfileStyles;
   theme: AppTheme;
@@ -4058,6 +4039,9 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
   syncDisabled: boolean;
   notifications: boolean;
   onToggleNotifications: (enabled: boolean) => void;
+  /** Read-only display of the account's privacy level (moved here from the old
+   *  Account Info card). */
+  privacyLevel?: string;
 }) {
   return (
     <>
@@ -4103,6 +4087,15 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
             thumbColor={'#ffffff'}
           />
+        </View>
+        {/* Privacy Level — read-only (moved from the old Account Info card). */}
+        <View style={styles.settingRow}>
+          <View style={styles.settingLeft}>
+            <Text style={styles.settingLabel}>Privacy Level</Text>
+          </View>
+          <Text style={styles.infoValue}>
+            {privacyLevel ? privacyLevel.charAt(0).toUpperCase() + privacyLevel.slice(1) : 'Standard'}
+          </Text>
         </View>
       </View>
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -942,7 +942,7 @@ export default function ProfileModal({
       const ok = await confirm({
         title: 'Merge profiles',
         message:
-          'You’ll see and edit one profile. From now on, editing your name, bio, or picture updates both Quorum and Farcaster at once. Until you edit, each keeps its current values. Usernames always stay separate. You can separate them again later.',
+          'Your name, bio, and picture will be made the same on Quorum and Farcaster (Quorum wins where both are set), and editing will update both at once. Your usernames are never affected. You can un-merge the profiles again later.',
         confirmLabel: 'Merge',
       });
       if (!ok) return;

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -149,6 +149,12 @@ interface ProfileModalProps {
   /** True when the header shows the identity switcher (unmerged + both profiles).
    *  Drives the Bio heading's brand icon + the duplicated My Casts button. */
   dualIdentity?: boolean;
+  /** Called after a Farcaster account is successfully connected/imported, so the
+   *  parent can redirect to the Farcaster pill. */
+  onFarcasterConnected?: () => void;
+  /** Re-enter split mode (unmerge). Surfaced as a "Keep profiles separate" row in
+   *  the Farcaster section when currently merged. */
+  onUnmergeProfiles?: () => void;
 }
 
 /** The selectable sections of the profile body. 'farcaster' only applies when a
@@ -349,6 +355,8 @@ export default function ProfileModal({
   onMergeProfiles,
   farcasterIdentity,
   dualIdentity,
+  onFarcasterConnected,
+  onUnmergeProfiles,
 }: ProfileModalProps) {
   const { theme, isDark, activeSkin } = useTheme();
   const { user, signOut, updateProfile } = useAuth();
@@ -447,6 +455,23 @@ export default function ProfileModal({
   const [farcasterMnemonic, setFarcasterMnemonic] = React.useState('');
   const [farcasterImporting, setFarcasterImporting] = React.useState(false);
   const [farcasterError, setFarcasterError] = React.useState<string | null>(null);
+  // Recovery phrase is hidden by default (treated like a password); the user can
+  // reveal it to double-check the words.
+  const [revealMnemonic, setRevealMnemonic] = React.useState(false);
+  // Paste the recovery phrase from the clipboard (mirrors the onboarding import).
+  const handlePasteFarcasterMnemonic = React.useCallback(async () => {
+    try {
+      const text = await Clipboard.getStringAsync();
+      if (!text || !text.trim()) {
+        setFarcasterError('Clipboard is empty');
+        return;
+      }
+      setFarcasterMnemonic(text.trim());
+      setFarcasterError(null);
+    } catch {
+      setFarcasterError('Failed to read clipboard');
+    }
+  }, []);
 
   // Device management
   const [deviceRegistrations, setDeviceRegistrations] = React.useState<DeviceRegistration[]>([]);
@@ -874,7 +899,10 @@ export default function ProfileModal({
       // Reset state and show success
       setShowFarcasterImport(false);
       setFarcasterMnemonic('');
+      setRevealMnemonic(false);
       Alert.alert('Success', `Connected as @${account.username}`);
+      // Redirect to the Farcaster pill now that it exists.
+      onFarcasterConnected?.();
     } catch (error) {
       setFarcasterError('Failed to import Farcaster account. Please try again.');
     } finally {
@@ -909,6 +937,22 @@ export default function ProfileModal({
       onMergeProfiles();
     })();
   }, [confirm, onMergeProfiles]);
+
+  // Unmerge (keep separate) — confirm first, then delegate to the parent (which
+  // flips split mode back on). Purely a display change; no data is altered.
+  const handleUnmergeProfiles = React.useCallback(() => {
+    if (!onUnmergeProfiles) return;
+    void (async () => {
+      const ok = await confirm({
+        title: 'Keep profiles separate',
+        message:
+          'Your Quorum and Farcaster profiles will be shown and edited separately again. Nothing is deleted.',
+        confirmLabel: 'Keep separate',
+      });
+      if (!ok) return;
+      onUnmergeProfiles();
+    })();
+  }, [confirm, onUnmergeProfiles]);
 
   const handlePickImage = React.useCallback(async () => {
     if (!user?.address) return;
@@ -2191,6 +2235,9 @@ export default function ProfileModal({
                     <Text style={styles.farcasterImportDescription}>
                       Enter your Farcaster recovery phrase (12 or 24 words) to import your account.
                     </Text>
+                    {/* Hidden by default (treated like a password). Hidden state
+                        uses a single-line secure field; revealing switches to a
+                        multiline plaintext field so the words can be checked. */}
                     <TextInput
                       style={styles.farcasterMnemonicInput}
                       value={farcasterMnemonic}
@@ -2198,15 +2245,34 @@ export default function ProfileModal({
                         setFarcasterMnemonic(text);
                         setFarcasterError(null);
                       }}
-                      placeholder="Enter recovery phrase..."
+                      placeholder="Enter or paste your recovery phrase..."
                       placeholderTextColor={theme.colors.textMuted}
-                      multiline
-                      numberOfLines={3}
+                      secureTextEntry={!revealMnemonic}
+                      multiline={revealMnemonic}
+                      numberOfLines={revealMnemonic ? 3 : 1}
                       textAlignVertical="top"
                       autoCapitalize="none"
                       autoCorrect={false}
                       editable={!farcasterImporting}
                     />
+                    <View style={styles.farcasterImportTools}>
+                      <TouchableOpacity
+                        style={styles.farcasterImportToolButton}
+                        onPress={handlePasteFarcasterMnemonic}
+                        disabled={farcasterImporting}
+                      >
+                        <IconSymbol name="doc.on.clipboard" size={16} color={theme.colors.primary} />
+                        <Text style={styles.farcasterImportToolText}>Paste</Text>
+                      </TouchableOpacity>
+                      <TouchableOpacity
+                        style={styles.farcasterImportToolButton}
+                        onPress={() => setRevealMnemonic((v) => !v)}
+                        disabled={farcasterImporting}
+                      >
+                        <IconSymbol name={revealMnemonic ? 'eye.slash' : 'eye'} size={16} color={theme.colors.primary} />
+                        <Text style={styles.farcasterImportToolText}>{revealMnemonic ? 'Hide' : 'Show'}</Text>
+                      </TouchableOpacity>
+                    </View>
                     {farcasterError && (
                       <View style={styles.farcasterErrorContainer}>
                         <IconSymbol name="exclamationmark.circle.fill" size={16} color={theme.colors.danger} />
@@ -2220,6 +2286,7 @@ export default function ProfileModal({
                           setShowFarcasterImport(false);
                           setFarcasterMnemonic('');
                           setFarcasterError(null);
+                          setRevealMnemonic(false);
                         }}
                         disabled={farcasterImporting}
                       >
@@ -2408,14 +2475,25 @@ export default function ProfileModal({
                     <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
                   </View>
                 )}
-                {/* Merge profiles — re-reachable entry to the merge chooser
-                    (only when currently unmerged; parent gates the callback). */}
+                {/* Merge profiles — shown when currently unmerged (parent gates
+                    the callback on splitMode). */}
                 {onMergeProfiles && (
                   <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleMergeProfiles}>
                     <IconSymbol name="merge" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
                     <View style={styles.actionButtonContent}>
                       <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Merge profiles</Text>
                       <Text style={styles.actionButtonSubtext}>Combine your Quorum and Farcaster profiles into one</Text>
+                    </View>
+                  </TouchableOpacity>
+                )}
+                {/* Keep separate (unmerge) — shown when currently merged. Purely a
+                    display change; no data is altered. */}
+                {onUnmergeProfiles && (
+                  <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleUnmergeProfiles}>
+                    <IconSymbol name="split" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                    <View style={styles.actionButtonContent}>
+                      <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Keep profiles separate</Text>
+                      <Text style={styles.actionButtonSubtext}>Show and edit your Quorum and Farcaster profiles separately</Text>
                     </View>
                   </TouchableOpacity>
                 )}
@@ -3540,6 +3618,24 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       borderWidth: Skin.border(1),
       borderColor: theme.colors.border,
     },
+    // Paste / Show-Hide tool row under the recovery-phrase input.
+    farcasterImportTools: {
+      flexDirection: 'row',
+      gap: Skin.space(16),
+      marginTop: Skin.space(8),
+    },
+    farcasterImportToolButton: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      gap: Skin.space(6),
+      paddingVertical: Skin.space(4),
+    },
+    farcasterImportToolText: {
+      fontSize: Skin.font(13),
+      color: theme.colors.primary,
+      fontFamily: theme.fonts.medium.fontFamily,
+      fontWeight: theme.fonts.medium.fontWeight,
+    },
     farcasterErrorContainer: {
       flexDirection: 'row',
       alignItems: 'center',
@@ -3994,7 +4090,12 @@ const ProfileTabSection = React.memo(function ProfileTabSection({
             <Text style={styles.bioText}>
               {showFarcaster
                 ? (farcasterIdentity?.bio || 'No Farcaster bio yet.')
-                : (user?.bio || 'No bio yet. Tap Edit to add one.')}
+                : // Merged (has Farcaster, not the dual-identity switcher): bios are
+                  // meant to be identical after editing, so fall back to the
+                  // Farcaster bio if the Quorum bio is empty.
+                  (user?.bio
+                    || (!dualIdentity && farcasterIdentity?.bio)
+                    || 'No bio yet. Tap Edit to add one.')}
             </Text>
           </View>
         )}

--- a/components/ProfileSplitModeModal.tsx
+++ b/components/ProfileSplitModeModal.tsx
@@ -58,8 +58,8 @@ export default function ProfileSplitModeModal({
           <View style={styles.optionTextWrap}>
             <Text style={styles.optionTitle}>Merge</Text>
             <Text style={styles.optionDesc}>
-              Nothing changes now. From then on, editing your name, avatar, or bio
-              updates both Quorum and Farcaster at once.
+              Your name, avatar, and bio are made the same on both, and editing
+              updates both at once. Usernames stay separate.
             </Text>
           </View>
         </TouchableOpacity>

--- a/components/ProfileSplitModeModal.tsx
+++ b/components/ProfileSplitModeModal.tsx
@@ -45,26 +45,26 @@ export default function ProfileSplitModeModal({
           <View style={styles.optionTextWrap}>
             <Text style={styles.optionTitle}>Keep separate</Text>
             <Text style={styles.optionDesc}>
-              Different display name, avatar, and bio per system. You pick which
-              one you're editing each time.
+              Keep a different name, avatar, and bio for each. You pick which one
+              you&apos;re editing each time.
             </Text>
           </View>
         </TouchableOpacity>
 
         <TouchableOpacity style={styles.option} onPress={() => choose(false)} activeOpacity={0.7}>
           <View style={styles.optionIcon}>
-            <IconSymbol name="link" size={22} color={theme.colors.accent} />
+            <IconSymbol name="merge" size={22} color={theme.colors.accent} />
           </View>
           <View style={styles.optionTextWrap}>
             <Text style={styles.optionTitle}>Merge</Text>
             <Text style={styles.optionDesc}>
-              Edit display name, avatar, and bio once — changes are applied to
-              both Quorum and Farcaster.
+              Nothing changes now. From then on, editing your name, avatar, or bio
+              updates both Quorum and Farcaster at once.
             </Text>
           </View>
         </TouchableOpacity>
 
-        <Text style={styles.footer}>You can change this any time in Settings.</Text>
+        <Text style={styles.footer}>You can change this any time from the Farcaster section of your profile.</Text>
       </View>
     </BaseModal>
   );

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -29,6 +29,7 @@ import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { ApexAvatarRing } from '@/components/ui/ApexAvatarRing';
 import { useApexStatusForFids } from '@/hooks/useApex';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { SpaceIcon } from '@/components/ui/SpaceIcon';
 import { useAuth } from '@/context/AuthContext';
 import { useConversations, type ConversationWithPreview } from '@/hooks/chat/useConversations';
@@ -505,11 +506,6 @@ const shareToChatStyles = {
     height: 40,
     borderRadius: Skin.radius(20),
   },
-  farcasterBadge: {
-    width: 18,
-    height: 18,
-    opacity: 0.7,
-  },
 };
 
 function ShareToChatModal({
@@ -726,10 +722,7 @@ function ShareToChatModal({
                           sublabel={showHandle ? `@${conv.farcasterUsername}` : undefined}
                           trailing={
                             isFarcaster ? (
-                              <Image
-                                source={require('../assets/images/farcaster.png')}
-                                style={shareToChatStyles.farcasterBadge}
-                              />
+                              <FarcasterLogoIcon size={16} color="#855DCD" />
                             ) : undefined
                           }
                           onPress={() => (isFarcaster ? handleSelectFarcasterDM(conv) : handleSelectDM(conv))}

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -2,7 +2,7 @@ import { BaseModal } from '@/components/shared';
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAuth, useWebSocket } from '@/context';
-import { useFarcasterProfile, type ProfilePage } from '@/hooks/useFarcasterProfile';
+import { useFarcasterProfile, type ProfilePage, type ProfileAuthor } from '@/hooks/useFarcasterProfile';
 import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { updateFarcasterProfile } from '@/services/farcaster/updateProfile';
 import { getAllSpaces } from '@/services/config/spaceStorage';
@@ -186,23 +186,29 @@ export default function UnifiedProfileEditModal({
   // Optimistically patch the cached Farcaster profile so the new name/bio/pfp
   // show immediately, then invalidate to reconcile with the server. Without this
   // the display reads the stale useFarcasterProfile cache for up to staleTime.
+  // Patches BOTH the page-level author (profile header) AND every own cast's
+  // embedded author (each cast row carries its own author snapshot), so the
+  // cast list updates instantly too.
   const applyFarcasterOptimistic = (pfpUrl?: string) => {
     const fid = user?.farcaster?.fid;
     if (!fid) return;
     const name = displayName.trim();
     const b = bio.trim();
+    const patchAuthor = <T extends ProfileAuthor>(author: T): T => ({
+      ...author,
+      displayName: name || author.displayName,
+      profile: { ...author.profile, bio: { text: b } },
+      pfp: pfpUrl ? { ...author.pfp, url: pfpUrl } : author.pfp,
+    });
     queryClient.setQueryData<InfiniteData<ProfilePage>>(['farcaster-profile', fid], (prev) => {
       if (!prev?.pages?.length) return prev;
-      const page0 = prev.pages[0];
-      const author = page0.author;
-      if (!author) return prev;
-      const nextAuthor = {
-        ...author,
-        displayName: name || author.displayName,
-        profile: { ...author.profile, bio: { text: b } },
-        pfp: pfpUrl ? { ...author.pfp, url: pfpUrl } : author.pfp,
-      };
-      const nextPages = prev.pages.map((p, i) => (i === 0 ? { ...p, author: nextAuthor } : p));
+      const nextPages = prev.pages.map((p) => ({
+        ...p,
+        author: p.author && p.author.fid === fid ? patchAuthor(p.author) : p.author,
+        casts: p.casts.map((c) =>
+          c.author?.fid === fid ? { ...c, author: patchAuthor(c.author) } : c,
+        ),
+      }));
       return { ...prev, pages: nextPages };
     });
     void queryClient.invalidateQueries({ queryKey: ['farcaster-profile', fid] });

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -42,7 +42,7 @@ export default function UnifiedProfileEditModal({
 }: UnifiedProfileEditModalProps) {
   const { theme } = useTheme();
   const { user, farcasterAuthToken, updateProfile } = useAuth();
-  const { enqueueOutbound } = useWebSocket();
+  const { enqueueOutbound, subscribe } = useWebSocket();
   const queryClient = useQueryClient();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
@@ -155,6 +155,22 @@ export default function UnifiedProfileEditModal({
         return envelopes;
       });
     }
+
+    // Broadcast to all DM partners too (identity sync over established DM
+    // sessions). Without this, DM contacts wouldn't see name/bio/avatar changes
+    // made through this editor. Bio gated on the public-profile toggle, matching
+    // the legacy save path. Fire-and-forget; the service dedupes + never throws.
+    void import('@/services/dm/dmProfileService').then(({ broadcastProfileToAllDMs }) =>
+      broadcastProfileToAllDMs(
+        {
+          selfAddress: user.address,
+          displayName: name || undefined,
+          bio: user.isProfilePublic ? (b || undefined) : undefined,
+          userIcon: avatar || undefined,
+        },
+        { enqueueOutbound, subscribe },
+      ),
+    );
   };
 
   const saveFarcaster = async (): Promise<{ errors: string[]; pfpUrl?: string }> => {

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -2,7 +2,8 @@ import { BaseModal } from '@/components/shared';
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAuth, useWebSocket } from '@/context';
-import { useFarcasterProfile } from '@/hooks/useFarcasterProfile';
+import { useFarcasterProfile, type ProfilePage } from '@/hooks/useFarcasterProfile';
+import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { updateFarcasterProfile } from '@/services/farcaster/updateProfile';
 import { getAllSpaces } from '@/services/config/spaceStorage';
 import { maybeSendUpdateProfileMessage } from '@/services/space/spaceMessageService';
@@ -42,6 +43,7 @@ export default function UnifiedProfileEditModal({
   const { theme } = useTheme();
   const { user, farcasterAuthToken, updateProfile } = useAuth();
   const { enqueueOutbound } = useWebSocket();
+  const queryClient = useQueryClient();
   const styles = useMemo(() => createStyles(theme), [theme]);
 
   const [displayName, setDisplayName] = useState('');
@@ -155,9 +157,9 @@ export default function UnifiedProfileEditModal({
     }
   };
 
-  const saveFarcaster = async (): Promise<string[]> => {
+  const saveFarcaster = async (): Promise<{ errors: string[]; pfpUrl?: string }> => {
     if (!farcasterAuthToken) {
-      return ['Farcaster not connected'];
+      return { errors: ['Farcaster not connected'] };
     }
     const name = displayName.trim();
     const b = bio.trim();
@@ -168,13 +170,42 @@ export default function UnifiedProfileEditModal({
     };
     // Only send a new pfp when the avatar differs from what we already had
     // (heuristic: data URI or local file URI indicates user picked a new image)
-    if (avatar && (avatar.startsWith('data:') || avatar.startsWith('file:'))) {
-      fields.pfp = avatar;
+    const pickedNewPfp = !!avatar && (avatar.startsWith('data:') || avatar.startsWith('file:'));
+    if (pickedNewPfp) {
+      fields.pfp = avatar!;
     }
 
     const res = await updateFarcasterProfile(farcasterAuthToken, fields);
-    if (!res.ok) return [res.error ?? 'Unknown error'];
-    return [];
+    if (!res.ok) return { errors: [res.error ?? 'Unknown error'] };
+    // Canonical pfp URL to reflect in the UI: the uploaded URL for a new image,
+    // otherwise whatever the avatar already was (an existing https URL).
+    const pfpUrl = res.uploadedPfpUrl ?? (avatar ?? undefined);
+    return { errors: [], pfpUrl };
+  };
+
+  // Optimistically patch the cached Farcaster profile so the new name/bio/pfp
+  // show immediately, then invalidate to reconcile with the server. Without this
+  // the display reads the stale useFarcasterProfile cache for up to staleTime.
+  const applyFarcasterOptimistic = (pfpUrl?: string) => {
+    const fid = user?.farcaster?.fid;
+    if (!fid) return;
+    const name = displayName.trim();
+    const b = bio.trim();
+    queryClient.setQueryData<InfiniteData<ProfilePage>>(['farcaster-profile', fid], (prev) => {
+      if (!prev?.pages?.length) return prev;
+      const page0 = prev.pages[0];
+      const author = page0.author;
+      if (!author) return prev;
+      const nextAuthor = {
+        ...author,
+        displayName: name || author.displayName,
+        profile: { ...author.profile, bio: { text: b } },
+        pfp: pfpUrl ? { ...author.pfp, url: pfpUrl } : author.pfp,
+      };
+      const nextPages = prev.pages.map((p, i) => (i === 0 ? { ...p, author: nextAuthor } : p));
+      return { ...prev, pages: nextPages };
+    });
+    void queryClient.invalidateQueries({ queryKey: ['farcaster-profile', fid] });
   };
 
   const handleSave = async () => {
@@ -200,7 +231,7 @@ export default function UnifiedProfileEditModal({
         await saveQuorum();
       }
       if (farcasterTargeted) {
-        const fcErrors = await saveFarcaster();
+        const { errors: fcErrors, pfpUrl } = await saveFarcaster();
         if (fcErrors.length > 0) {
           Alert.alert(
             'Farcaster update failed',
@@ -209,6 +240,9 @@ export default function UnifiedProfileEditModal({
           setSaving(false);
           return;
         }
+        // Reflect the saved values immediately (the profile query is otherwise
+        // stale for up to staleTime, so the old pfp/name/bio would linger).
+        applyFarcasterOptimistic(pfpUrl);
       }
       onClose();
     } catch (e) {

--- a/components/UnifiedProfileHeader.tsx
+++ b/components/UnifiedProfileHeader.tsx
@@ -2,6 +2,7 @@ import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { QuorumLogoIcon } from '@/components/SocialFeed/content/QuorumLogoIcon';
+import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import type { UserInfo } from '@/context/AuthContext';
 import type { ProfileAuthor } from '@/hooks/useFarcasterProfile';
 import { truncateAddress } from '@/utils/formatAddress';
@@ -11,19 +12,32 @@ import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Skin from '@/theme/skins/geometry';
 
+/** Which identity the big profile card shows when unmerged with both profiles. */
+export type IdentityTab = 'quorum' | 'farcaster';
+
 interface UnifiedProfileHeaderProps {
   user: UserInfo;
   farcasterProfile?: ProfileAuthor | null;
   splitMode: boolean;
+  /** Selected identity (unmerged-with-both layout). Owned by the parent. */
+  identityTab: IdentityTab;
+  onIdentityTabChange: (tab: IdentityTab) => void;
   onEditQuorum?: () => void;
   onEditFarcaster?: () => void;
   onEditUnified?: () => void;
 }
 
+const IDENTITY_PILLS: SegmentedPillItem[] = [
+  { key: 'quorum', label: 'Quorum', leading: <QuorumLogoIcon size={14} /> },
+  { key: 'farcaster', label: 'Farcaster', leading: <FarcasterLogoIcon size={14} /> },
+];
+
 export default function UnifiedProfileHeader({
   user,
   farcasterProfile,
   splitMode,
+  identityTab,
+  onIdentityTabChange,
   onEditQuorum,
   onEditFarcaster,
   onEditUnified,
@@ -37,14 +51,53 @@ export default function UnifiedProfileHeader({
     return <QuorumOnlyHeader user={user} onEdit={onEditQuorum} theme={theme} styles={styles} />;
   }
 
+  // Unmerged with both profiles: one big card + a [Quorum | Farcaster] switcher
+  // above it. Swapping changes only this card; the nav pills below are separate.
   if (splitMode) {
+    const showingFarcaster = identityTab === 'farcaster';
+    // Quorum identity owns the QNS handle + on-chain address; Farcaster identity
+    // shows only its @handle (no Quorum address). The address line renders only
+    // when `address` is set, so neither identity duplicates it.
+    const identity = showingFarcaster
+      ? {
+          displayName: farcasterProfile?.displayName || user.farcaster?.username || 'Unnamed',
+          avatarUri: farcasterProfile?.pfp?.url || user.farcaster?.pfpUrl,
+          bio: farcasterProfile?.profile?.bio?.text,
+          handle: user.farcaster?.username ? `@${user.farcaster.username}` : undefined,
+          handleAccent: false,
+          address: undefined as string | undefined,
+          onEdit: onEditFarcaster,
+        }
+      : {
+          displayName: user.displayName || user.primaryUsername || 'Unnamed',
+          avatarUri: user.profileImage,
+          bio: user.bio,
+          handle: user.primaryUsername ? `${user.primaryUsername}.q` : undefined,
+          handleAccent: Boolean(user.primaryUsername),
+          address: user.address,
+          onEdit: onEditQuorum,
+        };
+
     return (
-      <View style={styles.splitContainer}>
-        <QuorumCard user={user} onEdit={onEditQuorum} theme={theme} styles={styles} />
-        <FarcasterCard
-          user={user}
-          profile={farcasterProfile}
-          onEdit={onEditFarcaster}
+      <View style={styles.switcherContainer}>
+        {/* 'segmented' (iOS track) look distinguishes the identity switcher from
+            the solid nav pills below, so the two rows don't read as one. */}
+        <SegmentedPills
+          items={IDENTITY_PILLS}
+          activeKey={identityTab}
+          onChange={(key) => onIdentityTabChange(key as IdentityTab)}
+          variant="segmented"
+          scrollable={false}
+          itemRole="tab"
+          style={styles.identitySwitcher}
+        />
+        <BigProfileCard
+          displayName={identity.displayName}
+          avatarUri={identity.avatarUri}
+          handle={identity.handle}
+          handleAccent={identity.handleAccent}
+          address={identity.address}
+          onEdit={identity.onEdit}
           theme={theme}
           styles={styles}
         />
@@ -100,6 +153,63 @@ export default function UnifiedProfileHeader({
   );
 }
 
+/**
+ * The big single-identity profile card (96px avatar, pencil badge, name, handle,
+ * bio) used in the unmerged switcher layout. Mirrors the merged/Quorum-only look
+ * but renders whichever identity is selected.
+ */
+function BigProfileCard({
+  displayName,
+  avatarUri,
+  handle,
+  handleAccent,
+  address,
+  onEdit,
+  theme,
+  styles,
+}: {
+  displayName: string;
+  avatarUri?: string | null;
+  handle?: string;
+  handleAccent?: boolean;
+  address?: string;
+  onEdit?: () => void;
+  theme: AppTheme;
+  styles: ReturnType<typeof createStyles>;
+}) {
+  return (
+    <View style={styles.bigCardContainer}>
+      <TouchableOpacity onPress={onEdit} activeOpacity={0.8} style={styles.mergedAvatarWrap}>
+        <CachedAvatar
+          source={avatarUri ? { uri: avatarUri } : null}
+          style={styles.mergedAvatar}
+          fallbackName={displayName}
+        />
+        <View style={styles.editBadge}>
+          <IconSymbol name="pencil" size={12} color="#fff" />
+        </View>
+      </TouchableOpacity>
+
+      <Text style={styles.mergedDisplayName} numberOfLines={1}>
+        {displayName}
+      </Text>
+
+      <View style={styles.handlesRow}>
+        {handle ? (
+          <Text style={[styles.handleText, handleAccent && { color: theme.colors.accent }]}>
+            {handle}
+          </Text>
+        ) : null}
+        {address ? (
+          <Text style={styles.addressText}>{truncateAddress(address, 'medium')}</Text>
+        ) : null}
+      </View>
+      {/* Bio intentionally omitted here — it's shown in the Profile section
+          below, which reflects the selected identity. */}
+    </View>
+  );
+}
+
 function QuorumOnlyHeader({
   user,
   onEdit,
@@ -141,82 +251,6 @@ function QuorumOnlyHeader({
         </Text>
       ) : null}
     </View>
-  );
-}
-
-function QuorumCard({
-  user,
-  onEdit,
-  theme,
-  styles,
-}: {
-  user: UserInfo;
-  onEdit?: () => void;
-  theme: AppTheme;
-  styles: ReturnType<typeof createStyles>;
-}) {
-  const displayName = user.displayName || user.primaryUsername || 'Unnamed';
-  return (
-    <TouchableOpacity style={styles.card} activeOpacity={0.85} onPress={onEdit}>
-      <View style={styles.cardEditBadge}>
-        <IconSymbol name="pencil" size={11} color="#fff" />
-      </View>
-      <CachedAvatar
-        source={user.profileImage ? { uri: user.profileImage } : null}
-        style={styles.cardAvatar}
-        fallbackName={displayName}
-      />
-      <View style={styles.cardText}>
-        <View style={styles.cardLabelRow}>
-          <QuorumLogoIcon size={11} />
-          <Text style={[styles.cardLabel, { color: theme.colors.accent }]}>Quorum</Text>
-        </View>
-        <Text style={styles.cardDisplayName} numberOfLines={1}>{displayName}</Text>
-        <Text style={styles.cardHandleMuted} numberOfLines={1}>
-          {user.primaryUsername ? `${user.primaryUsername}.q` : truncateAddress(user.address, 'short')}
-        </Text>
-      </View>
-    </TouchableOpacity>
-  );
-}
-
-function FarcasterCard({
-  user,
-  profile,
-  onEdit,
-  theme,
-  styles,
-}: {
-  user: UserInfo;
-  profile?: ProfileAuthor | null;
-  onEdit?: () => void;
-  theme: AppTheme;
-  styles: ReturnType<typeof createStyles>;
-}) {
-  const displayName =
-    profile?.displayName || user.farcaster?.username || 'Unnamed';
-  const avatarUri = profile?.pfp?.url || user.farcaster?.pfpUrl;
-  return (
-    <TouchableOpacity style={styles.card} activeOpacity={0.85} onPress={onEdit}>
-      <View style={styles.cardEditBadge}>
-        <IconSymbol name="pencil" size={11} color="#fff" />
-      </View>
-      <CachedAvatar
-        source={avatarUri ? { uri: avatarUri } : null}
-        style={styles.cardAvatar}
-        fallbackName={displayName}
-      />
-      <View style={styles.cardText}>
-        <View style={styles.cardLabelRow}>
-          <FarcasterLogoIcon size={11} color={theme.colors.textMuted} />
-          <Text style={[styles.cardLabel, { color: theme.colors.textMuted }]}>Farcaster</Text>
-        </View>
-        <Text style={styles.cardDisplayName} numberOfLines={1}>{displayName}</Text>
-        {user.farcaster?.username ? (
-          <Text style={styles.cardHandleMuted} numberOfLines={1}>@{user.farcaster.username}</Text>
-        ) : null}
-      </View>
-    </TouchableOpacity>
   );
 }
 
@@ -279,73 +313,21 @@ function createStyles(theme: AppTheme) {
       marginTop: Skin.space(6),
       lineHeight: Skin.font(19),
     },
-    splitContainer: {
-      flexDirection: 'row',
-      paddingHorizontal: Skin.space(12),
-      paddingTop: Skin.space(10),
-      paddingBottom: Skin.space(12),
-      gap: Skin.space(8),
-    },
-    card: {
-      flex: 1,
-      flexDirection: 'row',
+    // Unmerged switcher layout: [Quorum|Farcaster] track + one big card.
+    switcherContainer: {
       alignItems: 'center',
-      position: 'relative',
-      paddingVertical: Skin.space(10),
-      paddingHorizontal: Skin.space(10),
-      borderRadius: Skin.radius(12),
-      backgroundColor: theme.colors.surface1,
-      borderWidth: Skin.border(1),
-      borderColor: theme.colors.surface3,
-      gap: Skin.space(10),
+      paddingTop: Skin.space(20),
     },
-    cardText: {
-      flex: 1,
-      minWidth: 0,
+    identitySwitcher: {
+      alignSelf: 'center',
+      marginBottom: Skin.space(4),
     },
-    cardLabelRow: {
-      flexDirection: 'row',
+    bigCardContainer: {
       alignItems: 'center',
-      gap: Skin.space(5),
-    },
-    cardLabel: {
-      fontSize: Skin.font(10),
-      fontWeight: '600',
-      letterSpacing: 0.4,
-      textTransform: 'uppercase',
-    },
-    cardAvatar: {
-      width: 40,
-      height: 40,
-      borderRadius: Skin.radius(20),
-      backgroundColor: theme.colors.surface2,
-    },
-    // Pencil badge in the top-right corner of the split-mode card — signals the
-    // card is tappable to edit, mirroring the merged/Quorum-only header's badge.
-    cardEditBadge: {
-      position: 'absolute',
-      top: Skin.space(6),
-      right: Skin.space(6),
-      width: 18,
-      height: 18,
-      borderRadius: Skin.radius(9),
-      alignItems: 'center',
-      justifyContent: 'center',
-      backgroundColor: theme.colors.accent,
-      zIndex: 1,
-    },
-    cardDisplayName: {
-      fontSize: Skin.font(14),
-      fontWeight: '600',
-      color: theme.colors.textStrong,
-    },
-    cardHandle: {
-      fontSize: Skin.font(12),
-      fontWeight: '500',
-    },
-    cardHandleMuted: {
-      fontSize: Skin.font(11),
-      color: theme.colors.textMuted,
+      paddingHorizontal: Skin.space(20),
+      paddingTop: Skin.space(16),
+      paddingBottom: Skin.space(16),
+      gap: Skin.space(6),
     },
   });
 }

--- a/components/UnifiedProfileHeader.tsx
+++ b/components/UnifiedProfileHeader.tsx
@@ -25,6 +25,8 @@ interface UnifiedProfileHeaderProps {
   onEditQuorum?: () => void;
   onEditFarcaster?: () => void;
   onEditUnified?: () => void;
+  /** Copy the Quorum address (tappable address line on the Quorum card). */
+  onCopyAddress?: () => void;
 }
 
 const IDENTITY_PILLS: SegmentedPillItem[] = [
@@ -41,6 +43,7 @@ export default function UnifiedProfileHeader({
   onEditQuorum,
   onEditFarcaster,
   onEditUnified,
+  onCopyAddress,
 }: UnifiedProfileHeaderProps) {
   const { theme } = useTheme();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -55,28 +58,6 @@ export default function UnifiedProfileHeader({
   // above it. Swapping changes only this card; the nav pills below are separate.
   if (splitMode) {
     const showingFarcaster = identityTab === 'farcaster';
-    // Quorum identity owns the QNS handle + on-chain address; Farcaster identity
-    // shows only its @handle (no Quorum address). The address line renders only
-    // when `address` is set, so neither identity duplicates it.
-    const identity = showingFarcaster
-      ? {
-          displayName: farcasterProfile?.displayName || user.farcaster?.username || 'Unnamed',
-          avatarUri: farcasterProfile?.pfp?.url || user.farcaster?.pfpUrl,
-          bio: farcasterProfile?.profile?.bio?.text,
-          handle: user.farcaster?.username ? `@${user.farcaster.username}` : undefined,
-          handleAccent: false,
-          address: undefined as string | undefined,
-          onEdit: onEditFarcaster,
-        }
-      : {
-          displayName: user.displayName || user.primaryUsername || 'Unnamed',
-          avatarUri: user.profileImage,
-          bio: user.bio,
-          handle: user.primaryUsername ? `${user.primaryUsername}.q` : undefined,
-          handleAccent: Boolean(user.primaryUsername),
-          address: user.address,
-          onEdit: onEditQuorum,
-        };
 
     return (
       <View style={styles.switcherContainer}>
@@ -91,16 +72,28 @@ export default function UnifiedProfileHeader({
           itemRole="tab"
           style={styles.identitySwitcher}
         />
-        <BigProfileCard
-          displayName={identity.displayName}
-          avatarUri={identity.avatarUri}
-          handle={identity.handle}
-          handleAccent={identity.handleAccent}
-          address={identity.address}
-          onEdit={identity.onEdit}
-          theme={theme}
-          styles={styles}
-        />
+        {showingFarcaster ? (
+          <BigProfileCard
+            displayName={farcasterProfile?.displayName || user.farcaster?.username || 'Unnamed'}
+            avatarUri={farcasterProfile?.pfp?.url || user.farcaster?.pfpUrl}
+            username={user.farcaster?.username ? `@${user.farcaster.username}` : undefined}
+            fid={user.farcaster?.fid}
+            onEdit={onEditFarcaster}
+            theme={theme}
+            styles={styles}
+          />
+        ) : (
+          <BigProfileCard
+            displayName={user.displayName || user.primaryUsername || 'Unnamed'}
+            avatarUri={user.profileImage}
+            qname={user.primaryUsername ? `${user.primaryUsername}.q` : undefined}
+            address={user.address}
+            onCopyAddress={onCopyAddress}
+            onEdit={onEditQuorum}
+            theme={theme}
+            styles={styles}
+          />
+        )}
       </View>
     );
   }
@@ -154,25 +147,35 @@ export default function UnifiedProfileHeader({
 }
 
 /**
- * The big single-identity profile card (96px avatar, pencil badge, name, handle,
- * bio) used in the unmerged switcher layout. Mirrors the merged/Quorum-only look
- * but renders whichever identity is selected.
+ * The big single-identity profile card (96px avatar, pencil badge) used in the
+ * unmerged switcher layout. Renders identity-specific lines under the name:
+ *  - Quorum: `.q` name (accent) + a tappable, copyable address.
+ *  - Farcaster: @username + FID, with a top-right Disconnect control.
+ * Bio is omitted here — it lives in the Profile section below.
  */
 function BigProfileCard({
   displayName,
   avatarUri,
-  handle,
-  handleAccent,
+  qname,
+  username,
+  fid,
   address,
+  onCopyAddress,
   onEdit,
   theme,
   styles,
 }: {
   displayName: string;
   avatarUri?: string | null;
-  handle?: string;
-  handleAccent?: boolean;
+  /** Quorum `.q` primary username, e.g. "alice.q". */
+  qname?: string;
+  /** Farcaster @handle. */
+  username?: string;
+  /** Farcaster ID. */
+  fid?: number;
+  /** Quorum on-chain address (tappable to copy). */
   address?: string;
+  onCopyAddress?: () => void;
   onEdit?: () => void;
   theme: AppTheme;
   styles: ReturnType<typeof createStyles>;
@@ -194,18 +197,33 @@ function BigProfileCard({
         {displayName}
       </Text>
 
-      <View style={styles.handlesRow}>
-        {handle ? (
-          <Text style={[styles.handleText, handleAccent && { color: theme.colors.accent }]}>
-            {handle}
-          </Text>
-        ) : null}
-        {address ? (
+      {/* Quorum: .q name */}
+      {qname ? (
+        <Text style={[styles.handleText, { color: theme.colors.accent }]}>{qname}</Text>
+      ) : null}
+
+      {/* Quorum: tappable address + copy icon */}
+      {address ? (
+        <TouchableOpacity
+          style={styles.addressRow}
+          onPress={onCopyAddress}
+          accessibilityRole="button"
+          accessibilityLabel="Copy address"
+        >
           <Text style={styles.addressText}>{truncateAddress(address, 'medium')}</Text>
-        ) : null}
-      </View>
-      {/* Bio intentionally omitted here — it's shown in the Profile section
-          below, which reflects the selected identity. */}
+          <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
+        </TouchableOpacity>
+      ) : null}
+
+      {/* Farcaster: @username */}
+      {username ? (
+        <Text style={styles.handleText}>{username}</Text>
+      ) : null}
+
+      {/* Farcaster: FID — same size/style as the username line */}
+      {typeof fid === 'number' ? (
+        <Text style={styles.handleText}>FID: {fid}</Text>
+      ) : null}
     </View>
   );
 }
@@ -324,9 +342,16 @@ function createStyles(theme: AppTheme) {
     },
     bigCardContainer: {
       alignItems: 'center',
+      position: 'relative',
       paddingHorizontal: Skin.space(20),
       paddingTop: Skin.space(16),
       paddingBottom: Skin.space(16),
+      gap: Skin.space(6),
+    },
+    // Tappable address line (copy on press) with a trailing copy icon.
+    addressRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
       gap: Skin.space(6),
     },
   });

--- a/components/UnifiedProfileHeader.tsx
+++ b/components/UnifiedProfileHeader.tsx
@@ -51,7 +51,7 @@ export default function UnifiedProfileHeader({
   const hasFarcaster = Boolean(user.farcaster?.fid);
 
   if (!hasFarcaster) {
-    return <QuorumOnlyHeader user={user} onEdit={onEditQuorum} theme={theme} styles={styles} />;
+    return <QuorumOnlyHeader user={user} onEdit={onEditQuorum} onCopyAddress={onCopyAddress} theme={theme} styles={styles} />;
   }
 
   // Unmerged with both profiles: one big card + a [Quorum | Farcaster] switcher
@@ -106,7 +106,6 @@ export default function UnifiedProfileHeader({
     user.farcaster?.username ||
     'Unnamed';
   const avatarUri = user.profileImage || farcasterProfile?.pfp?.url || user.farcaster?.pfpUrl;
-  const bio = user.bio || farcasterProfile?.profile?.bio?.text;
 
   return (
     <View style={styles.mergedContainer}>
@@ -134,14 +133,17 @@ export default function UnifiedProfileHeader({
             {user.primaryUsername}.q
           </Text>
         )}
-        <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
       </View>
-
-      {bio ? (
-        <Text style={styles.bioText} numberOfLines={3}>
-          {bio}
-        </Text>
-      ) : null}
+      <TouchableOpacity
+        style={styles.addressRow}
+        onPress={onCopyAddress}
+        accessibilityRole="button"
+        accessibilityLabel="Copy address"
+      >
+        <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
+        <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
+      </TouchableOpacity>
+      {/* Bio intentionally omitted — shown only in the Profile section's Bio. */}
     </View>
   );
 }
@@ -231,11 +233,13 @@ function BigProfileCard({
 function QuorumOnlyHeader({
   user,
   onEdit,
+  onCopyAddress,
   theme,
   styles,
 }: {
   user: UserInfo;
   onEdit?: () => void;
+  onCopyAddress?: () => void;
   theme: AppTheme;
   styles: ReturnType<typeof createStyles>;
 }) {
@@ -255,19 +259,21 @@ function QuorumOnlyHeader({
       <Text style={styles.mergedDisplayName} numberOfLines={1}>
         {displayName}
       </Text>
-      <View style={styles.handlesRow}>
-        {user.primaryUsername && (
-          <Text style={[styles.handleText, { color: theme.colors.accent }]}>
-            {user.primaryUsername}.q
-          </Text>
-        )}
-        <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
-      </View>
-      {user.bio ? (
-        <Text style={styles.bioText} numberOfLines={3}>
-          {user.bio}
+      {user.primaryUsername ? (
+        <Text style={[styles.handleText, { color: theme.colors.accent }]}>
+          {user.primaryUsername}.q
         </Text>
       ) : null}
+      <TouchableOpacity
+        style={styles.addressRow}
+        onPress={onCopyAddress}
+        accessibilityRole="button"
+        accessibilityLabel="Copy address"
+      >
+        <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
+        <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
+      </TouchableOpacity>
+      {/* Bio intentionally omitted — shown only in the Profile section's Bio. */}
     </View>
   );
 }

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -165,7 +165,14 @@ export default function UnifiedProfileScreen({
         scrollable
         centerOnSelect
         style={styles.pillRow}
-        contentContainerStyle={styles.pillRowContent}
+        // Center the row only when there are few pills (merged/Quorum-only:
+        // Profile/Premium/Settings always fit). With the 5-pill split layout we
+        // keep left-aligned so the row can scroll without clipping on narrow
+        // screens. flexGrow makes the centered content fill the viewport.
+        contentContainerStyle={[
+          styles.pillRowContent,
+          pills.length <= 3 && styles.pillRowContentCentered,
+        ]}
       />
 
       <View style={styles.content}>
@@ -178,9 +185,12 @@ export default function UnifiedProfileScreen({
           hideTabBar={true}
           activeSection={activePill}
           onViewMyCasts={handleViewMyCasts}
-          // Offer "Merge profiles" only while unmerged (split mode). ProfileModal
-          // shows a confirmation before invoking this; here we just apply it.
+          // Merge when unmerged; unmerge when merged. ProfileModal confirms first;
+          // here we just flip the split-mode display flag (no data is altered).
           onMergeProfiles={splitMode ? () => setSplitMode(false) : undefined}
+          onUnmergeProfiles={!splitMode ? () => setSplitMode(true) : undefined}
+          // After connecting Farcaster, jump to the Farcaster pill.
+          onFarcasterConnected={() => setActivePill('farcaster')}
           farcasterIdentity={{
             // Only drive the Profile section to Farcaster when unmerged AND the
             // header switcher is on Farcaster.
@@ -337,6 +347,11 @@ function createStyles(theme: AppTheme) {
     },
     pillRowContent: {
       paddingHorizontal: Skin.space(16),
+    },
+    // Applied only with few pills: fill the viewport and center them.
+    pillRowContentCentered: {
+      flexGrow: 1,
+      justifyContent: 'center',
     },
     content: {
       flex: 1,

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -5,7 +5,7 @@ import BuyNameModal from '@/components/qns/BuyNameModal';
 import MarketplaceModal from '@/components/qns/MarketplaceModal';
 import OffersModal from '@/components/qns/OffersModal';
 import type { ResaleListing } from '@/services/api/qnsClient';
-import UnifiedProfileHeader from '@/components/UnifiedProfileHeader';
+import UnifiedProfileHeader, { type IdentityTab } from '@/components/UnifiedProfileHeader';
 import UnifiedProfileEditModal from '@/components/UnifiedProfileEditModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
@@ -37,7 +37,7 @@ export default function UnifiedProfileScreen({
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
-  const [splitMode] = useProfileSplitMode();
+  const [splitMode, setSplitMode] = useProfileSplitMode();
   const [decisionModalVisible, setDecisionModalVisible] = useState(false);
   const [editTarget, setEditTarget] = useState<EditTarget>(null);
   const [editPickerVisible, setEditPickerVisible] = useState(false);
@@ -82,6 +82,9 @@ export default function UnifiedProfileScreen({
   }, [hasFarcaster]);
 
   const [activePill, setActivePill] = useState<ProfileSection>('profile');
+
+  // Which identity the big profile card shows in the unmerged switcher layout.
+  const [identityTab, setIdentityTab] = useState<IdentityTab>('quorum');
 
   // If the active pill becomes unavailable (e.g. Farcaster disconnected while on
   // the Farcaster pill), fall back to Profile.
@@ -136,6 +139,8 @@ export default function UnifiedProfileScreen({
         user={user}
         farcasterProfile={farcasterAuthor}
         splitMode={splitMode}
+        identityTab={identityTab}
+        onIdentityTabChange={setIdentityTab}
         onEditQuorum={() => setEditTarget('quorum')}
         onEditFarcaster={() => setEditTarget('farcaster')}
         onEditUnified={handleEditRequest}
@@ -162,6 +167,18 @@ export default function UnifiedProfileScreen({
           hideTabBar={true}
           activeSection={activePill}
           onViewMyCasts={handleViewMyCasts}
+          // Offer "Merge profiles" only while unmerged (split mode). ProfileModal
+          // shows a confirmation before invoking this; here we just apply it.
+          onMergeProfiles={splitMode ? () => setSplitMode(false) : undefined}
+          farcasterIdentity={{
+            // Only drive the Profile section to Farcaster when unmerged AND the
+            // header switcher is on Farcaster.
+            active: splitMode && hasFarcaster && identityTab === 'farcaster',
+            displayName: farcasterAuthor?.displayName || user.farcaster?.username,
+            bio: farcasterAuthor?.profile?.bio?.text,
+            username: user.farcaster?.username,
+            fid: user.farcaster?.fid,
+          }}
           onOpenMarketplace={() => setMarketplaceModalVisible(true)}
           onOpenAuctions={() => setAuctionsModalVisible(true)}
           onOpenOffers={() => setOffersModalVisible(true)}

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -299,6 +299,16 @@ export default function UnifiedProfileScreen({
       <ProfileSplitModeModal
         visible={decisionModalVisible}
         onClose={() => setDecisionModalVisible(false)}
+        onDecision={(split) => {
+          // The modal already flipped the splitMode flag. If the user chose to
+          // MERGE (split === false), run the same field reconcile + sync as the
+          // in-app "Merge profiles" row so the onboarding path isn't a flag-only
+          // flip that bypasses the sync logic.
+          if (!split) {
+            showToast({ type: 'info', title: 'Merging…' });
+            void reconcileMergedProfiles();
+          }
+        }}
       />
 
       {/* Edit target picker (split mode) */}

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -12,6 +12,9 @@ import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/Segmente
 import { useAuth } from '@/context/AuthContext';
 import { useToast } from '@/context/ToastContext';
 import { useFarcasterProfile } from '@/hooks/useFarcasterProfile';
+import { updateFarcasterProfile } from '@/services/farcaster/updateProfile';
+import { compressAvatarImage } from '@/services/media/imageAttachment';
+import { capDisplayName, capBio } from '@/hooks/validation/errorTranslator';
 import {
   hasDecidedSplitMode,
   useProfileSplitMode,
@@ -35,7 +38,7 @@ export default function UnifiedProfileScreen({
   onOpenWarpcastImport,
 }: UnifiedProfileScreenProps) {
   const { theme } = useTheme();
-  const { user, farcasterAuthToken } = useAuth();
+  const { user, farcasterAuthToken, updateProfile } = useAuth();
   const { showToast } = useToast();
   const insets = useSafeAreaInsets();
   const router = useRouter();
@@ -129,6 +132,66 @@ export default function UnifiedProfileScreen({
     showToast({ type: 'success', title: 'Address copied' });
   }, [user?.address, showToast]);
 
+  // Merge: reconcile name/bio/pfp across both identities, then enter merged mode.
+  // Per-field rule: whichever side has content wins; Quorum wins ties; if Quorum
+  // is empty for a field, pull Farcaster's value into it. After this both systems
+  // hold the same value per field, so the merged (Quorum-preferred) display is
+  // accurate on both sides. ProfileModal confirms before calling this.
+  const handleMergeProfiles = useCallback(async () => {
+    const fcName = farcasterAuthor?.displayName?.trim() || '';
+    const fcBio = farcasterAuthor?.profile?.bio?.text?.trim() || '';
+    const fcPfp = farcasterAuthor?.pfp?.url || '';
+    const qName = user?.displayName?.trim() || '';
+    const qBio = user?.bio?.trim() || '';
+    const qPfp = user?.profileImage || '';
+
+    // --- Pull Farcaster -> Quorum for any field Quorum is missing ---
+    const quorumUpdates: { displayName?: string; bio?: string; profileImage?: string } = {};
+    if (!qName && fcName) quorumUpdates.displayName = fcName;
+    if (!qBio && fcBio) quorumUpdates.bio = fcBio;
+    if (!qPfp && fcPfp) {
+      // Convert the remote FC pfp to a data URI (like the picker) so it displays
+      // AND broadcasts to peers, not just a bare stored URL.
+      try {
+        const compressed = await compressAvatarImage(fcPfp, 512, 512);
+        if (compressed?.dataUri) quorumUpdates.profileImage = compressed.dataUri;
+      } catch {
+        // If the image can't be fetched/compressed, skip the pfp pull; the rest
+        // of the merge still proceeds.
+      }
+    }
+    if (Object.keys(quorumUpdates).length > 0) {
+      updateProfile(quorumUpdates);
+    }
+
+    // --- Push Quorum -> Farcaster for fields Quorum has (Quorum wins) ---
+    if (farcasterAuthToken) {
+      const fcFields: { displayName?: string; bio?: string; pfp?: string } = {};
+      // Only push a field to Farcaster when it would actually change it (Quorum
+      // had content that differs), capped to Farcaster's byte limits.
+      if (qName && capDisplayName(qName) !== fcName) fcFields.displayName = capDisplayName(qName);
+      if (qBio && capBio(qBio) !== fcBio) fcFields.bio = capBio(qBio);
+      // Push the Quorum pfp (data URI) to Farcaster only when Quorum had its own.
+      if (qPfp) fcFields.pfp = qPfp;
+
+      if (Object.keys(fcFields).length > 0) {
+        try {
+          const res = await updateFarcasterProfile(farcasterAuthToken, fcFields);
+          if (!res.ok) {
+            showToast({ type: 'error', title: 'Farcaster not fully updated', message: res.error });
+          }
+        } catch {
+          showToast({ type: 'error', title: "Couldn't update Farcaster", message: 'Your Quorum profile was merged; Farcaster will sync on your next edit.' });
+        }
+      }
+    } else if (qName || qBio || qPfp) {
+      // No Farcaster token — can't push. Merge the display anyway; warn.
+      showToast({ type: 'info', title: 'Reconnect Farcaster to sync', message: 'Merged your profile view; Farcaster will update when you reconnect.' });
+    }
+
+    setSplitMode(false);
+  }, [farcasterAuthor, user?.displayName, user?.bio, user?.profileImage, farcasterAuthToken, updateProfile, showToast, setSplitMode]);
+
   const handleEditRequest = () => {
     if (!hasFarcaster) {
       setEditTarget('quorum');
@@ -193,7 +256,7 @@ export default function UnifiedProfileScreen({
           onViewMyCasts={handleViewMyCasts}
           // Merge when unmerged; unmerge when merged. ProfileModal confirms first;
           // here we just flip the split-mode display flag (no data is altered).
-          onMergeProfiles={splitMode ? () => setSplitMode(false) : undefined}
+          onMergeProfiles={splitMode ? () => { void handleMergeProfiles(); } : undefined}
           onUnmergeProfiles={!splitMode ? () => setSplitMode(true) : undefined}
           // After connecting Farcaster, jump to the Farcaster pill.
           onFarcasterConnected={() => setActivePill('farcaster')}

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -10,6 +10,7 @@ import UnifiedProfileEditModal from '@/components/UnifiedProfileEditModal';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useAuth } from '@/context/AuthContext';
+import { useToast } from '@/context/ToastContext';
 import { useFarcasterProfile } from '@/hooks/useFarcasterProfile';
 import {
   hasDecidedSplitMode,
@@ -17,6 +18,7 @@ import {
 } from '@/services/profile/profilePrefs';
 import { useTheme, type AppTheme } from '@/theme';
 import { useRouter } from 'expo-router';
+import * as Clipboard from 'expo-clipboard';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
@@ -34,6 +36,7 @@ export default function UnifiedProfileScreen({
 }: UnifiedProfileScreenProps) {
   const { theme } = useTheme();
   const { user, farcasterAuthToken } = useAuth();
+  const { showToast } = useToast();
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
@@ -113,6 +116,13 @@ export default function UnifiedProfileScreen({
     });
   }, [router, user?.farcaster?.fid, user?.farcaster?.username]);
 
+  // Copy the Quorum address (tappable address line on the Quorum big card).
+  const handleCopyAddress = useCallback(() => {
+    if (!user?.address) return;
+    void Clipboard.setStringAsync(user.address);
+    showToast({ type: 'success', title: 'Address copied' });
+  }, [user?.address, showToast]);
+
   const handleEditRequest = () => {
     if (!hasFarcaster) {
       setEditTarget('quorum');
@@ -144,6 +154,7 @@ export default function UnifiedProfileScreen({
         onEditQuorum={() => setEditTarget('quorum')}
         onEditFarcaster={() => setEditTarget('farcaster')}
         onEditUnified={handleEditRequest}
+        onCopyAddress={handleCopyAddress}
       />
 
       <SegmentedPills
@@ -179,6 +190,9 @@ export default function UnifiedProfileScreen({
             username: user.farcaster?.username,
             fid: user.farcaster?.fid,
           }}
+          // The header shows the identity switcher only when unmerged with both
+          // profiles — that's when Bio carries a brand icon.
+          dualIdentity={splitMode && hasFarcaster}
           onOpenMarketplace={() => setMarketplaceModalVisible(true)}
           onOpenAuctions={() => setAuctionsModalVisible(true)}
           onOpenOffers={() => setOffersModalVisible(true)}

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -89,13 +89,19 @@ export default function UnifiedProfileScreen({
   // Which identity the big profile card shows in the unmerged switcher layout.
   const [identityTab, setIdentityTab] = useState<IdentityTab>('quorum');
 
-  // If the active pill becomes unavailable (e.g. Farcaster disconnected while on
-  // the Farcaster pill), fall back to Profile.
+  // Disconnecting Farcaster removes the Farcaster pill + switcher. Derive safe
+  // values for THIS render so there's no one-frame window where the Farcaster
+  // section/identity renders without a Farcaster account (avoids a blank flash).
+  const effectiveActivePill: ProfileSection =
+    !hasFarcaster && activePill === 'farcaster' ? 'profile' : activePill;
+  const effectiveIdentityTab: IdentityTab = !hasFarcaster ? 'quorum' : identityTab;
+
+  // Persist the fallback so the state matches what we render (also resets the
+  // identity tab so reconnecting doesn't silently land on the Farcaster card).
   useEffect(() => {
-    if (!hasFarcaster && activePill === 'farcaster') {
-      setActivePill('profile');
-    }
-  }, [hasFarcaster, activePill]);
+    if (!hasFarcaster && activePill === 'farcaster') setActivePill('profile');
+    if (!hasFarcaster && identityTab === 'farcaster') setIdentityTab('quorum');
+  }, [hasFarcaster, activePill, identityTab]);
 
   // Open the current user's own cast feed (their ProfileView) via the feed tab's
   // existing profileFid deep-link. Surfaced from the Farcaster section's
@@ -149,7 +155,7 @@ export default function UnifiedProfileScreen({
         user={user}
         farcasterProfile={farcasterAuthor}
         splitMode={splitMode}
-        identityTab={identityTab}
+        identityTab={effectiveIdentityTab}
         onIdentityTabChange={setIdentityTab}
         onEditQuorum={() => setEditTarget('quorum')}
         onEditFarcaster={() => setEditTarget('farcaster')}
@@ -159,7 +165,7 @@ export default function UnifiedProfileScreen({
 
       <SegmentedPills
         items={pills}
-        activeKey={activePill}
+        activeKey={effectiveActivePill}
         onChange={(key) => setActivePill(key as ProfileSection)}
         variant="solid"
         scrollable
@@ -183,7 +189,7 @@ export default function UnifiedProfileScreen({
           isRouteMode={true}
           hideHeader={true}
           hideTabBar={true}
-          activeSection={activePill}
+          activeSection={effectiveActivePill}
           onViewMyCasts={handleViewMyCasts}
           // Merge when unmerged; unmerge when merged. ProfileModal confirms first;
           // here we just flip the split-mode display flag (no data is altered).
@@ -194,7 +200,7 @@ export default function UnifiedProfileScreen({
           farcasterIdentity={{
             // Only drive the Profile section to Farcaster when unmerged AND the
             // header switcher is on Farcaster.
-            active: splitMode && hasFarcaster && identityTab === 'farcaster',
+            active: splitMode && hasFarcaster && effectiveIdentityTab === 'farcaster',
             displayName: farcasterAuthor?.displayName || user.farcaster?.username,
             bio: farcasterAuthor?.profile?.bio?.text,
             username: user.farcaster?.username,

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -300,10 +300,14 @@ export default function UnifiedProfileScreen({
         visible={decisionModalVisible}
         onClose={() => setDecisionModalVisible(false)}
         onDecision={(split) => {
-          // The modal already flipped the splitMode flag. If the user chose to
-          // MERGE (split === false), run the same field reconcile + sync as the
-          // in-app "Merge profiles" row so the onboarding path isn't a flag-only
-          // flip that bypasses the sync logic.
+          // The modal writes MMKV directly via setProfileSplitMode, which the
+          // parent's useProfileSplitMode only picks up on its next poll (~2s).
+          // Mirror it through the React-state setter so the header/pills update
+          // immediately (idempotent with the modal's write).
+          setSplitMode(split);
+          // If the user chose to MERGE (split === false), run the same field
+          // reconcile + sync as the in-app "Merge profiles" row so the onboarding
+          // path isn't a flag-only flip that bypasses the sync logic.
           if (!split) {
             showToast({ type: 'info', title: 'Merging…' });
             void reconcileMergedProfiles();

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -132,12 +132,11 @@ export default function UnifiedProfileScreen({
     showToast({ type: 'success', title: 'Address copied' });
   }, [user?.address, showToast]);
 
-  // Merge: reconcile name/bio/pfp across both identities, then enter merged mode.
-  // Per-field rule: whichever side has content wins; Quorum wins ties; if Quorum
-  // is empty for a field, pull Farcaster's value into it. After this both systems
-  // hold the same value per field, so the merged (Quorum-preferred) display is
-  // accurate on both sides. ProfileModal confirms before calling this.
-  const handleMergeProfiles = useCallback(async () => {
+  // Background reconcile of name/bio/pfp across both identities. Per-field rule:
+  // whichever side has content wins; Quorum wins ties; if Quorum is empty, pull
+  // Farcaster's value in. Runs AFTER the display has already merged (optimistic),
+  // so the user never waits on the Farcaster API / image work.
+  const reconcileMergedProfiles = useCallback(async () => {
     const fcName = farcasterAuthor?.displayName?.trim() || '';
     const fcBio = farcasterAuthor?.profile?.bio?.text?.trim() || '';
     const fcPfp = farcasterAuthor?.pfp?.url || '';
@@ -179,18 +178,29 @@ export default function UnifiedProfileScreen({
           const res = await updateFarcasterProfile(farcasterAuthToken, fcFields);
           if (!res.ok) {
             showToast({ type: 'error', title: 'Farcaster not fully updated', message: res.error });
+            return;
           }
         } catch {
-          showToast({ type: 'error', title: "Couldn't update Farcaster", message: 'Your Quorum profile was merged; Farcaster will sync on your next edit.' });
+          showToast({ type: 'error', title: "Couldn't update Farcaster", message: 'Your profiles are merged; Farcaster will sync on your next edit.' });
+          return;
         }
       }
     } else if (qName || qBio || qPfp) {
-      // No Farcaster token — can't push. Merge the display anyway; warn.
-      showToast({ type: 'info', title: 'Reconnect Farcaster to sync', message: 'Merged your profile view; Farcaster will update when you reconnect.' });
+      // No Farcaster token — can't push. Display already merged; warn.
+      showToast({ type: 'info', title: 'Reconnect Farcaster to sync', message: 'Your profiles are merged; Farcaster will update when you reconnect.' });
+      return;
     }
 
+    showToast({ type: 'success', title: 'Profiles merged' });
+  }, [farcasterAuthor, user?.displayName, user?.bio, user?.profileImage, farcasterAuthToken, updateProfile, showToast]);
+
+  // Merge entry (called after ProfileModal's confirm). Optimistic: merge the
+  // display immediately so it feels instant, then reconcile in the background.
+  const handleMergeProfiles = useCallback(() => {
     setSplitMode(false);
-  }, [farcasterAuthor, user?.displayName, user?.bio, user?.profileImage, farcasterAuthToken, updateProfile, showToast, setSplitMode]);
+    showToast({ type: 'info', title: 'Merging…' });
+    void reconcileMergedProfiles();
+  }, [setSplitMode, showToast, reconcileMergedProfiles]);
 
   const handleEditRequest = () => {
     if (!hasFarcaster) {

--- a/components/UnifiedProfileScreen.tsx
+++ b/components/UnifiedProfileScreen.tsx
@@ -11,6 +11,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
 import { useAuth } from '@/context/AuthContext';
 import { useToast } from '@/context/ToastContext';
+import { useQueryClient } from '@tanstack/react-query';
 import { useFarcasterProfile } from '@/hooks/useFarcasterProfile';
 import { updateFarcasterProfile } from '@/services/farcaster/updateProfile';
 import { compressAvatarImage } from '@/services/media/imageAttachment';
@@ -40,6 +41,7 @@ export default function UnifiedProfileScreen({
   const { theme } = useTheme();
   const { user, farcasterAuthToken, updateProfile } = useAuth();
   const { showToast } = useToast();
+  const queryClient = useQueryClient();
   const insets = useSafeAreaInsets();
   const router = useRouter();
 
@@ -191,8 +193,13 @@ export default function UnifiedProfileScreen({
       return;
     }
 
+    // Refresh the Farcaster profile query so My Casts (header + cast rows) picks
+    // up the new name/pfp instead of serving the stale cache until staleTime.
+    const fid = user?.farcaster?.fid;
+    if (fid) void queryClient.invalidateQueries({ queryKey: ['farcaster-profile', fid] });
+
     showToast({ type: 'success', title: 'Profiles merged' });
-  }, [farcasterAuthor, user?.displayName, user?.bio, user?.profileImage, farcasterAuthToken, updateProfile, showToast]);
+  }, [farcasterAuthor, user?.displayName, user?.bio, user?.profileImage, user?.farcaster?.fid, farcasterAuthToken, updateProfile, showToast, queryClient]);
 
   // Merge entry (called after ProfileModal's confirm). Optimistic: merge the
   // display immediately so it feels instant, then reconcile in the background.

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -255,6 +255,7 @@ const SF_TO_TABLER = {
   'square.and.pencil': tabler('IconEdit'),
   'pencil': tabler('IconPencil'),
   'feather': tabler('IconFeather'),
+  'merge': tabler('IconArrowMerge'),
   'hammer': tabler('IconHammer'),
   'hammer.fill': tabler('IconHammer'),
 

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -256,6 +256,7 @@ const SF_TO_TABLER = {
   'pencil': tabler('IconPencil'),
   'feather': tabler('IconFeather'),
   'merge': tabler('IconArrowMerge'),
+  'split': tabler('IconArrowsSplit2'),
   'hammer': tabler('IconHammer'),
   'hammer.fill': tabler('IconHammer'),
 

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -29,6 +29,7 @@ import IconArrowDownLeft from '@tabler/icons-react-native/IconArrowDownLeft';
 import IconArrowDownRight from '@tabler/icons-react-native/IconArrowDownRight';
 import IconArrowForwardUp from '@tabler/icons-react-native/IconArrowForwardUp';
 import IconArrowLeft from '@tabler/icons-react-native/IconArrowLeft';
+import IconArrowMerge from '@tabler/icons-react-native/IconArrowMerge';
 import IconArrowUp from '@tabler/icons-react-native/IconArrowUp';
 import IconArrowUpRight from '@tabler/icons-react-native/IconArrowUpRight';
 import IconArrowsExchange from '@tabler/icons-react-native/IconArrowsExchange';
@@ -285,6 +286,7 @@ export const TablerIcons = {
   IconArrowDownRight,
   IconArrowForwardUp,
   IconArrowLeft,
+  IconArrowMerge,
   IconArrowUp,
   IconArrowUpRight,
   IconArrowsExchange,

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -33,6 +33,7 @@ import IconArrowMerge from '@tabler/icons-react-native/IconArrowMerge';
 import IconArrowUp from '@tabler/icons-react-native/IconArrowUp';
 import IconArrowUpRight from '@tabler/icons-react-native/IconArrowUpRight';
 import IconArrowsExchange from '@tabler/icons-react-native/IconArrowsExchange';
+import IconArrowsSplit2 from '@tabler/icons-react-native/IconArrowsSplit2';
 import IconArrowsUpDown from '@tabler/icons-react-native/IconArrowsUpDown';
 import IconAt from '@tabler/icons-react-native/IconAt';
 import IconBadge from '@tabler/icons-react-native/IconBadge';
@@ -290,6 +291,7 @@ export const TablerIcons = {
   IconArrowUp,
   IconArrowUpRight,
   IconArrowsExchange,
+  IconArrowsSplit2,
   IconArrowsUpDown,
   IconAt,
   IconBadge,


### PR DESCRIPTION
Reworks the profile screen and polishes Farcaster-related surfaces.

Profile screen
- Identity switcher for unmerged Quorum + Farcaster profiles (segmented track + one big card), with brand icons
- Per-identity big card: Quorum shows .q name + tappable/copyable address; Farcaster shows @username + FID
- Lean Profile section (Account Info removed; identity-aware bio with brand-icon headings); Privacy Level moved to Settings
- Merge: reconciles name/bio/picture across both systems (non-empty wins, Quorum wins ties, pull Farcaster when empty; pfp fetched+compressed); optimistic display + toast feedback
- Unmerge ('Separate profiles') row; both merge and unmerge reachable in-app and from the onboarding chooser, running the same reconcile
- Farcaster edits reflect immediately (optimistic cache patch of header + cast rows, then invalidate); 'My Casts' entry; reliable re-open routing
- Disconnect edge cases cleaned up (no blank flash, identity-tab reset, import-form collapse); DM profile broadcast from the edit modal

Farcaster surfaces
- Replace the raster farcaster.png with the FarcasterLogoIcon SVG across DM list, DM message view, mini-app cards, and share-to-chat
- DM avatar badge: brand-purple circle + white icon; mini-app list cards: bare theme-muted glyph; featured/auth badge over the banner keeps the circle
- Slightly larger mini-app grid icons
- Enrich Saved/Recent mini-app cards (name, icon, Farcaster badge) from discovery metadata

Companion: merge/split/feather icons added to quorum-shared.