### PR TITLE
feat: DM mute that syncs across devices

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -7,6 +7,7 @@ import { FarcasterDirectMessageView } from '@/components/Chat/FarcasterDirectMes
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useConversation } from '@/hooks/chat/useConversations';
+import { useDMMute } from '@/hooks/chat/useDMMute';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
 import { useStorageAdapter } from '@/context/StorageContext';
 import { useQueryClient } from '@tanstack/react-query';
@@ -204,6 +205,16 @@ export default function DMChatScreen() {
   const handleOpenDmSettings = useCallback(() => {
     setSettingsVisible(true);
   }, []);
+
+  // DM mute is config-backed (syncs across devices). `isMuted`/`toggleMute`
+  // read straight from the local config (bookmark pattern), so no per-device
+  // divergence.
+  const { isMuted, toggleMute } = useDMMute();
+  const conversationMuted = conversationId ? isMuted(conversationId) : false;
+  const handleToggleMute = useCallback(() => {
+    if (!conversationId) return;
+    toggleMute(conversationId);
+  }, [conversationId, toggleMute]);
 
   // Delete this conversation locally (DMs are E2E-encrypted, so this only
   // removes it from this device). The confirm lives in DMSettingsSheet; this
@@ -405,6 +416,8 @@ export default function DMChatScreen() {
             onDeleteConversation={handleDeleteConversation}
             isRepudiable={conversation.isRepudiable}
             saveEditHistory={conversation.saveEditHistory}
+            isMuted={conversationMuted}
+            onToggleMute={handleToggleMute}
           />
         </Suspense>
       )}

--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -12,6 +12,7 @@ import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useAuth } from '@/context/AuthContext';
 import type { Conversation } from '@/hooks/chat';
+import { useDMMute } from '@/hooks/chat/useDMMute';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
 import { textStyles, useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
@@ -39,6 +40,7 @@ interface InboxItem {
   unreadCount: number;
   isRepudiable?: boolean;
   isFarcaster?: boolean;
+  isMuted?: boolean;
   subtitle?: string;
   subtitlePrefix?: string;
   placeholder?: boolean;
@@ -78,6 +80,11 @@ const InboxRow = React.memo(function InboxRow({ item, styles, theme, onPress }: 
         {item.isFarcaster && (
           <View style={styles.farcasterBadge}>
             <FarcasterLogoIcon size={8} color="#fff" />
+          </View>
+        )}
+        {item.isMuted && (
+          <View style={styles.mutedBadge}>
+            <IconSymbol name="bell.slash" size={11} color={theme.colors.textSubtle} />
           </View>
         )}
       </View>
@@ -139,6 +146,10 @@ export default function MessagesInbox() {
   const listPadding = useFloatingTabBarPadding();
   const styles = useMemo(() => createStyles(theme, isDark, listPadding), [theme, isDark, listPadding]);
 
+  // Muted DMs (config-backed, syncs across devices). `mutedConversations` is a
+  // Set; depending on it keeps the list memo in sync when a mute toggles.
+  const { isMuted, mutedConversations } = useDMMute();
+
   // DMs list
   const items = useMemo<InboxItem[]>(() => {
     const rows: InboxItem[] = [];
@@ -157,6 +168,7 @@ export default function MessagesInbox() {
         unreadCount: hasUnread ? 1 : 0,
         isRepudiable: conv.isRepudiable,
         isFarcaster: conv.source === 'farcaster',
+        isMuted: isMuted(conv.conversationId),
         subtitle: preview || undefined,
         subtitlePrefix: preview && senderName ? senderName : undefined,
         placeholder: !preview,
@@ -172,7 +184,7 @@ export default function MessagesInbox() {
     // Sort by timestamp desc
     filtered.sort((a, b) => b.timestamp - a.timestamp);
     return filtered;
-  }, [conversations, search]);
+  }, [conversations, search, isMuted, mutedConversations]);
 
   const handlePressItem = useCallback((item: InboxItem) => {
     haptics.light();
@@ -390,6 +402,22 @@ const createStyles = (theme: AppTheme, isDark: boolean, listPadding: number) =>
       height: 18,
       borderRadius: Skin.radius(9),
       backgroundColor: '#855DCD', // Farcaster brand purple
+      borderWidth: Skin.border(2),
+      borderColor: theme.colors.surface1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
+    // Muted indicator: bell-off badge at the top-left of the pfp (mirrors
+    // desktop's dm-muted-badge). Neutral surface chip so it reads as a status,
+    // not an action.
+    mutedBadge: {
+      position: 'absolute',
+      top: -2,
+      left: -2,
+      width: 18,
+      height: 18,
+      borderRadius: Skin.radius(9),
+      backgroundColor: theme.colors.surface3,
       borderWidth: Skin.border(2),
       borderColor: theme.colors.surface1,
       alignItems: 'center',

--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -14,6 +14,9 @@ import { useAuth } from '@/context/AuthContext';
 import type { Conversation } from '@/hooks/chat';
 import { useDMMute } from '@/hooks/chat/useDMMute';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
+import { useStorageAdapter } from '@/context/StorageContext';
+import { useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@quilibrium/quorum-shared';
 import { textStyles, useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
 import { truncateAddress } from '@/utils/formatAddress';
@@ -31,11 +34,18 @@ import * as Skin from '@/theme/skins/geometry';
 const importNewConversationModal = () => import('@/components/NewConversationModal');
 const NewConversationModal = React.lazy(importNewConversationModal);
 
+// Long-pressing a conversation row opens the same settings sheet as the DM
+// header gear. Lazy so the chunk only loads on first long-press.
+const DMSettingsSheet = React.lazy(() =>
+  import('@/components/Chat/DMSettingsSheet').then((m) => ({ default: m.DMSettingsSheet }))
+);
+
 // Row for the DMs list
 interface InboxItem {
   id: string;
   title: string;
   icon?: string;
+  address?: string;
   timestamp: number;
   unreadCount: number;
   isRepudiable?: boolean;
@@ -64,13 +74,21 @@ interface InboxRowProps {
   styles: ReturnType<typeof createStyles>;
   theme: AppTheme;
   onPress: (item: InboxItem) => void;
+  onLongPress: (item: InboxItem) => void;
 }
 
-const InboxRow = React.memo(function InboxRow({ item, styles, theme, onPress }: InboxRowProps) {
+const InboxRow = React.memo(function InboxRow({ item, styles, theme, onPress, onLongPress }: InboxRowProps) {
   const handlePress = useCallback(() => onPress(item), [item, onPress]);
+  const handleLongPress = useCallback(() => onLongPress(item), [item, onLongPress]);
 
   return (
-    <TouchableOpacity style={styles.row} onPress={handlePress} activeOpacity={0.6}>
+    <TouchableOpacity
+      style={styles.row}
+      onPress={handlePress}
+      onLongPress={handleLongPress}
+      delayLongPress={350}
+      activeOpacity={0.6}
+    >
       <View style={styles.avatarContainer}>
         {isValidAvatarUri(item.icon) ? (
           <Image source={{ uri: item.icon }} style={styles.dmAvatar} />
@@ -146,9 +164,33 @@ export default function MessagesInbox() {
   const listPadding = useFloatingTabBarPadding();
   const styles = useMemo(() => createStyles(theme, isDark, listPadding), [theme, isDark, listPadding]);
 
-  // Muted DMs (config-backed, syncs across devices). `mutedConversations` is a
-  // Set; depending on it keeps the list memo in sync when a mute toggles.
-  const { isMuted, mutedConversations } = useDMMute();
+  // Muted DMs (config-backed, syncs across devices). `isMuted` is keyed on the
+  // muted set, so the list memo re-runs on toggle via its dep on `isMuted`.
+  const { isMuted, toggleMute } = useDMMute();
+
+  const storage = useStorageAdapter();
+  const queryClient = useQueryClient();
+
+  // Long-press → conversation settings sheet for that row.
+  const [settingsItem, setSettingsItem] = useState<InboxItem | null>(null);
+  const handleLongPressItem = useCallback((item: InboxItem) => {
+    // Farcaster DMs don't have the Quorum conversation-settings surface.
+    if (item.isFarcaster) return;
+    haptics.medium();
+    setSettingsItem(item);
+  }, []);
+
+  const handleToggleMuteFromSheet = useCallback(() => {
+    if (settingsItem) toggleMute(settingsItem.id);
+  }, [settingsItem, toggleMute]);
+
+  // Delete the conversation locally (same as the DM-screen sheet does).
+  const handleDeleteFromSheet = useCallback(async () => {
+    if (!settingsItem) return;
+    await storage.deleteConversation(settingsItem.id);
+    queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
+    setSettingsItem(null);
+  }, [settingsItem, storage, queryClient]);
 
   // DMs list
   const items = useMemo<InboxItem[]>(() => {
@@ -164,6 +206,7 @@ export default function MessagesInbox() {
           conv.displayName ||
           (conv.address ? truncateAddress(conv.address, 'long') : 'Conversation'),
         icon: conv.icon,
+        address: conv.address,
         timestamp: conv.timestamp,
         unreadCount: hasUnread ? 1 : 0,
         isRepudiable: conv.isRepudiable,
@@ -184,7 +227,10 @@ export default function MessagesInbox() {
     // Sort by timestamp desc
     filtered.sort((a, b) => b.timestamp - a.timestamp);
     return filtered;
-  }, [conversations, search, isMuted, mutedConversations]);
+    // `isMuted` is a useCallback keyed on the muted set, so its identity changes
+    // on every toggle — that alone re-runs this memo. No separate
+    // `mutedConversations` dep needed.
+  }, [conversations, search, isMuted]);
 
   const handlePressItem = useCallback((item: InboxItem) => {
     haptics.light();
@@ -221,9 +267,15 @@ export default function MessagesInbox() {
 
   const renderItem = useCallback(
     ({ item }: { item: InboxItem }) => (
-      <InboxRow item={item} styles={styles} theme={theme} onPress={handlePressItem} />
+      <InboxRow
+        item={item}
+        styles={styles}
+        theme={theme}
+        onPress={handlePressItem}
+        onLongPress={handleLongPressItem}
+      />
     ),
-    [styles, theme, handlePressItem]
+    [styles, theme, handlePressItem, handleLongPressItem]
   );
 
   const loading = dmsLoading;
@@ -316,6 +368,26 @@ export default function MessagesInbox() {
             visible
             onClose={handleCloseNewConversation}
             onConversationCreated={handleConversationCreated}
+          />
+        </Suspense>
+      )}
+
+      {/* Conversation settings — opened by long-pressing a row. Shows the
+          recipient's pfp + name above the title since there's no other
+          on-screen context for which conversation was hit. */}
+      {settingsItem && (
+        <Suspense fallback={null}>
+          <DMSettingsSheet
+            visible
+            onClose={() => setSettingsItem(null)}
+            conversationId={settingsItem.id}
+            displayName={settingsItem.title}
+            theme={theme}
+            avatarUri={settingsItem.icon}
+            address={settingsItem.address ?? settingsItem.id.split('/')[0]}
+            isMuted={isMuted(settingsItem.id)}
+            onToggleMute={handleToggleMuteFromSheet}
+            onDeleteConversation={handleDeleteFromSheet}
           />
         </Suspense>
       )}

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -21,6 +21,8 @@ interface DMSettingsSheetProps {
   onToggleRepudiable?: (value: boolean) => void;
   saveEditHistory?: boolean;
   onToggleEditHistory?: (value: boolean) => void;
+  isMuted?: boolean;
+  onToggleMute?: (value: boolean) => void;
 }
 
 export function DMSettingsSheet({
@@ -34,6 +36,8 @@ export function DMSettingsSheet({
   onToggleRepudiable,
   saveEditHistory,
   onToggleEditHistory,
+  isMuted,
+  onToggleMute,
 }: DMSettingsSheetProps) {
   const styles = createStyles(theme);
   const { confirm, confirmDialog } = useConfirmDialog();
@@ -85,6 +89,22 @@ export function DMSettingsSheet({
         <View style={styles.header}>
           <Text style={styles.headerText}>Conversation Settings</Text>
         </View>
+
+        {onToggleMute && (
+          <ActionRowGroup style={styles.group}>
+            <ActionRow
+              label="Mute Conversation"
+              sublabel="No notifications or unread badges"
+              trailing={
+                <Switch
+                  value={isMuted ?? false}
+                  onValueChange={onToggleMute}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                />
+              }
+            />
+          </ActionRowGroup>
+        )}
 
         {(onToggleRepudiable || onToggleEditHistory) && (
           <ActionRowGroup style={styles.group}>

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -4,10 +4,13 @@
 
 import type { AppTheme } from '@/theme';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, Switch } from 'react-native';
+import { View, Text, StyleSheet, Alert, Switch, Image } from 'react-native';
 import { BaseModal, ActionRow, ActionRowGroup } from '@/components/shared';
+import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { resetDMSession } from '@/hooks/chat/useSendDirectMessage';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
+import { isValidAvatarUri } from '@/utils/validation';
+import { truncateAddress } from '@/utils/formatAddress';
 import * as Skin from '@/theme/skins/geometry';
 
 interface DMSettingsSheetProps {
@@ -16,6 +19,11 @@ interface DMSettingsSheetProps {
   conversationId: string;
   displayName: string;
   theme: AppTheme;
+  /** When provided, the sheet shows the recipient's pfp + name above the title.
+   *  Used when opening the sheet from the messages list (long-press), where the
+   *  user has no other on-screen confirmation of which conversation they hit. */
+  avatarUri?: string;
+  address?: string;
   onDeleteConversation?: () => void;
   isRepudiable?: boolean;
   onToggleRepudiable?: (value: boolean) => void;
@@ -31,6 +39,8 @@ export function DMSettingsSheet({
   conversationId,
   displayName,
   theme,
+  avatarUri,
+  address,
   onDeleteConversation,
   isRepudiable,
   onToggleRepudiable,
@@ -87,14 +97,31 @@ export function DMSettingsSheet({
     <BaseModal visible={visible} onClose={guardedClose} showHandle>
       <View style={styles.container}>
         <View style={styles.header}>
-          <Text style={styles.headerText}>Conversation Settings</Text>
+          {address != null && (
+            isValidAvatarUri(avatarUri) ? (
+              <Image source={{ uri: avatarUri }} style={styles.headerAvatar} />
+            ) : (
+              <DefaultAvatar displayName={displayName} address={address} size={56} style={styles.headerAvatar} />
+            )
+          )}
+          {address != null && (
+            <Text style={styles.headerName} numberOfLines={1}>{displayName}</Text>
+          )}
+          {address != null && (
+            <Text style={styles.headerAddress} numberOfLines={1}>
+              {truncateAddress(address, 'long')}
+            </Text>
+          )}
+          <Text style={address != null ? styles.headerSubtitle : styles.headerText}>
+            Conversation Settings
+          </Text>
         </View>
 
         {onToggleMute && (
           <ActionRowGroup style={styles.group}>
             <ActionRow
+              icon="bell.slash"
               label="Mute Conversation"
-              sublabel="No notifications or unread badges"
               trailing={
                 <Switch
                   value={isMuted ?? false}
@@ -167,13 +194,36 @@ const createStyles = (theme: AppTheme) =>
     },
     header: {
       alignItems: 'center',
-      paddingTop: Skin.space(4),
+      paddingTop: Skin.space(16),
       paddingBottom: Skin.space(14),
     },
     headerText: {
       ...theme.textStyles.headline,
       color: theme.colors.textStrong,
       textAlign: 'center',
+    },
+    headerAvatar: {
+      width: 56,
+      height: 56,
+      borderRadius: Skin.radius(28),
+      marginBottom: Skin.space(8),
+    },
+    headerName: {
+      ...theme.textStyles.headline,
+      color: theme.colors.textStrong,
+      textAlign: 'center',
+      marginBottom: Skin.space(2),
+    },
+    headerAddress: {
+      ...theme.textStyles.footnote,
+      color: theme.colors.textMuted,
+      textAlign: 'center',
+    },
+    headerSubtitle: {
+      ...theme.textStyles.subheadline,
+      color: theme.colors.textSubtle,
+      textAlign: 'center',
+      marginTop: Skin.space(12),
     },
     group: {
       marginBottom: Skin.space(12),

--- a/hooks/chat/useDMMute.ts
+++ b/hooks/chat/useDMMute.ts
@@ -8,10 +8,16 @@
  * object (that read-back bridge is the one that broke primaryUsername /
  * isProfilePublic; see `config-to-user-readback-bridge-missing`).
  *
+ * The in-memory muted set is held in a module-level store and exposed via
+ * useSyncExternalStore, so EVERY consumer (the DM settings sheet, the messages
+ * list, the conversation row) sees a toggle immediately — without that, each
+ * useDMMute() call kept its own useState copy and a mute made on the DM screen
+ * never reached the list until a remount.
+ *
  * Muted conversations are excluded from unread badge counts.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
 import { useAuth } from '@/context';
 import { createMMKV } from 'react-native-mmkv';
 import {
@@ -25,7 +31,7 @@ const legacyStore = createMMKV({ id: 'dm-muted' });
 function legacyKey(userAddress: string): string {
   return `muted:${userAddress}`;
 }
-function migrateLegacyMuted(userAddress: string): string[] {
+function consumeLegacyMuted(userAddress: string): string[] {
   const raw = legacyStore.getString(legacyKey(userAddress));
   if (!raw) return [];
   try {
@@ -38,49 +44,97 @@ function migrateLegacyMuted(userAddress: string): string[] {
   }
 }
 
+// --- Module-level shared store (one source of truth across all hook instances) ---
+
+let mutedSet = new Set<string>();
+let loadedForAddress: string | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): Set<string> {
+  return mutedSet;
+}
+
+/** Load (once per address) from config + migrate any legacy local mutes. */
+function ensureLoaded(address: string): void {
+  if (loadedForAddress === address) return;
+  loadedForAddress = address;
+
+  const fromConfig = getLocalMutedConversations(address);
+  const legacy = consumeLegacyMuted(address);
+
+  if (legacy.length > 0) {
+    const merged = Array.from(new Set([...fromConfig, ...legacy]));
+    mutedSet = new Set(merged);
+    void persistMutedConversations(address, merged);
+  } else {
+    mutedSet = new Set(fromConfig);
+  }
+  emit();
+}
+
+/**
+ * Clear the in-memory store on logout. Without this, the module-level set
+ * outlives the session (there's no JS reload on sign-out), so a same-address
+ * re-login after a config wipe would keep showing the pre-logout mutes
+ * (`ensureLoaded` would short-circuit on the matching address). Resetting
+ * `loadedForAddress` forces a fresh config read on the next sign-in.
+ */
+function resetForLogout(): void {
+  if (loadedForAddress === null && mutedSet.size === 0) return;
+  loadedForAddress = null;
+  mutedSet = new Set();
+  emit();
+}
+
+function setMuted(address: string, conversationId: string, muted: boolean): void {
+  const next = new Set(mutedSet);
+  if (muted) {
+    next.add(conversationId);
+  } else {
+    next.delete(conversationId);
+  }
+  mutedSet = next; // new reference so useSyncExternalStore re-renders consumers
+  emit();
+  void persistMutedConversations(address, [...next]);
+}
+
 export function useDMMute() {
   const { user } = useAuth();
-  const [mutedConversations, setMutedConversations] = useState<Set<string>>(new Set());
+  const address = user?.address ?? null;
 
+  // Load synchronously on first sight of this address so the very first render
+  // already has the correct muted set (no one-frame flash of un-muted badges).
+  // `ensureLoaded` is idempotent (guarded on `loadedForAddress`) and the legacy
+  // migration's key-delete makes it safe under StrictMode double-invoke. Reading
+  // an external store during render is explicitly supported by useSyncExternalStore.
+  if (address) ensureLoaded(address);
+
+  // Clearing on sign-out is a state change, so it belongs in an effect, not the
+  // render body. Without it the module-level set outlives the session.
   useEffect(() => {
-    if (!user?.address) {
-      setMutedConversations(new Set());
-      return;
-    }
+    if (!address) resetForLogout();
+  }, [address]);
 
-    const fromConfig = getLocalMutedConversations(user.address);
-    const legacy = migrateLegacyMuted(user.address);
-
-    if (legacy.length > 0) {
-      // Fold any pre-sync local mutes into the config-backed list once.
-      const merged = Array.from(new Set([...fromConfig, ...legacy]));
-      setMutedConversations(new Set(merged));
-      void persistMutedConversations(user.address, merged);
-    } else {
-      setMutedConversations(new Set(fromConfig));
-    }
-  }, [user?.address]);
+  const mutedConversations = useSyncExternalStore(subscribe, getSnapshot);
 
   const toggleMute = useCallback((conversationId: string) => {
-    if (!user?.address) return;
-    const address = user.address;
+    if (!address) return;
+    setMuted(address, conversationId, !mutedSet.has(conversationId));
+  }, [address]);
 
-    setMutedConversations((prev) => {
-      const next = new Set(prev);
-      if (next.has(conversationId)) {
-        next.delete(conversationId);
-      } else {
-        next.add(conversationId);
-      }
-      // Persist + sync (best-effort) outside the setter's pure return.
-      void persistMutedConversations(address, [...next]);
-      return next;
-    });
-  }, [user?.address]);
-
-  const isMuted = useCallback((conversationId: string): boolean => {
-    return mutedConversations.has(conversationId);
-  }, [mutedConversations]);
+  const isMuted = useCallback(
+    (conversationId: string): boolean => mutedConversations.has(conversationId),
+    [mutedConversations]
+  );
 
   return {
     mutedConversations,

--- a/hooks/chat/useDMMute.ts
+++ b/hooks/chat/useDMMute.ts
@@ -1,32 +1,41 @@
 /**
  * useDMMute - Hook for muting/unmuting DM conversations
  *
- * Stores muted conversations in local MMKV storage.
+ * Mute state is stored in `UserConfig.mutedConversations` so it SYNCS ACROSS
+ * DEVICES (matching desktop). This follows the "bookmark pattern": the value
+ * lives in the config, is persisted to the local MMKV config, and is read
+ * straight back from there — it is NOT routed through the in-memory `user`
+ * object (that read-back bridge is the one that broke primaryUsername /
+ * isProfilePublic; see `config-to-user-readback-bridge-missing`).
+ *
  * Muted conversations are excluded from unread badge counts.
  */
 
 import { useState, useEffect, useCallback } from 'react';
 import { useAuth } from '@/context';
 import { createMMKV } from 'react-native-mmkv';
+import {
+  getLocalMutedConversations,
+  setMutedConversations as persistMutedConversations,
+} from '@/services/config';
 
-const storage = createMMKV({ id: 'dm-muted' });
-
-function getStorageKey(userAddress: string): string {
+// Legacy device-local store (pre-sync). Kept only to migrate existing muted
+// ids into the config-backed list once, then it is no longer written.
+const legacyStore = createMMKV({ id: 'dm-muted' });
+function legacyKey(userAddress: string): string {
   return `muted:${userAddress}`;
 }
-
-function loadMuted(userAddress: string): Set<string> {
-  const raw = storage.getString(getStorageKey(userAddress));
-  if (!raw) return new Set();
+function migrateLegacyMuted(userAddress: string): string[] {
+  const raw = legacyStore.getString(legacyKey(userAddress));
+  if (!raw) return [];
   try {
-    return new Set(JSON.parse(raw));
+    const ids = JSON.parse(raw) as string[];
+    // One-time consume: clear the legacy entry so this only merges once.
+    legacyStore.remove(legacyKey(userAddress));
+    return Array.isArray(ids) ? ids : [];
   } catch {
-    return new Set();
+    return [];
   }
-}
-
-function saveMuted(userAddress: string, muted: Set<string>): void {
-  storage.set(getStorageKey(userAddress), JSON.stringify([...muted]));
 }
 
 export function useDMMute() {
@@ -38,20 +47,33 @@ export function useDMMute() {
       setMutedConversations(new Set());
       return;
     }
-    setMutedConversations(loadMuted(user.address));
+
+    const fromConfig = getLocalMutedConversations(user.address);
+    const legacy = migrateLegacyMuted(user.address);
+
+    if (legacy.length > 0) {
+      // Fold any pre-sync local mutes into the config-backed list once.
+      const merged = Array.from(new Set([...fromConfig, ...legacy]));
+      setMutedConversations(new Set(merged));
+      void persistMutedConversations(user.address, merged);
+    } else {
+      setMutedConversations(new Set(fromConfig));
+    }
   }, [user?.address]);
 
   const toggleMute = useCallback((conversationId: string) => {
     if (!user?.address) return;
+    const address = user.address;
 
-    setMutedConversations(prev => {
+    setMutedConversations((prev) => {
       const next = new Set(prev);
       if (next.has(conversationId)) {
         next.delete(conversationId);
       } else {
         next.add(conversationId);
       }
-      saveMuted(user.address, next);
+      // Persist + sync (best-effort) outside the setter's pure return.
+      void persistMutedConversations(address, [...next]);
       return next;
     });
   }, [user?.address]);

--- a/hooks/useUnifiedNotifications.ts
+++ b/hooks/useUnifiedNotifications.ts
@@ -17,6 +17,7 @@ import {
 } from './useFarcasterNotifications';
 import { useHaatzNotifications } from './useHaatzNotifications';
 import { isScamCast } from '@/services/farcaster/scamFilter';
+import { useDMMute } from '@/hooks/chat/useDMMute';
 import {
   getLastSeenTimestamp,
   useNotificationLog,
@@ -284,6 +285,9 @@ export function useUnifiedNotifications(): UnifiedNotificationsResult {
   // deduped against the official feed so notifications still show when the
   // farcaster.xyz bearer token is missing or expired.
   const haatzQuery = useHaatzNotifications();
+  // Muted DMs are excluded from the unread count below. Consuming the hook (vs
+  // reading MMKV) makes `unreadCount` recompute the moment a mute toggles.
+  const { mutedConversations } = useDMMute();
 
   const farcasterItems = useMemo(() => {
     const isNotScam = (n: FarcasterNotification) =>
@@ -300,11 +304,20 @@ export function useUnifiedNotifications(): UnifiedNotificationsResult {
       ...chatEntries.map(chatToUnified),
       ...farcasterItems.map(farcasterToUnified),
     ];
-    merged.sort((a, b) => b.timestamp - a.timestamp);
-    return merged;
-  }, [chatEntries, farcasterItems]);
+    // Drop muted DMs from the attention feed entirely — consistent with the
+    // badge + push suppression. The conversation stays reachable via the
+    // messages tab (its unread dot is intentionally kept).
+    const visible = merged.filter((e) => {
+      const convId = e.link?.type === 'message' ? e.link.conversationId : undefined;
+      return !(convId && mutedConversations.has(convId));
+    });
+    visible.sort((a, b) => b.timestamp - a.timestamp);
+    return visible;
+  }, [chatEntries, farcasterItems, mutedConversations]);
 
   const unreadCount = useMemo(() => {
+    // `items` is already filtered to exclude muted DMs (see above), so the
+    // badge count derived here inherits that exclusion — no separate mute check.
     // Prefer the server's per-notification isUnread for Farcaster items
     // (it survives mark-all-read calls from the web client), fall back
     // to lastSeen for chat items where we don't have a server flag.

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -400,6 +400,10 @@ export async function getConfig(address: string): Promise<UserConfig> {
       profile_image: decryptedConfig.profile_image,
       bio: (decryptedConfig as any).bio,
       isProfilePublic: (decryptedConfig as any).isProfilePublic,
+      // Explicitly carry the synced muted-DM list so an incoming config can't
+      // silently drop it (the failure mode that hit primaryUsername). The spread
+      // above should include it, but mute relies on this round-trip, so list it.
+      mutedConversations: (decryptedConfig as any).mutedConversations,
     } as UserConfig;
     saveLocalUserConfig(configWithTimestamp);
 
@@ -539,4 +543,32 @@ export function getDisplayName(address: string): string | undefined {
 export function getProfileImage(address: string): string | undefined {
   const config = getLocalUserConfig(address);
   return config?.profile_image;
+}
+
+// Muted DM conversations — config-backed so they sync across devices (the
+// "bookmark pattern": stored in UserConfig, read straight back from the local
+// MMKV config, never routed through the in-memory `user` object). Matches
+// desktop, which also stores mute in UserConfig.mutedConversations.
+
+export function getLocalMutedConversations(address: string): string[] {
+  const config = getLocalUserConfig(address);
+  return config?.mutedConversations ?? [];
+}
+
+/** Persist the muted list locally and sync outbound when allowSync is on. */
+export async function setMutedConversations(
+  address: string,
+  mutedConversations: string[]
+): Promise<void> {
+  const current = getLocalUserConfig(address) ?? getDefaultUserConfig(address);
+  const updated: UserConfig = { ...current, mutedConversations };
+  // Persist locally first so the value survives even if the sync below fails.
+  saveLocalUserConfig(updated);
+  try {
+    if (updated.allowSync) {
+      await saveConfig(updated);
+    }
+  } catch {
+    // Config sync is best-effort — the mute change is already saved locally.
+  }
 }

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -7,6 +7,7 @@ import { gcm } from '@noble/ciphers/aes.js';
 import { randomBytes } from '@noble/ciphers/webcrypto.js';
 import { createMMKV, type MMKV } from 'react-native-mmkv';
 import { getQuorumClient } from '../api/quorumClient';
+import { mmkvStorage } from '../offline/storage';
 import { getPrivateKey, getPublicKey } from '../onboarding/secureStorage';
 import { NativeCryptoProvider } from '../crypto/native-provider';
 import {
@@ -571,4 +572,26 @@ export async function setMutedConversations(
   } catch {
     // Config sync is best-effort — the mute change is already saved locally.
   }
+}
+
+// Resolve the muted list for the CURRENT user without the caller needing the
+// address. Used by the notification gate + unread-count paths, which run
+// outside React (no useAuth) and only have a conversationId. Reads the signed-in
+// address from the same MMKV key AuthContext writes (`auth:user`).
+function getCurrentUserAddressFromStorage(): string | null {
+  try {
+    const json = mmkvStorage.getItem('auth:user');
+    if (!json) return null;
+    const u = JSON.parse(json) as { address?: string };
+    return u?.address ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when `conversationId` is muted for the currently signed-in user. */
+export function isConversationMutedForCurrentUser(conversationId: string): boolean {
+  const address = getCurrentUserAddressFromStorage();
+  if (!address) return false;
+  return getLocalMutedConversations(address).includes(conversationId);
 }

--- a/services/config/index.ts
+++ b/services/config/index.ts
@@ -20,4 +20,5 @@ export {
   // DM mute management (config-backed, syncs across devices)
   getLocalMutedConversations,
   setMutedConversations,
+  isConversationMutedForCurrentUser,
 } from './configService';

--- a/services/config/index.ts
+++ b/services/config/index.ts
@@ -17,4 +17,7 @@ export {
   getLocalBookmarks,
   addBookmark,
   removeBookmark,
+  // DM mute management (config-backed, syncs across devices)
+  getLocalMutedConversations,
+  setMutedConversations,
 } from './configService';

--- a/services/notifications/NotificationService.ts
+++ b/services/notifications/NotificationService.ts
@@ -7,6 +7,7 @@ import { Platform } from 'react-native';
 import { router } from 'expo-router';
 import { appendNotificationLog } from './notificationLog';
 import { shouldNotifyForContext } from './notificationPrefs';
+import { isConversationMutedForCurrentUser } from '@/services/config';
 
 // Wake-type strings sent by the server for silent / generic-body pushes.
 // In foreground these are redundant (the websocket has already delivered
@@ -105,6 +106,15 @@ export async function showMessageNotification(
     spaceId: content.data?.spaceId,
     channelId: content.data?.channelId,
   })) {
+    return undefined;
+  }
+
+  // Per-DM mute (config-backed, syncs across devices). The space/channel gate
+  // above doesn't cover DMs — a muted conversation must not notify. Only
+  // applies when we know the conversationId (the decrypted/foreground path);
+  // the generic background "new messages" wake has none and falls through.
+  const convId = content.data?.conversationId;
+  if (convId && isConversationMutedForCurrentUser(convId)) {
     return undefined;
   }
   try {


### PR DESCRIPTION
DM conversation mute that syncs across devices, with the supporting UI and notification suppression.

- Store mute on `UserConfig.mutedConversations` so it syncs across a user's devices (read back from local config, not the in-memory user object)
- Shared in-memory store via `useSyncExternalStore` so every consumer (settings sheet, list, badge) updates live on toggle; resets on logout
- Long-press a conversation row opens the settings sheet (recipient pfp + name + truncated address)
- Add a Mute Conversation toggle to the DM settings sheet
- Bell-off badge on muted rows in the messages list
- Suppress foreground notifications for muted DMs
- Exclude muted DMs from the in-app notifications list and the unread badge
- Keep the per-row unread dot for muted conversations (mute is not "mark read")