### PR TITLE
Sync channel/space notification mute across devices + muted UI

### DIFF
--- a/app/(tabs)/spaces/[id]/index.tsx
+++ b/app/(tabs)/spaces/[id]/index.tsx
@@ -5,6 +5,7 @@ import { SpaceDescriptionSheet } from '@/components/SpaceDescriptionSheet';
 import { useChannels } from '@/hooks/chat/useChannels';
 import { useReplyTracking } from '@/hooks/chat/useReplyTracking';
 import { useMentionTracking } from '@/hooks/chat/useMentionTracking';
+import { useChannelMute } from '@/hooks/chat/useChannelMute';
 import { useSpace } from '@/hooks/chat/useSpaces';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
@@ -40,6 +41,8 @@ export default function SpaceChannelsScreen() {
 
   const { data: spaceData, isLoading } = useSpace(spaceId, { enabled: !!spaceId });
   useChannels(spaceId, { enabled: !!spaceId });
+  const { mutedChannels, isSpaceMuted } = useChannelMute(spaceId);
+  const spaceMuted = isSpaceMuted();
   const { getReplyCount } = useReplyTracking();
   const { getMentionCount } = useMentionTracking();
 
@@ -91,6 +94,7 @@ export default function SpaceChannelsScreen() {
         onInvite={() => setInviteVisible(true)}
         onSettings={() => setSettingsVisible(true)}
         onDescriptionPress={() => setDescriptionVisible(true)}
+        isMuted={spaceMuted}
       />
 
       <ScrollView
@@ -103,6 +107,10 @@ export default function SpaceChannelsScreen() {
               const replies = getReplyCount(spaceId, channel.channelId) ?? 0;
               const mentions = getMentionCount(spaceId, channel.channelId) ?? 0;
               const badgeCount = mentions + replies;
+              // Per-row muted treatment fires only for an INDIVIDUALLY muted
+              // channel — a whole-space mute is shown on the space header/icon
+              // instead, so the channel list doesn't read as all-broken.
+              const muted = mutedChannels.has(channel.channelId);
               return (
                 <TouchableOpacity
                   key={channel.channelId}
@@ -119,9 +127,24 @@ export default function SpaceChannelsScreen() {
                     color={resolveChannelIconColor(channel.iconColor, theme.colors.textMuted)}
                     variant={channel.iconVariant ?? 'outline'}
                   />
-                  <Text style={[styles.channelName, badgeCount > 0 && styles.channelNameUnread]} numberOfLines={1}>
+                  <Text
+                    style={[
+                      styles.channelName,
+                      badgeCount > 0 && styles.channelNameUnread,
+                      muted && styles.channelNameMuted,
+                    ]}
+                    numberOfLines={1}
+                  >
                     {channel.channelName}
                   </Text>
+                  {muted && (
+                    <IconSymbol
+                      name="bell.slash.fill"
+                      size={14}
+                      color={theme.colors.textMuted}
+                      style={styles.channelMuteIcon}
+                    />
+                  )}
                   {badgeCount > 0 && (
                     <View style={styles.unreadBadge}>
                       <Text style={styles.unreadText}>
@@ -218,6 +241,9 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
       paddingVertical: Skin.space(8),
       gap: Skin.space(10),
     },
+    channelMuteIcon: {
+      marginLeft: Skin.space(2),
+    },
     channelName: {
       flex: 1,
       ...theme.textStyles.body,
@@ -226,6 +252,11 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
     channelNameUnread: {
       fontFamily: theme.fonts.bold.fontFamily,
       fontWeight: theme.fonts.bold.fontWeight,
+    },
+    // Muted channel: the NAME reads muted (a solid muted-color token, not opacity,
+    // and not the icon) alongside the bell-off marker.
+    channelNameMuted: {
+      color: theme.colors.textMuted,
     },
     unreadDotSlot: {
       width: 16,

--- a/app/(tabs)/spaces/index.tsx
+++ b/app/(tabs)/spaces/index.tsx
@@ -7,6 +7,7 @@ import { isValidAvatarUri } from '@/utils/validation';
 import { useReplyTracking } from '@/hooks/chat/useReplyTracking';
 import { useMentionTracking } from '@/hooks/chat/useMentionTracking';
 import { useSpaceActivity } from '@/hooks/chat/useSpaceActivity';
+import { useMutedSpaceIds } from '@/hooks/chat/useChannelMute';
 import { textStyles, useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
 import type { Space } from '@quilibrium/quorum-shared';
@@ -31,6 +32,7 @@ interface SpaceItem {
   channelCount: number;
   unreadCount: number;
   timestamp: number;
+  isMuted: boolean;
 }
 
 function formatRelativeTime(timestamp: number): string {
@@ -66,6 +68,11 @@ const SpaceRow = React.memo(function SpaceRow({
           <Image source={{ uri: item.icon }} style={styles.avatar} />
         ) : (
           <SpaceIcon name={item.name} size={48} style={styles.avatar} />
+        )}
+        {item.isMuted && (
+          <View style={styles.mutedBadge}>
+            <IconSymbol name="bell.slash" size={11} color={theme.colors.textSubtle} />
+          </View>
         )}
       </View>
       <View style={styles.rowContent}>
@@ -112,6 +119,12 @@ export default function SpacesIndex() {
   const listPadding = useFloatingTabBarPadding();
   const styles = useMemo(() => createStyles(theme, isDark, listPadding), [theme, isDark, listPadding]);
 
+  const spaceIds = useMemo(
+    () => ((spaces as Space[]) ?? []).map(s => s.spaceId),
+    [spaces],
+  );
+  const mutedSpaceIds = useMutedSpaceIds(spaceIds);
+
   const items = useMemo<SpaceItem[]>(() => {
     const rows: SpaceItem[] = [];
     for (const space of (spaces as Space[]) ?? []) {
@@ -133,6 +146,7 @@ export default function SpacesIndex() {
         channelCount,
         unreadCount: unread,
         timestamp: activity?.timestamp ?? space.modifiedDate ?? space.createdDate ?? 0,
+        isMuted: mutedSpaceIds.has(space.spaceId),
       });
     }
 
@@ -140,7 +154,7 @@ export default function SpacesIndex() {
     const filtered = q ? rows.filter(r => r.name.toLowerCase().includes(q)) : rows;
     filtered.sort((a, b) => b.timestamp - a.timestamp);
     return filtered;
-  }, [spaces, search, getReplyCount, getMentionCount, getActivity]);
+  }, [spaces, search, getReplyCount, getMentionCount, getActivity, mutedSpaceIds]);
 
   const handlePress = useCallback((spaceId: string) => {
     haptics.light();
@@ -311,8 +325,23 @@ const createStyles = (theme: AppTheme, isDark: boolean, listPadding: number) =>
       paddingVertical: Skin.space(12),
       gap: Skin.space(12),
     },
-    avatarContainer: {},
+    avatarContainer: { position: 'relative' },
     avatar: { width: 48, height: 48, borderRadius: Skin.radius(12) },
+    // Muted-space marker: bell-off chip at the top-left of the space icon,
+    // mirroring the muted-contact badge in the messages list.
+    mutedBadge: {
+      position: 'absolute',
+      top: -2,
+      left: -2,
+      width: 18,
+      height: 18,
+      borderRadius: Skin.radius(9),
+      backgroundColor: theme.colors.surface3,
+      borderWidth: Skin.border(2),
+      borderColor: theme.colors.surface1,
+      alignItems: 'center',
+      justifyContent: 'center',
+    },
     rowContent: { flex: 1, gap: Skin.space(2) },
     rowTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
     rowTitle: { ...theme.textStyles.body, color: theme.colors.textMain, fontWeight: '600', flex: 1, marginRight: Skin.space(8) },

--- a/components/SpaceBannerHeader.tsx
+++ b/components/SpaceBannerHeader.tsx
@@ -19,6 +19,8 @@ interface SpaceBannerHeaderProps {
   onInvite: () => void;
   onSettings: () => void;
   onDescriptionPress: () => void;
+  /** Whole-space notifications muted — shows a bell-off marker by the name. */
+  isMuted?: boolean;
 }
 
 export function SpaceBannerHeader({
@@ -28,6 +30,7 @@ export function SpaceBannerHeader({
   onInvite,
   onSettings,
   onDescriptionPress,
+  isMuted = false,
 }: SpaceBannerHeaderProps) {
   const { theme, isDark } = useTheme();
 
@@ -93,6 +96,9 @@ export function SpaceBannerHeader({
         <Text style={[styles.spaceName, { color: nameColor }]} numberOfLines={1}>
           {space.spaceName}
         </Text>
+        {isMuted && (
+          <IconSymbol name="bell.slash.fill" size={16} color={nameColor} />
+        )}
       </TouchableOpacity>
     </View>
   );

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -51,12 +51,7 @@ import { useWalletSelection } from '@/hooks/useWalletSelection';
 import type { ApexToken } from '@/services/apex/config';
 import { getErrorMessage } from '@/utils/error';
 import { getSpace, getSpaceKey } from '@/services/config/spaceStorage';
-import {
-  getChannelNotificationsEnabled,
-  getSpaceNotificationsEnabled,
-  setChannelNotificationsEnabled,
-  setSpaceNotificationsEnabled,
-} from '@/services/notifications/notificationPrefs';
+import { useChannelMute } from '@/hooks/chat/useChannelMute';
 // NativeCryptoProvider and getApiConfig imported dynamically in handlePublishToDirectory
 // to avoid module-level import failures on some devices
 import { pickEmoji, pickSticker } from '@/services/media/customAssets';
@@ -541,46 +536,21 @@ export default function SpaceSettingsModal({
     if (visible) loadSpace();
   }, [visible, loadSpace]);
 
-  // Per-space notification preference. Anyone can mute/unmute their
-  // own copy of a space — this is a local user setting, not a
-  // space-wide config. Persisted in MMKV; gates
-  // showMessageNotification at presentation time.
-  const [spaceNotificationsOn, setSpaceNotificationsOn] = useState<boolean>(() =>
-    getSpaceNotificationsEnabled(spaceId),
-  );
-  useEffect(() => {
-    if (visible && spaceId) {
-      setSpaceNotificationsOn(getSpaceNotificationsEnabled(spaceId));
-    }
-  }, [visible, spaceId]);
-  const handleToggleSpaceNotifications = useCallback((next: boolean) => {
-    setSpaceNotificationsOn(next);
-    setSpaceNotificationsEnabled(spaceId, next);
-  }, [spaceId]);
-
-  // Per-channel notification preferences. Map keyed by channelId
-  // mirrors what's in MMKV; we re-read on open so a fresh modal
-  // shows current state. Channel-level mute is independent of the
-  // space-level toggle — if the space is muted nothing notifies
-  // regardless of channel toggle (gating is in
-  // services/notifications/pushReceivedTask.ts).
-  const [channelNotifMap, setChannelNotifMap] = useState<Record<string, boolean>>({});
-  useEffect(() => {
-    if (!visible || !spaceId || !space) return;
-    const next: Record<string, boolean> = {};
-    for (const group of space.groups ?? []) {
-      for (const ch of group.channels ?? []) {
-        next[ch.channelId] = getChannelNotificationsEnabled(spaceId, ch.channelId);
-      }
-    }
-    setChannelNotifMap(next);
-  }, [visible, spaceId, space]);
+  // Per-space / per-channel notification mute. Stored in UserConfig so it syncs
+  // across the user's devices; useChannelMute is the reactive, config-backed
+  // source of truth (and keeps the local MMKV mirror the native gates read in
+  // lockstep). The UI here is phrased as "notifications ON", i.e. NOT muted.
+  const { isSpaceMuted, mutedChannels, toggleSpaceMute, toggleChannelMute } =
+    useChannelMute(spaceId);
+  const spaceNotificationsOn = !isSpaceMuted();
+  const handleToggleSpaceNotifications = useCallback(() => {
+    toggleSpaceMute();
+  }, [toggleSpaceMute]);
   const handleToggleChannelNotifications = useCallback(
-    (channelId: string, next: boolean) => {
-      setChannelNotifMap(prev => ({ ...prev, [channelId]: next }));
-      setChannelNotificationsEnabled(spaceId, channelId, next);
+    (channelId: string) => {
+      toggleChannelMute(channelId);
     },
-    [spaceId],
+    [toggleChannelMute],
   );
 
   // Per-space profile — overrides the user's global profile for this
@@ -1602,7 +1572,10 @@ export default function SpaceSettingsModal({
           </Text>
           {(space?.groups ?? []).map(group => (
             (group.channels ?? []).map(channel => {
-              const channelOn = channelNotifMap[channel.channelId] ?? true;
+              // Per-channel switch reflects only the channel's own mute, so the
+              // user can configure channels independently even while the whole
+              // space is muted (space-off overrides at notify time regardless).
+              const channelOn = !mutedChannels.has(channel.channelId);
               return (
                 <View
                   key={channel.channelId}
@@ -1619,7 +1592,7 @@ export default function SpaceSettingsModal({
                   </Text>
                   <Switch
                     value={channelOn}
-                    onValueChange={(next) => handleToggleChannelNotifications(channel.channelId, next)}
+                    onValueChange={() => handleToggleChannelNotifications(channel.channelId)}
                     trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
                     thumbColor={'#ffffff'}
                   />

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -36,6 +36,7 @@ import type { Conversation } from '@/hooks/chat/useConversations';
 import { incrementReplyCount } from '@/hooks/chat/useReplyTracking';
 import { incrementMentionCount } from '@/hooks/chat/useMentionTracking';
 import { recordSpaceActivity } from '@/hooks/chat/useSpaceActivity';
+import { shouldNotifyForContext } from '@/services/notifications/notificationPrefs';
 import { messagePreview as getSpaceMessagePreview, messageSenderName } from '@/utils/messagePreview';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type {
@@ -2268,8 +2269,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               space?.spaceName || spaceId.substring(0, 8)
             );
 
+            // Muting a channel/space silences its in-app reply/mention badge
+            // too, not just push notifications — same gate as the push path.
+            const notifyForBadge = shouldNotifyForContext({ spaceId, channelId });
+
             // Track replies to current user
             if (
+              notifyForBadge &&
               spaceMessage.replyMetadata?.parentAuthor &&
               spaceMessage.replyMetadata.parentAuthor === fullUserAddrRef.current &&
               ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined) !== fullUserAddrRef.current &&
@@ -2283,6 +2289,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // messages. @everyone is gated on the sender's mention:everyone
             // permission inside isMentionedWithSettings.
             if (
+              notifyForBadge &&
               fullUserAddrRef.current &&
               ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined) !== fullUserAddrRef.current &&
               isMentionedWithSettings(spaceMessage, {
@@ -3579,8 +3586,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             space?.spaceName || spaceId.substring(0, 8)
           );
 
+          // Muted channel/space → no in-app badge (same gate as push).
+          const notifyForBadge = shouldNotifyForContext({ spaceId, channelId });
+
           // Track replies
           if (
+            notifyForBadge &&
             spaceMessage.replyMetadata?.parentAuthor &&
             spaceMessage.replyMetadata.parentAuthor === fullUserAddrRef.current &&
             ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined) !== fullUserAddrRef.current &&
@@ -3592,6 +3603,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // Track @mentions of the current user (same channel-row badge as
           // replies — see the live path for rationale).
           if (
+            notifyForBadge &&
             fullUserAddrRef.current &&
             ('senderId' in spaceMessage.content ? spaceMessage.content.senderId : undefined) !== fullUserAddrRef.current &&
             isMentionedWithSettings(spaceMessage, {

--- a/hooks/chat/useChannelMute.ts
+++ b/hooks/chat/useChannelMute.ts
@@ -1,0 +1,221 @@
+/**
+ * useChannelMute — channel/space notification mute that syncs across devices.
+ *
+ * Mute state lives in `UserConfig.mutedChannels[spaceId]` (per-channel) and
+ * `UserConfig.notificationSettings[spaceId].isMuted` (per-space), so a mute
+ * toggled on one device shows up on the user's other devices via the encrypted
+ * config sync. The value is read straight back from the local config, never
+ * through the in-memory `user` object.
+ *
+ * Two layers:
+ *   - Source of truth + sync: UserConfig (this hook).
+ *   - Local mirror for the native gates: the `quorum-notification-prefs` MMKV
+ *     store (+ iOS App-Group mirror), which `shouldNotifyForContext` and the NSE
+ *     read unchanged. The mirror is kept in lockstep with UserConfig here — on
+ *     first load (migrating any legacy device-local mutes), on inbound sync, and
+ *     on every toggle.
+ *
+ * In-memory state is a module-level store exposed via useSyncExternalStore so
+ * every consumer (settings sheet, channel-list row) updates instantly on a
+ * toggle; a per-hook useState copy would not propagate.
+ */
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useAuth } from '@/context';
+import {
+  getLocalMutedChannels,
+  setMutedChannels as persistMutedChannels,
+  getLocalSpaceMuted,
+  setSpaceMuted as persistSpaceMuted,
+} from '@/services/config';
+import {
+  mirrorSpaceMuteState,
+  readLegacyMutesForSpace,
+} from '@/services/notifications/notificationPrefs';
+
+// --- Module-level shared store (one source of truth across all hook instances) ---
+//
+// Keyed by spaceId so a screen showing one space doesn't churn another's state.
+// `mutedChannels` is the set of muted channel ids per space; `spaceMuted` is the
+// per-space flag. A space is loaded lazily the first time it's seen.
+
+type SpaceMuteState = { mutedChannels: Set<string>; spaceMuted: boolean };
+
+let store: Record<string, SpaceMuteState> = {};
+let loadedForAddress: string | null = null;
+const loadedSpaces = new Set<string>();
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): Record<string, SpaceMuteState> {
+  return store;
+}
+
+const EMPTY: SpaceMuteState = { mutedChannels: new Set(), spaceMuted: false };
+
+/** Reset everything when the address changes (login/logout). */
+function resetForAddress(address: string | null): void {
+  if (loadedForAddress === address) return;
+  loadedForAddress = address;
+  store = {};
+  loadedSpaces.clear();
+  emit();
+}
+
+/**
+ * Load one space's mute state from UserConfig (once), migrating any legacy
+ * device-local MMKV mutes into the config on first run, then writing the mirror
+ * so the native gates reflect the config-backed state.
+ */
+function ensureSpaceLoaded(address: string, spaceId: string): void {
+  if (loadedSpaces.has(spaceId)) return;
+  loadedSpaces.add(spaceId);
+
+  let mutedChannels = getLocalMutedChannels(address, spaceId);
+  let spaceMuted = getLocalSpaceMuted(address, spaceId);
+
+  // One-time migration: if the config has no mute state for this space yet but
+  // the legacy MMKV store does, seed the config from it. (Idempotent: after the
+  // config is authoritative, the mirror is rewritten FROM it below, so the legacy
+  // reads converge to the same values and re-seeding is a no-op.)
+  if (mutedChannels.length === 0 && !spaceMuted) {
+    const legacy = readLegacyMutesForSpace(spaceId);
+    if (legacy.mutedChannelIds.length > 0 || legacy.spaceMuted) {
+      mutedChannels = legacy.mutedChannelIds;
+      spaceMuted = legacy.spaceMuted;
+      void persistMutedChannels(address, spaceId, mutedChannels);
+      void persistSpaceMuted(address, spaceId, spaceMuted);
+    }
+  }
+
+  store = {
+    ...store,
+    [spaceId]: { mutedChannels: new Set(mutedChannels), spaceMuted },
+  };
+  // Keep the native-gate mirror in lockstep with the config-backed truth.
+  mirrorSpaceMuteState(spaceId, mutedChannels, spaceMuted);
+  emit();
+}
+
+function setChannelMuted(
+  address: string,
+  spaceId: string,
+  channelId: string,
+  muted: boolean,
+): void {
+  const prev = store[spaceId] ?? EMPTY;
+  const next = new Set(prev.mutedChannels);
+  if (muted) next.add(channelId);
+  else next.delete(channelId);
+  store = { ...store, [spaceId]: { ...prev, mutedChannels: next } };
+  emit();
+  const ids = [...next];
+  void persistMutedChannels(address, spaceId, ids);
+  mirrorSpaceMuteState(spaceId, ids, store[spaceId].spaceMuted);
+}
+
+function setSpaceMutedState(address: string, spaceId: string, muted: boolean): void {
+  const prev = store[spaceId] ?? EMPTY;
+  store = { ...store, [spaceId]: { ...prev, spaceMuted: muted } };
+  emit();
+  void persistSpaceMuted(address, spaceId, muted);
+  mirrorSpaceMuteState(spaceId, [...prev.mutedChannels], muted);
+}
+
+/**
+ * Re-read a space's mute state from local config and refresh the mirror. Call
+ * when an inbound config sync may have changed it on another device, so the
+ * gates + UI reflect the synced state without a remount.
+ */
+export function refreshChannelMuteFromConfig(address: string, spaceId: string): void {
+  const mutedChannels = getLocalMutedChannels(address, spaceId);
+  const spaceMuted = getLocalSpaceMuted(address, spaceId);
+  store = {
+    ...store,
+    [spaceId]: { mutedChannels: new Set(mutedChannels), spaceMuted },
+  };
+  mirrorSpaceMuteState(spaceId, mutedChannels, spaceMuted);
+  emit();
+}
+
+/**
+ * Reactive set of space ids that are muted at the whole-space level, across the
+ * given spaces. For list surfaces (the spaces list) that need to mark many
+ * spaces at once without a per-space hook. Loads each space's state on first
+ * sight (same migration + mirror as the single-space hook).
+ */
+export function useMutedSpaceIds(spaceIds: string[]): Set<string> {
+  const { user } = useAuth();
+  const address = user?.address ?? null;
+
+  if (address) {
+    for (const id of spaceIds) ensureSpaceLoaded(address, id);
+  }
+
+  useEffect(() => {
+    if (!address) resetForAddress(null);
+  }, [address]);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+  const muted = new Set<string>();
+  for (const id of spaceIds) {
+    if (snapshot[id]?.spaceMuted) muted.add(id);
+  }
+  return muted;
+}
+
+/**
+ * Channel/space mute for one space. Pass the spaceId the screen is showing.
+ * Returns reactive `isChannelMuted` / `isSpaceMuted` and the toggles.
+ */
+export function useChannelMute(spaceId: string | undefined) {
+  const { user } = useAuth();
+  const address = user?.address ?? null;
+
+  // Load this space's state on first sight so the first render is correct.
+  if (address && spaceId) ensureSpaceLoaded(address, spaceId);
+
+  useEffect(() => {
+    if (!address) resetForAddress(null);
+  }, [address]);
+
+  const snapshot = useSyncExternalStore(subscribe, getSnapshot);
+  const spaceState = (spaceId && snapshot[spaceId]) || EMPTY;
+
+  const isChannelMuted = useCallback(
+    (channelId: string): boolean =>
+      spaceState.spaceMuted || spaceState.mutedChannels.has(channelId),
+    [spaceState],
+  );
+
+  const isSpaceMuted = useCallback((): boolean => spaceState.spaceMuted, [spaceState]);
+
+  const toggleChannelMute = useCallback(
+    (channelId: string) => {
+      if (!address || !spaceId) return;
+      setChannelMuted(address, spaceId, channelId, !spaceState.mutedChannels.has(channelId));
+    },
+    [address, spaceId, spaceState],
+  );
+
+  const toggleSpaceMute = useCallback(() => {
+    if (!address || !spaceId) return;
+    setSpaceMutedState(address, spaceId, !spaceState.spaceMuted);
+  }, [address, spaceId, spaceState]);
+
+  return {
+    mutedChannels: spaceState.mutedChannels,
+    isChannelMuted,
+    isSpaceMuted,
+    toggleChannelMute,
+    toggleSpaceMute,
+  };
+}

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -405,6 +405,11 @@ export async function getConfig(address: string): Promise<UserConfig> {
       // silently drop it (the failure mode that hit primaryUsername). The spread
       // above should include it, but mute relies on this round-trip, so list it.
       mutedConversations: (decryptedConfig as any).mutedConversations,
+      // Same round-trip guard for the synced channel/space notification mute
+      // (mutedChannels[spaceId] and notificationSettings[spaceId].isMuted) so an
+      // incoming config can't silently drop a mute toggled on another device.
+      mutedChannels: (decryptedConfig as any).mutedChannels,
+      notificationSettings: (decryptedConfig as any).notificationSettings,
     } as UserConfig;
     saveLocalUserConfig(configWithTimestamp);
 
@@ -594,4 +599,78 @@ export function isConversationMutedForCurrentUser(conversationId: string): boole
   const address = getCurrentUserAddressFromStorage();
   if (!address) return false;
   return getLocalMutedConversations(address).includes(conversationId);
+}
+
+// --- Channel / Space notification mute (synced via UserConfig) ---
+//
+// Per-channel mute lives in `UserConfig.mutedChannels[spaceId]: string[]` and
+// per-space mute in `UserConfig.notificationSettings[spaceId].isMuted` — the same
+// fields desktop uses, so the setting syncs cross-device via the encrypted config
+// blob. Write the field, persist locally, let `saveConfig` carry it, read back
+// from local config.
+//
+// `notificationSettings[spaceId].isMuted` is accessed via `(config as any)` because
+// the pinned shared `NotificationSettings` type does not declare `isMuted` yet; it
+// rides the untyped JSON config blob correctly regardless.
+// TODO: drop the `as any` once the shared NotificationSettings.isMuted type is published + pinned.
+
+export function getLocalMutedChannels(address: string, spaceId: string): string[] {
+  const config = getLocalUserConfig(address);
+  return config?.mutedChannels?.[spaceId] ?? [];
+}
+
+/** Persist the muted-channel list for a space locally and sync outbound. */
+export async function setMutedChannels(
+  address: string,
+  spaceId: string,
+  mutedChannelIds: string[]
+): Promise<void> {
+  const current = getLocalUserConfig(address) ?? getDefaultUserConfig(address);
+  const updated: UserConfig = {
+    ...current,
+    mutedChannels: { ...(current.mutedChannels ?? {}), [spaceId]: mutedChannelIds },
+  };
+  saveLocalUserConfig(updated);
+  try {
+    if (updated.allowSync) {
+      await saveConfig(updated);
+    }
+  } catch {
+    // Best-effort sync — the mute change is already saved locally.
+  }
+}
+
+export function getLocalSpaceMuted(address: string, spaceId: string): boolean {
+  const config = getLocalUserConfig(address);
+  const settings = config?.notificationSettings?.[spaceId] as
+    | { isMuted?: boolean }
+    | undefined;
+  return settings?.isMuted ?? false;
+}
+
+/** Persist the per-space mute flag locally and sync outbound. */
+export async function setSpaceMuted(
+  address: string,
+  spaceId: string,
+  muted: boolean
+): Promise<void> {
+  const current = getLocalUserConfig(address) ?? getDefaultUserConfig(address);
+  const prevSettings = current.notificationSettings ?? {};
+  const updated: UserConfig = {
+    ...current,
+    notificationSettings: {
+      ...prevSettings,
+      // Preserve any existing per-space notification settings; add isMuted, which
+      // the pinned shared type doesn't declare yet (rides the untyped config blob).
+      [spaceId]: { ...(prevSettings[spaceId] ?? {}), isMuted: muted } as any,
+    },
+  };
+  saveLocalUserConfig(updated);
+  try {
+    if (updated.allowSync) {
+      await saveConfig(updated);
+    }
+  } catch {
+    // Best-effort sync — the mute change is already saved locally.
+  }
 }

--- a/services/config/index.ts
+++ b/services/config/index.ts
@@ -21,4 +21,9 @@ export {
   getLocalMutedConversations,
   setMutedConversations,
   isConversationMutedForCurrentUser,
+  // Channel/Space notification mute (config-backed, syncs across devices)
+  getLocalMutedChannels,
+  setMutedChannels,
+  getLocalSpaceMuted,
+  setSpaceMuted,
 } from './configService';

--- a/services/notifications/notificationPrefs.ts
+++ b/services/notifications/notificationPrefs.ts
@@ -117,6 +117,77 @@ export function setChannelNotificationsEnabled(
   getStore().set(channelKey(spaceId, channelId), enabled);
 }
 
+// --- UserConfig mirror ---
+//
+// The cross-device source of truth for channel/space mute is `UserConfig`
+// (configService + useChannelMute). This MMKV store is a fast local mirror so
+// the non-React notification gates (shouldNotifyForContext, the iOS NSE's
+// HubLogClassifier.swift via the App-Group mirror) keep reading the same keys.
+// The mirror is derived from UserConfig and rewritten on every change.
+//
+// Semantics bridge: UserConfig stores MUTED state; this store uses ENABLED
+// booleans (muted ⟺ enabled === false).
+
+/**
+ * Overwrite this space's mirror keys to match the config-backed muted state.
+ * `mutedChannelIds` are the channels muted in this space; `spaceMuted` is the
+ * whole-space mute flag. Channels NOT in the list are set back to enabled, so
+ * an unmute synced from another device clears the gate too.
+ */
+export function mirrorSpaceMuteState(
+  spaceId: string,
+  mutedChannelIds: string[],
+  spaceMuted: boolean,
+  knownChannelIds?: string[],
+): void {
+  const store = getStore();
+  // Space-level gate (also fed to the server via pushPrefsSync).
+  setSpaceNotificationsEnabled(spaceId, !spaceMuted);
+  const muted = new Set(mutedChannelIds);
+  // Set every muted channel's gate off.
+  for (const channelId of muted) {
+    store.set(channelKey(spaceId, channelId), false);
+  }
+  // Re-enable channels that are no longer muted. We can only re-enable channels
+  // we know about: the explicitly-muted set is covered above; for the rest,
+  // clear any stale `false` keys for this space that aren't in the muted set.
+  const prefix = `${K_CHANNEL_PREFIX}${spaceId}:`;
+  for (const key of store.getAllKeys()) {
+    if (!key.startsWith(prefix)) continue;
+    const channelId = key.slice(prefix.length);
+    if (!muted.has(channelId)) store.set(key, true);
+  }
+  // If the caller passed the full channel list, make sure none are left muted
+  // that shouldn't be (defensive; the loop above already covers existing keys).
+  if (knownChannelIds) {
+    for (const channelId of knownChannelIds) {
+      if (!muted.has(channelId)) store.set(channelKey(spaceId, channelId), true);
+    }
+  }
+}
+
+/**
+ * Read existing device-local mutes so they can be migrated into UserConfig once.
+ * Returns the muted channel ids for the space and whether the space is muted.
+ * Does not clear anything; migration is idempotent.
+ */
+export function readLegacyMutesForSpace(spaceId: string): {
+  mutedChannelIds: string[];
+  spaceMuted: boolean;
+} {
+  const store = getStore();
+  const spaceMuted = store.getBoolean(spaceKey(spaceId)) === false;
+  const prefix = `${K_CHANNEL_PREFIX}${spaceId}:`;
+  const mutedChannelIds: string[] = [];
+  for (const key of store.getAllKeys()) {
+    if (!key.startsWith(prefix)) continue;
+    if (store.getBoolean(key) === false) {
+      mutedChannelIds.push(key.slice(prefix.length));
+    }
+  }
+  return { mutedChannelIds, spaceMuted };
+}
+
 // Resolution
 
 /**


### PR DESCRIPTION
## What

Makes channel and space notification mute **sync across a user's devices** (it was device-local before), and gives muted channels/spaces a clear visual treatment.

### Sync
- Channel/space mute now lives in `UserConfig` (`mutedChannels` / `notificationSettings[spaceId].isMuted`) — the same fields desktop uses — so it rides the encrypted config sync.
- The local `quorum-notification-prefs` MMKV store is kept as a **mirror** so the native push gates (and the iOS NSE) keep reading the same keys unchanged.
- New reactive `useChannelMute` store (config-backed, `useSyncExternalStore`) drives the settings toggles + the UI so changes apply instantly. Existing device-local mutes migrate into the synced config on first run.

### UI
- **Individually muted channel:** name dims + bell-off icon (the channel icon stays colored).
- **Whole space muted:** bell-off marker on the space icon (spaces list) and next to the space name (header) — the channel list is **not** dimmed.
- Muting a channel/space now also suppresses the **in-app mention/reply badge**, not just push notifications (matches desktop).

## Notes
- `notificationSettings[spaceId].isMuted` is accessed untyped (`as any`) until the shared type is published; TODO comment marks the cleanup.
- **Cross-device propagation happens on peer restart**, not live — this is a pre-existing platform limitation for all `UserConfig` settings (the outbound write is correct). Tracked separately.
- Tested on Android. iOS notification-gate (NSE) verification pending.

## Test
1. Mute one channel → its name dims + bell-off; icon stays colored; other channels untouched.
2. Mute the whole space → space icon + header show bell-off; channel list not dimmed.
3. Muted channel produces no in-app badge and no push; unmuting restores both.