### PR TITLE
Strip image EXIF metadata before Farcaster uploads

### DIFF
--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -66,6 +66,7 @@ export default function ProfileSetupScreen() {
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
+      exif: false,
     });
 
     if (!result.canceled && result.assets[0]) {
@@ -83,6 +84,7 @@ export default function ProfileSetupScreen() {
       allowsEditing: true,
       aspect: [1, 1],
       quality: 0.8,
+      exif: false,
     });
 
     if (!result.canceled && result.assets[0]) {

--- a/services/farcasterClient.ts
+++ b/services/farcasterClient.ts
@@ -1,5 +1,6 @@
 import { logger } from '@quilibrium/quorum-shared';
 import { reportFarcasterAuthFailure } from './farcaster/authTokenEvents';
+import { stripImageMetadata } from '../utils/stripImageMetadata';
 
 const FARCASTER_BASE_URL = 'https://client.farcaster.xyz';
 
@@ -836,8 +837,11 @@ export async function uploadImageToCloudflare({
   name = 'direct-cast-image',
   mimeType = 'image/jpeg',
 }: UploadImageParams): Promise<string | undefined> {
+  // Strip EXIF (e.g. GPS location) before the image leaves the device.
+  const safeUri = await stripImageMetadata(uri, mimeType);
+
   const file = {
-    uri,
+    uri: safeUri,
     type: mimeType,
     name,
   };
@@ -1005,9 +1009,12 @@ export async function uploadImageForCast(
   // CDN URL we hand to the cast embed comes from step 2.
   const { url: uploadUrl } = await generateImageUploadUrl(token);
 
+  // Strip EXIF (e.g. GPS location) before the image leaves the device.
+  const safeUri = await stripImageMetadata(localUri, mimeType);
+
   const formData = new FormData();
   formData.append('file', {
-    uri: localUri,
+    uri: safeUri,
     type: mimeType,
     name: `image_${Date.now()}.${mimeType.split('/')[1] || 'jpg'}`,
   } as unknown as Blob);

--- a/utils/stripImageMetadata.ts
+++ b/utils/stripImageMetadata.ts
@@ -1,0 +1,49 @@
+import * as ImageManipulator from 'expo-image-manipulator';
+
+/**
+ * Strip embedded metadata (EXIF) from an image before it leaves the device.
+ *
+ * Photos taken on a phone carry EXIF metadata that can include GPS
+ * coordinates, capture time, and the camera/device model. Uploading that
+ * raw file would leak the user's location. Re-encoding the image through
+ * ImageManipulator performs a decode-and-reencode, which drops every
+ * metadata segment while keeping the visible pixels.
+ *
+ * Behaviour:
+ * - GIFs are returned unchanged: re-encoding a GIF through ImageManipulator
+ *   would flatten it to a single frame and lose the animation. Animated
+ *   GIFs effectively never carry GPS/camera EXIF, so the privacy risk is
+ *   negligible.
+ * - PNG inputs are re-encoded as PNG so transparency is preserved.
+ * - Everything else is re-encoded as JPEG.
+ *
+ * On any failure the original URI is returned, so callers never break an
+ * upload just because the strip step failed.
+ *
+ * @param uri      Local file URI of the image to sanitise.
+ * @param mimeType Optional MIME type used to pick the output format and to
+ *                 detect GIFs. Falls back to a JPEG re-encode when unknown.
+ * @returns A new local file URI for the metadata-free image, or the original
+ *          URI when stripping is skipped or fails.
+ */
+export async function stripImageMetadata(uri: string, mimeType?: string): Promise<string> {
+  const type = mimeType?.toLowerCase() ?? '';
+
+  // Animated GIFs would lose their animation if re-encoded; skip them.
+  if (type.includes('gif') || uri.toLowerCase().endsWith('.gif')) {
+    return uri;
+  }
+
+  const isPng = type.includes('png') || uri.toLowerCase().endsWith('.png');
+  const format = isPng ? ImageManipulator.SaveFormat.PNG : ImageManipulator.SaveFormat.JPEG;
+
+  try {
+    // No transform actions — an empty action list still forces a full
+    // decode-and-reencode, which is what discards the metadata.
+    const result = await ImageManipulator.manipulateAsync(uri, [], { format });
+    return result.uri;
+  } catch {
+    // Never block an upload on a failed strip; fall back to the original.
+    return uri;
+  }
+}


### PR DESCRIPTION
## What

Photos taken on a phone embed EXIF metadata that can include **GPS coordinates**, capture time, and the camera/device model. The Farcaster image upload paths posted the raw picked file straight to Cloudflare, so that metadata (including location) left the device un-stripped.

This re-encodes images before upload to drop all embedded metadata, and tells the onboarding image picker not to return EXIF in the first place.

## Changes

- **`utils/stripImageMetadata.ts`** (new): re-encodes an image via `expo-image-manipulator` (a decode + re-encode discards all metadata segments). It keeps PNG inputs as PNG so transparency is preserved, skips GIFs so animation isn't flattened, and falls back to the original URI on failure so an upload never breaks just because the strip step failed. No new dependency — `expo-image-manipulator` is already in the project.
- **`services/farcasterClient.ts`**: strip metadata in both upload entry points (`uploadImageToCloudflare` and `uploadImageForCast`) before building the FormData.
- **`app/(onboarding)/profile-setup.tsx`**: pass `exif: false` to the library and camera pickers (belt-and-suspenders).

## Context

Image attachments, avatars, space icons, and skins already strip metadata on master as a side effect of the existing compress/re-encode pipeline. The Farcaster upload path was the remaining gap where a raw URI reached an external server. This closes it.

## Testing

- Type-checks and lints clean on the touched files (no new errors/warnings).
- Behavioural test: send an image with GPS EXIF to a Farcaster DM / cast and confirm the uploaded image no longer carries location metadata; confirm PNGs keep transparency and GIFs keep animating.