### PR TITLE
fix: profile copy tap target, QNS lookup without @, long-name truncation

### DIFF
--- a/components/NewConversationModal.tsx
+++ b/components/NewConversationModal.tsx
@@ -22,26 +22,41 @@ interface NewConversationModalProps {
   onConversationCreated: (conversationId: string) => void;
 }
 
-// Validate address format: Base58 multihash (Qm...) or username (@...)
+// Base58 multihash format (starts with Qm, 46 chars total for CIDv0).
+// Also accept other valid Base58 characters for flexibility.
+const BASE58_ADDRESS_REGEX =
+  /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{32,}$/;
+
+// QNS username: alphanumeric + underscores, with an optional leading @.
+// Anything that isn't a full Base58 address is treated as a username candidate
+// so a bare name (e.g. "cassie") resolves via QNS without needing the @ prefix.
+const USERNAME_REGEX = /^[a-zA-Z0-9_]{1,}$/;
+
+// Strip an optional leading @ from a (trimmed) input.
+function stripAtPrefix(input: string): string {
+  return input.startsWith('@') ? input.slice(1) : input;
+}
+
+// Check if input is a username (vs a full Base58 address).
+// A bare name without @ counts as a username as long as it isn't a 32+ char
+// Base58 address.
+function isUsername(address: string): boolean {
+  const trimmed = address.trim();
+  if (!trimmed) return false;
+  if (trimmed.startsWith('@')) return true;
+  return !BASE58_ADDRESS_REGEX.test(trimmed);
+}
+
+// Validate address format: Base58 multihash (Qm...) or username (with/without @).
 function isValidAddress(address: string): boolean {
   if (!address) return false;
   const trimmed = address.trim();
 
-  // Username format: @username (alphanumeric, underscores, min 1 char after @)
-  if (trimmed.startsWith('@')) {
-    const username = trimmed.slice(1);
-    return /^[a-zA-Z0-9_]{1,}$/.test(username);
+  if (isUsername(trimmed)) {
+    return USERNAME_REGEX.test(stripAtPrefix(trimmed));
   }
 
-  // Base58 multihash format (starts with Qm, 46 chars total for CIDv0)
-  // Also accept other valid Base58 characters for flexibility
-  const base58Regex = /^[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{32,}$/;
-  return base58Regex.test(trimmed);
-}
-
-// Check if input is a username
-function isUsername(address: string): boolean {
-  return address.trim().startsWith('@');
+  return BASE58_ADDRESS_REGEX.test(trimmed);
 }
 
 export default function NewConversationModal({
@@ -59,11 +74,12 @@ export default function NewConversationModal({
   const [error, setError] = useState<string | null>(null);
   const [resolvedAddress, setResolvedAddress] = useState<string | null>(null);
 
-  // Extract username for QNS lookup (without @ prefix)
+  // Extract username for QNS lookup (without @ prefix). A bare name resolves
+  // too, so the @ is optional (issue #50).
   const usernameToResolve = useMemo(() => {
     const trimmed = address.trim();
-    if (trimmed.startsWith('@') && trimmed.length > 1) {
-      return trimmed.slice(1);
+    if (isUsername(trimmed)) {
+      return stripAtPrefix(trimmed);
     }
     return '';
   }, [address]);
@@ -103,7 +119,7 @@ export default function NewConversationModal({
   // If it's a username and we have a resolved address, use that
   const normalizedAddress = useMemo(() => {
     const trimmed = address.trim();
-    if (trimmed.startsWith('@') && resolvedAddress) {
+    if (isUsername(trimmed) && resolvedAddress) {
       return resolvedAddress;
     }
     return trimmed;
@@ -111,7 +127,7 @@ export default function NewConversationModal({
 
   // Check if conversation already exists
   const existingConversation = useMemo(() => {
-    if (!normalizedAddress || normalizedAddress.startsWith('@')) return undefined;
+    if (!normalizedAddress || isUsername(normalizedAddress)) return undefined;
     const searchAddress = normalizedAddress.toLowerCase();
     return existingConversations.find(
       c => c.address?.toLowerCase() === searchAddress
@@ -134,8 +150,8 @@ export default function NewConversationModal({
     setError(null);
 
     try {
-      // For @usernames, use the resolved Qm address
-      const targetAddress = address.trim().startsWith('@') && resolvedAddress
+      // For usernames (with or without @), use the resolved Qm address
+      const targetAddress = isUsername(address.trim()) && resolvedAddress
         ? resolvedAddress
         : address.trim();
 

--- a/components/UnifiedProfileHeader.tsx
+++ b/components/UnifiedProfileHeader.tsx
@@ -126,10 +126,12 @@ export default function UnifiedProfileHeader({
 
       <View style={styles.handlesRow}>
         {user.farcaster?.username && (
-          <Text style={styles.handleText}>@{user.farcaster.username}</Text>
+          <Text style={styles.handleText} numberOfLines={1}>
+            @{user.farcaster.username}
+          </Text>
         )}
         {user.primaryUsername && (
-          <Text style={[styles.handleText, { color: theme.colors.accent }]}>
+          <Text style={[styles.handleText, { color: theme.colors.accent }]} numberOfLines={1}>
             {user.primaryUsername}.q
           </Text>
         )}
@@ -139,6 +141,7 @@ export default function UnifiedProfileHeader({
         onPress={onCopyAddress}
         accessibilityRole="button"
         accessibilityLabel="Copy address"
+        hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
       >
         <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
         <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
@@ -201,7 +204,9 @@ function BigProfileCard({
 
       {/* Quorum: .q name */}
       {qname ? (
-        <Text style={[styles.handleText, { color: theme.colors.accent }]}>{qname}</Text>
+        <Text style={[styles.handleText, { color: theme.colors.accent }]} numberOfLines={1}>
+          {qname}
+        </Text>
       ) : null}
 
       {/* Quorum: tappable address + copy icon */}
@@ -211,6 +216,7 @@ function BigProfileCard({
           onPress={onCopyAddress}
           accessibilityRole="button"
           accessibilityLabel="Copy address"
+          hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
         >
           <Text style={styles.addressText}>{truncateAddress(address, 'medium')}</Text>
           <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
@@ -219,7 +225,9 @@ function BigProfileCard({
 
       {/* Farcaster: @username */}
       {username ? (
-        <Text style={styles.handleText}>{username}</Text>
+        <Text style={styles.handleText} numberOfLines={1}>
+          {username}
+        </Text>
       ) : null}
 
       {/* Farcaster: FID — same size/style as the username line */}
@@ -260,7 +268,7 @@ function QuorumOnlyHeader({
         {displayName}
       </Text>
       {user.primaryUsername ? (
-        <Text style={[styles.handleText, { color: theme.colors.accent }]}>
+        <Text style={[styles.handleText, { color: theme.colors.accent }]} numberOfLines={1}>
           {user.primaryUsername}.q
         </Text>
       ) : null}
@@ -269,6 +277,7 @@ function QuorumOnlyHeader({
         onPress={onCopyAddress}
         accessibilityRole="button"
         accessibilityLabel="Copy address"
+        hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
       >
         <Text style={styles.addressText}>{truncateAddress(user.address, 'medium')}</Text>
         <IconSymbol name="doc.on.doc" size={13} color={theme.colors.textMuted} />
@@ -324,6 +333,9 @@ function createStyles(theme: AppTheme) {
     handleText: {
       fontSize: Skin.font(14),
       color: theme.colors.textMuted,
+      // Allow a very long handle to shrink + ellipsize instead of overflowing
+      // the card or pushing a sibling handle off-screen (see issue #61).
+      flexShrink: 1,
     },
     addressText: {
       fontSize: Skin.font(13),
@@ -359,6 +371,10 @@ function createStyles(theme: AppTheme) {
       flexDirection: 'row',
       alignItems: 'center',
       gap: Skin.space(6),
+      // Padding enlarges the tap target so the copy action is comfortably
+      // hittable on Android (the row is otherwise just text + a 13px icon).
+      paddingVertical: Skin.space(8),
+      paddingHorizontal: Skin.space(8),
     },
   });
 }

--- a/components/UserProfileModal.tsx
+++ b/components/UserProfileModal.tsx
@@ -221,7 +221,13 @@ export default function UserProfileModal({
           {user.primaryUsername && (
             <Text style={styles.username}>@{user.primaryUsername}</Text>
           )}
-          <TouchableOpacity onPress={handleCopyAddress} style={styles.addressRow}>
+          <TouchableOpacity
+            onPress={handleCopyAddress}
+            style={styles.addressRow}
+            accessibilityRole="button"
+            accessibilityLabel="Copy address"
+            hitSlop={{ top: 8, bottom: 8, left: 12, right: 12 }}
+          >
             <Text style={styles.userId}>{truncateAddress(user.userId)}</Text>
             <IconSymbol name="doc.on.doc" size={12} color={theme.colors.textMuted} />
           </TouchableOpacity>
@@ -466,6 +472,10 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       flexDirection: 'row',
       alignItems: 'center',
       gap: Skin.space(6),
+      // Padding enlarges the tap target so the copy action is comfortably
+      // hittable on Android (the row is otherwise just text + a 12px icon).
+      paddingVertical: Skin.space(8),
+      paddingHorizontal: Skin.space(8),
     },
     farcasterRow: {
       flexDirection: 'row',


### PR DESCRIPTION
Three small, independent fixes from issue triage.

### #47 — Cannot copy account address (tiny tap target)
The copy-address row was just text + a ~12-13px icon with no padding, giving a tiny tap target (especially on Android). Added padding + a `hitSlop` to **two** places that share this pattern:
- The profile header (`UnifiedProfileHeader`) — all three variants (merged, big card, Quorum-only).
- The other-user profile modal (`UserProfileModal`) — copying another user's address.

Clipboard logic was already working; this only enlarges the target.

Closes #47

### #50 — QNS name lookup required an @ prefix
In the New Conversation modal, typing `cassie` did nothing while `@cassie` worked, because the username/QNS-resolution path was gated on a leading `@`. Reworked `isUsername`/`isValidAddress` so any input that isn't a 32+ char Base58 address is treated as a username candidate, and the `@` is now optional (stripped if present) across resolution, validation, dedupe, and create.

Closes #50

### #61 — Long usernames not truncated
Long handles (`@superlongname…`, long `.q` names) could overflow the profile card or push a sibling handle off-screen. Added `numberOfLines={1}` to the handle `<Text>` rows and `flexShrink: 1` to the handle style so they ellipsize gracefully.

Closes #61

### Testing
Type-checked clean (the only `tsc` errors are pre-existing, in unrelated `services/` files — the noble-v2/codegen mismatches). Device-tested: #47 (Settings profile) and #50 confirmed working; #47 also now covered in the other-user profile modal.