### PR TITLE
fix: unresolve QNS name + stop clipping invite-join errors

### DIFF
--- a/components/Chat/InviteLinkCard.tsx
+++ b/components/Chat/InviteLinkCard.tsx
@@ -188,52 +188,57 @@ export function InviteLinkCard({
 
   return (
     <View style={styles.container}>
-      {/* Space Icon */}
-      <View style={styles.iconContainer}>
-        {spaceInfo.iconUrl ? (
-          <Image source={{ uri: spaceInfo.iconUrl }} style={styles.icon} />
-        ) : (
-          <SpaceIcon name={spaceInfo.spaceName} size={44} style={styles.icon} />
-        )}
+      {/* Card row: icon + info + join button */}
+      <View style={styles.cardRow}>
+        {/* Space Icon */}
+        <View style={styles.iconContainer}>
+          {spaceInfo.iconUrl ? (
+            <Image source={{ uri: spaceInfo.iconUrl }} style={styles.icon} />
+          ) : (
+            <SpaceIcon name={spaceInfo.spaceName} size={44} style={styles.icon} />
+          )}
+        </View>
+
+        {/* Space Info */}
+        <View style={styles.infoContainer}>
+          <Text style={styles.spaceName} numberOfLines={1}>
+            {spaceInfo.spaceName}
+          </Text>
+          {description && (
+            <Text style={styles.description} numberOfLines={2}>
+              {description}
+            </Text>
+          )}
+        </View>
+
+        {/* Join Button */}
+        <TouchableOpacity
+          style={[
+            styles.joinButton,
+            buttonState.disabled && styles.joinButtonDisabled,
+            isAlreadyMember && styles.joinButtonJoined,
+          ]}
+          onPress={handleJoin}
+          disabled={buttonState.disabled}
+        >
+          {joinMutation.isPending ? (
+            <ActivityIndicator size="small" color="#fff" />
+          ) : (
+            <Text
+              style={[
+                styles.joinButtonText,
+                buttonState.disabled && styles.joinButtonTextDisabled,
+              ]}
+            >
+              {buttonState.text}
+            </Text>
+          )}
+        </TouchableOpacity>
       </View>
 
-      {/* Space Info */}
-      <View style={styles.infoContainer}>
-        <Text style={styles.spaceName} numberOfLines={1}>
-          {spaceInfo.spaceName}
-        </Text>
-        {description && (
-          <Text style={styles.description} numberOfLines={2}>
-            {description}
-          </Text>
-        )}
-      </View>
-
-      {/* Join Button */}
-      <TouchableOpacity
-        style={[
-          styles.joinButton,
-          buttonState.disabled && styles.joinButtonDisabled,
-          isAlreadyMember && styles.joinButtonJoined,
-        ]}
-        onPress={handleJoin}
-        disabled={buttonState.disabled}
-      >
-        {joinMutation.isPending ? (
-          <ActivityIndicator size="small" color="#fff" />
-        ) : (
-          <Text
-            style={[
-              styles.joinButtonText,
-              buttonState.disabled && styles.joinButtonTextDisabled,
-            ]}
-          >
-            {buttonState.text}
-          </Text>
-        )}
-      </TouchableOpacity>
-
-      {/* Join Error */}
+      {/* Join Error — in normal flow below the row so the card grows to fit it
+          (was absolutely positioned and clipped when the invite was the last
+          message; see issue #20). */}
       {joinMutation.error && (
         <View style={styles.joinErrorContainer}>
           <Text style={styles.joinErrorText}>
@@ -250,8 +255,6 @@ export function InviteLinkCard({
 const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
     container: {
-      flexDirection: 'row',
-      alignItems: 'center',
       backgroundColor: theme.colors.surface3,
       borderRadius: Skin.radius(12),
       borderWidth: Skin.border(1),
@@ -259,6 +262,10 @@ const createStyles = (theme: AppTheme) =>
       padding: Skin.space(12),
       marginTop: Skin.space(8),
       maxWidth: 400,
+    },
+    cardRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
     },
     iconContainer: {
       marginRight: Skin.space(12),
@@ -323,10 +330,7 @@ const createStyles = (theme: AppTheme) =>
       color: theme.colors.warning ?? '#f59e0b',
     },
     joinErrorContainer: {
-      position: 'absolute',
-      bottom: -24,
-      left: 0,
-      right: 0,
+      marginTop: Skin.space(8),
     },
     joinErrorText: {
       fontSize: Skin.font(12),

--- a/components/qns/NameDetailModal.tsx
+++ b/components/qns/NameDetailModal.tsx
@@ -98,9 +98,20 @@ export default function NameDetailModal({
     Alert.alert('Primary Set', `@${name} is now your primary username.`);
   };
 
-  const handleMakeResolvable = async () => {
-    if (!user?.quilibriumAddress || !user?.publicKey || !nameRecord?.ownership?.one_time_key || !nameRecord?.ownership?.verification_key) {
+  /**
+   * Update (set or clear) the public resolve key for this name.
+   * Passing `resolveKey: undefined` makes the name private (unresolvable);
+   * passing the user's ed448 public key makes it publicly resolvable.
+   * The signature is over (name, nameType, timestamp, nonce) in both
+   * directions, so the same signing flow covers resolve and unresolve.
+   */
+  const submitResolveKeyUpdate = async (makeResolvable: boolean) => {
+    if (!user?.quilibriumAddress || !nameRecord?.ownership?.one_time_key || !nameRecord?.ownership?.verification_key) {
       Alert.alert('Error', 'Could not retrieve ownership information.');
+      return;
+    }
+    if (makeResolvable && !user?.publicKey) {
+      Alert.alert('Error', 'Could not retrieve your public key.');
       return;
     }
 
@@ -132,13 +143,20 @@ export default function NameDetailModal({
       updateResolveKey({
         name,
         nameType,
-        resolveKey: user.publicKey, // ed448 public key as hex (57 bytes / 114 hex chars)
+        // Omit the resolve key to make the name private; include the ed448
+        // public key (57 bytes / 114 hex chars) to make it resolvable.
+        resolveKey: makeResolvable ? user.publicKey : undefined,
         signature,
         timestamp,
         nonce,
       }, {
         onSuccess: () => {
-          Alert.alert('Success', `@${name} is now publicly resolvable.`);
+          Alert.alert(
+            'Success',
+            makeResolvable
+              ? `@${name} is now publicly resolvable.`
+              : `@${name} is now private and no longer resolvable.`
+          );
           onRefresh?.();
         },
         onError: (err) => {
@@ -146,8 +164,21 @@ export default function NameDetailModal({
         },
       });
     } catch (err) {
-      Alert.alert('Error', 'Failed to make name resolvable');
+      Alert.alert('Error', makeResolvable ? 'Failed to make name resolvable' : 'Failed to make name private');
     }
+  };
+
+  const handleMakeResolvable = () => submitResolveKeyUpdate(true);
+
+  const handleMakePrivate = () => {
+    Alert.alert(
+      'Make Private',
+      `Stop resolving @${name}? Others will no longer be able to find your address by this name. You keep ownership and can make it resolvable again at any time.`,
+      [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Make Private', style: 'destructive', onPress: () => submitResolveKeyUpdate(false) },
+      ]
+    );
   };
 
   const handleCancelListing = () => {
@@ -402,6 +433,26 @@ export default function NameDetailModal({
               <View style={styles.actionContent}>
                 <Text style={styles.actionText}>Make Resolvable</Text>
                 <Text style={styles.actionSubtext}>Allow others to find your address by name</Text>
+              </View>
+              {isUpdatingResolveKey ? (
+                <ActivityIndicator size="small" color={theme.colors.primary} />
+              ) : (
+                <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
+              )}
+            </TouchableOpacity>
+          )}
+
+          {/* Make Private (stop resolving) — only when currently resolvable */}
+          {isResolvable && (
+            <TouchableOpacity
+              style={styles.actionButton}
+              onPress={handleMakePrivate}
+              disabled={isUpdatingResolveKey}
+            >
+              <IconSymbol name="lock.fill" size={18} color={theme.colors.textMuted} />
+              <View style={styles.actionContent}>
+                <Text style={styles.actionText}>Make Private</Text>
+                <Text style={styles.actionSubtext}>Stop resolving this name (you keep ownership)</Text>
               </View>
               {isUpdatingResolveKey ? (
                 <ActivityIndicator size="small" color={theme.colors.primary} />


### PR DESCRIPTION
Two fixes from the issue triage.

### #51 — User cannot unresolve their QNS name after resolving
The name-detail modal only offered "Make Resolvable" (when a name wasn't yet resolvable); there was no way to stop resolving without transferring. The backend already supported it (`updateResolveKey` with no key makes a name private).

Added a **Make Private** action, shown when the name is currently resolvable. It clears the resolve key through the same signed flow, behind a confirmation Alert that makes clear ownership is retained and the name can be made resolvable again. Refactored the resolve-key logic into one helper (`submitResolveKeyUpdate(makeResolvable)`) shared by both directions instead of duplicating ~50 lines of signing code.

Closes #51

### #20 — Space-invite join error gets clipped
When a Join failed, the error was rendered `position: absolute; bottom: -24`, placing it outside the card's bounds where it got clipped (especially when the invite was the last message). Restructured the card to a column: the icon/info/button stay in a row, and the error now renders in normal flow below it, so the card grows to fit the message. No forced list scroll needed.

Closes #20

### Testing
Type-checks clean (only the pre-existing `services/` noble-v2 errors remain). Fixed an icon name along the way (`lock` → `lock.fill`, the mapped variant). Needs a device pass: see PR discussion for steps.