### PR TITLE
fix: make Add Space tabs scrollable on tall/foldable screens

### DIFF
--- a/components/SpaceModal.tsx
+++ b/components/SpaceModal.tsx
@@ -7,7 +7,7 @@
  */
 
 import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
-import { View, Text, TextInput, StyleSheet, ActivityIndicator, Image } from 'react-native';
+import { View, Text, TextInput, StyleSheet, ActivityIndicator, Image, ScrollView } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { BaseModal } from '@/components/shared';
@@ -219,7 +219,12 @@ export default function SpaceModal({
   );
 
   const renderCreateTab = () => (
-    <View style={styles.tabContent}>
+    <ScrollView
+      style={styles.tabContent}
+      contentContainerStyle={styles.tabContentScroll}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    >
       {/* Space Name */}
       <View style={styles.inputSection}>
         <Text style={styles.label}>Space Name</Text>
@@ -308,11 +313,16 @@ export default function SpaceModal({
           )}
         </TouchableOpacity>
       </View>
-    </View>
+    </ScrollView>
   );
 
   const renderJoinTab = () => (
-    <View style={styles.tabContent}>
+    <ScrollView
+      style={styles.tabContent}
+      contentContainerStyle={styles.tabContentScroll}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+    >
       {/* Validated Space Preview */}
       {validatedSpace && (
         <View style={styles.spacePreview}>
@@ -422,7 +432,7 @@ export default function SpaceModal({
           )}
         </TouchableOpacity>
       </View>
-    </View>
+    </ScrollView>
   );
 
   return (
@@ -467,6 +477,13 @@ const createStyles = (theme: AppTheme, insets: EdgeInsets) =>
     },
     tabContent: {
       flex: 1,
+    },
+    // flexGrow keeps the content filling the sheet on normal phones (so the
+    // actions stay pinned to the bottom via marginTop:'auto'), while letting
+    // it scroll when content + keyboard exceed the sheet height on tall /
+    // foldable screens (issue #7).
+    tabContentScroll: {
+      flexGrow: 1,
     },
     inputSection: {
       marginBottom: Skin.space(16),


### PR DESCRIPTION
### #7 — Large screen devices cannot scroll on Space Creation
On a Samsung Fold 6 (and other tall/foldable screens), the Add Space sheet's content plus the on-screen keyboard could exceed the fixed-height (75%) sheet, clipping the Create/Join buttons at the bottom with no way to scroll to them. `BaseModal` renders its children directly and does not scroll them.

**Fix:** Wrapped both the **Create** and **Join** tab content in a `ScrollView` whose `contentContainerStyle` uses `flexGrow: 1`.

**Why this is regression-safe on normal phones:**
- `flexGrow: 1` makes the content stretch to fill the sheet exactly like the old `flex: 1` View did, so `actions: { marginTop: 'auto' }` still pins the buttons to the bottom — no visual change when content fits.
- The ScrollView only actually scrolls when content overflows (tall screens / keyboard up).
- `keyboardShouldPersistTaps='handled'` keeps the buttons tappable while the keyboard is open.
- This is the same ScrollView-in-BaseModal pattern already proven in `SpaceSettingsModal`, so there's no new gesture contention with the sheet's swipe-to-dismiss.

Closes #7

### Testing
Type-checks clean. See PR notes for the regression-check + the fold-screen verification steps.