### PR TITLE
fix: reaction picker polish + DM reaction count + remove dead online-status toggle

### DIFF
--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -484,6 +484,7 @@ export const DMChatArea = React.memo(function DMChatArea({
         onBookmark={handleBookmarkMessage}
         isBookmarked={isBookmarked}
         onReport={handleReportMessage}
+        isDM
       />
 
       <ChatBottomChrome tabBarHeight={tabBarHeight} surfaceColor={theme.colors.surface1} isDark={theme.dark}>

--- a/components/Chat/EmojiPicker.tsx
+++ b/components/Chat/EmojiPicker.tsx
@@ -257,12 +257,6 @@ interface EmojiPickerProps {
   /** Render inline (no Modal/backdrop) for hosts that already own a modal —
    *  e.g. the audio-space overlay, where a second Modal can't be shown. */
   embedded?: boolean;
-  /** Show the backdrop at full opacity instantly on open (no fade). Used when
-   *  the picker is opened directly from another already-dimmed modal (the
-   *  message action sheet) so there's no undimmed frame between the two
-   *  backdrops — otherwise the screen flashes during the handoff. The panel
-   *  still slides in normally. */
-  instantBackdrop?: boolean;
 }
 
 export function EmojiPicker({
@@ -272,7 +266,6 @@ export function EmojiPicker({
   theme,
   customEmojis = [],
   embedded = false,
-  instantBackdrop = false,
 }: EmojiPickerProps) {
   const { recentEmojis, trackEmoji, refreshRecent } = useEmojiFrecency();
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>(
@@ -294,16 +287,8 @@ export function EmojiPicker({
   useEffect(() => {
     if (visible) {
       setRendered(true);
-      // Opened from the already-dimmed action sheet: snap the backdrop to full
-      // opacity so it covers the exact frame the action sheet's backdrop leaves
-      // (no undimmed flash). A fresh open fades the backdrop in normally.
-      if (instantBackdrop) {
-        backdropAnim.setValue(1);
-      }
       Animated.parallel([
-        ...(instantBackdrop
-          ? []
-          : [Animated.timing(backdropAnim, { toValue: 1, duration: 200, useNativeDriver: true })]),
+        Animated.timing(backdropAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
         Animated.spring(slideAnim, { toValue: 0, useNativeDriver: true, damping: 24, stiffness: 240, mass: 0.8 }),
       ]).start();
     } else {
@@ -314,7 +299,7 @@ export function EmojiPicker({
         if (finished) setRendered(false);
       });
     }
-  }, [visible, backdropAnim, slideAnim, instantBackdrop]);
+  }, [visible, backdropAnim, slideAnim]);
 
   // Refresh recent emojis when picker becomes visible
   useEffect(() => {

--- a/components/Chat/EmojiPicker.tsx
+++ b/components/Chat/EmojiPicker.tsx
@@ -257,6 +257,12 @@ interface EmojiPickerProps {
   /** Render inline (no Modal/backdrop) for hosts that already own a modal —
    *  e.g. the audio-space overlay, where a second Modal can't be shown. */
   embedded?: boolean;
+  /** Show the backdrop at full opacity instantly on open (no fade). Used when
+   *  the picker is opened directly from another already-dimmed modal (the
+   *  message action sheet) so there's no undimmed frame between the two
+   *  backdrops — otherwise the screen flashes during the handoff. The panel
+   *  still slides in normally. */
+  instantBackdrop?: boolean;
 }
 
 export function EmojiPicker({
@@ -266,6 +272,7 @@ export function EmojiPicker({
   theme,
   customEmojis = [],
   embedded = false,
+  instantBackdrop = false,
 }: EmojiPickerProps) {
   const { recentEmojis, trackEmoji, refreshRecent } = useEmojiFrecency();
   const [selectedCategory, setSelectedCategory] = useState<CategoryKey>(
@@ -287,8 +294,16 @@ export function EmojiPicker({
   useEffect(() => {
     if (visible) {
       setRendered(true);
+      // Opened from the already-dimmed action sheet: snap the backdrop to full
+      // opacity so it covers the exact frame the action sheet's backdrop leaves
+      // (no undimmed flash). A fresh open fades the backdrop in normally.
+      if (instantBackdrop) {
+        backdropAnim.setValue(1);
+      }
       Animated.parallel([
-        Animated.timing(backdropAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
+        ...(instantBackdrop
+          ? []
+          : [Animated.timing(backdropAnim, { toValue: 1, duration: 200, useNativeDriver: true })]),
         Animated.spring(slideAnim, { toValue: 0, useNativeDriver: true, damping: 24, stiffness: 240, mass: 0.8 }),
       ]).start();
     } else {
@@ -299,7 +314,7 @@ export function EmojiPicker({
         if (finished) setRendered(false);
       });
     }
-  }, [visible, backdropAnim, slideAnim]);
+  }, [visible, backdropAnim, slideAnim, instantBackdrop]);
 
   // Refresh recent emojis when picker becomes visible
   useEffect(() => {

--- a/components/Chat/EmojiPicker.tsx
+++ b/components/Chat/EmojiPicker.tsx
@@ -6,14 +6,16 @@
  */
 
 import type { AppTheme } from '@/theme';
-import React, { useState, useCallback, useMemo, useEffect } from 'react';
-import { View, Text, ScrollView, StyleSheet, Modal, Pressable, TextInput, Image, Keyboard, Platform } from 'react-native';
+import React, { useState, useCallback, useMemo, useEffect, useRef } from 'react';
+import { View, Text, ScrollView, StyleSheet, Modal, Pressable, TextInput, Image, Keyboard, Platform, Animated, Dimensions } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { IconSymbol } from '@/components/ui/IconSymbol';
 import type { Emoji } from '@quilibrium/quorum-shared';
 import { useEmojiFrecency } from '@/hooks/useEmojiFrecency';
 import { EMOJI_KEYWORDS, searchEmojis } from '@/data/emojiData';
 import * as Skin from '@/theme/skins/geometry';
-import { SegmentedPills, type SegmentedPillItem } from '@/components/ui/SegmentedPills';
+
+const SCREEN_HEIGHT = Dimensions.get('window').height;
 
 // Custom emoji type for the picker (includes isCustom flag for rendering)
 type PickerEmoji = {
@@ -273,6 +275,32 @@ export function EmojiPicker({
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const styles = createStyles(theme, keyboardHeight);
 
+  // Backdrop + panel are animated independently (like BaseModal): the backdrop
+  // fades over the whole screen while only the panel slides up from the bottom.
+  // The native Modal itself uses animationType="none" so it never slides the
+  // backdrop with the content (issue #57). `rendered` keeps the Modal mounted
+  // through the close animation.
+  const [rendered, setRendered] = useState(visible);
+  const backdropAnim = useRef(new Animated.Value(0)).current;
+  const slideAnim = useRef(new Animated.Value(SCREEN_HEIGHT)).current;
+
+  useEffect(() => {
+    if (visible) {
+      setRendered(true);
+      Animated.parallel([
+        Animated.timing(backdropAnim, { toValue: 1, duration: 200, useNativeDriver: true }),
+        Animated.spring(slideAnim, { toValue: 0, useNativeDriver: true, damping: 24, stiffness: 240, mass: 0.8 }),
+      ]).start();
+    } else {
+      Animated.parallel([
+        Animated.timing(backdropAnim, { toValue: 0, duration: 180, useNativeDriver: true }),
+        Animated.timing(slideAnim, { toValue: SCREEN_HEIGHT, duration: 200, useNativeDriver: true }),
+      ]).start(({ finished }) => {
+        if (finished) setRendered(false);
+      });
+    }
+  }, [visible, backdropAnim, slideAnim]);
+
   // Refresh recent emojis when picker becomes visible
   useEffect(() => {
     if (visible) {
@@ -386,15 +414,25 @@ export function EmojiPicker({
     return [...matchedCustom, ...matchedStandard];
   }, [searchQuery, displayEmojis, customPickerEmojis]);
 
-  if (!visible) return null;
+  // Embedded hosts (e.g. audio-space overlay) keep rendering whenever visible;
+  // the Modal branch keeps itself mounted through the close animation via
+  // `rendered`.
+  if (embedded && !visible) return null;
+  if (!embedded && !rendered && !visible) return null;
 
   const panel = (
         <View style={styles.container}>
           {/* Header */}
           <View style={styles.header}>
             <Text style={styles.headerTitle}>Emoji</Text>
-            <TouchableOpacity onPress={onClose} style={styles.closeButton}>
-              <Text style={styles.closeButtonText}>✕</Text>
+            <TouchableOpacity
+              onPress={onClose}
+              style={styles.closeButton}
+              hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+              accessibilityRole="button"
+              accessibilityLabel="Close emoji picker"
+            >
+              <IconSymbol name="xmark" size={18} color={theme.colors.textMuted} />
             </TouchableOpacity>
           </View>
 
@@ -409,29 +447,42 @@ export function EmojiPicker({
             />
           </View>
 
-          {/* Category tabs */}
+          {/* Category tabs — continuous color band with a floating active pill,
+              matching the composer's inline emoji panel (no divider borders). */}
           {!searchQuery && (
-            <SegmentedPills
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
               style={styles.categoryTabs}
               contentContainerStyle={styles.categoryTabsContent}
-              pillShape="rect"
-              emojiSize={22}
-              items={categories.map<SegmentedPillItem>(([key, category]) => ({
-                key,
-                accessibilityLabel: category.name,
-                ...(typeof category.icon === 'string'
-                  ? { emoji: category.icon }
-                  : { leading: category.icon }),
-              }))}
-              activeKey={selectedCategory}
-              onChange={(key) => setSelectedCategory(key as CategoryKey)}
-            />
+              keyboardShouldPersistTaps="always"
+            >
+              {categories.map(([key, category]) => (
+                <TouchableOpacity
+                  key={key}
+                  style={[
+                    styles.categoryTab,
+                    selectedCategory === key && styles.categoryTabActive,
+                  ]}
+                  onPress={() => setSelectedCategory(key as CategoryKey)}
+                  accessibilityRole="button"
+                  accessibilityLabel={category.name}
+                >
+                  {typeof category.icon === 'string' ? (
+                    <Text style={styles.categoryTabEmoji}>{category.icon}</Text>
+                  ) : (
+                    category.icon
+                  )}
+                </TouchableOpacity>
+              ))}
+            </ScrollView>
           )}
 
           {/* Emoji grid */}
           <ScrollView
             style={styles.emojiGrid}
             contentContainerStyle={styles.emojiGridContent}
+            keyboardShouldPersistTaps="always"
           >
             {filteredEmojis.length === 0 ? (
               <Text style={styles.emptyText}>
@@ -470,14 +521,18 @@ export function EmojiPicker({
 
   return (
     <Modal
-      visible={visible}
+      visible={rendered}
       transparent
-      animationType="slide"
+      animationType="none"
       onRequestClose={onClose}
     >
       <View style={styles.overlay}>
-        <Pressable style={styles.backdrop} onPress={onClose} />
-        {panel}
+        <Animated.View style={[styles.backdrop, { opacity: backdropAnim }]}>
+          <Pressable style={StyleSheet.absoluteFill} onPress={onClose} />
+        </Animated.View>
+        <Animated.View style={{ transform: [{ translateY: slideAnim }] }}>
+          {panel}
+        </Animated.View>
       </View>
     </Modal>
   );
@@ -493,9 +548,13 @@ const createStyles = (theme: AppTheme, keyboardHeight: number) => StyleSheet.cre
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
   },
   container: {
-    backgroundColor: theme.colors.surface1 ?? theme.colors.background,
+    // Same surface family as the composer's emoji panel so the reaction picker
+    // reads as the same component in both light/dark schemes.
+    backgroundColor: theme.colors.composerPillBg,
     borderTopLeftRadius: Skin.radius(16),
     borderTopRightRadius: Skin.radius(16),
+    // Clip the search row / category band to the rounded top corners.
+    overflow: 'hidden',
     // Match the visual size of the MessageActionSheet that precedes
     // this picker. The action sheet has no explicit cap and grows to
     // fit ~7-9 rows (Reply, React, Quick React, Edit, Pin, Delete,
@@ -512,8 +571,8 @@ const createStyles = (theme: AppTheme, keyboardHeight: number) => StyleSheet.cre
     alignItems: 'center',
     paddingHorizontal: Skin.space(16),
     paddingVertical: Skin.space(12),
-    borderBottomWidth: Skin.border(1),
-    borderBottomColor: theme.colors.border ?? theme.colors.surface3,
+    // No bottom border — separation comes from the category band's color step
+    // below, matching the composer panel (issue #57).
   },
   headerTitle: {
     fontSize: Skin.font(18),
@@ -523,13 +582,10 @@ const createStyles = (theme: AppTheme, keyboardHeight: number) => StyleSheet.cre
   closeButton: {
     padding: Skin.space(4),
   },
-  closeButtonText: {
-    fontSize: Skin.font(20),
-    color: theme.colors.textMuted,
-  },
   searchContainer: {
     paddingHorizontal: Skin.space(16),
-    paddingVertical: Skin.space(8),
+    paddingTop: Skin.space(4),
+    paddingBottom: Skin.space(8),
   },
   searchInput: {
     backgroundColor: theme.colors.surface2 ?? theme.colors.surface3,
@@ -540,12 +596,30 @@ const createStyles = (theme: AppTheme, keyboardHeight: number) => StyleSheet.cre
     color: theme.colors.textMain,
   },
   categoryTabs: {
-    maxHeight: 44,
-    borderBottomWidth: Skin.border(1),
-    borderBottomColor: theme.colors.border ?? theme.colors.surface3,
+    // Continuous color band (no divider borders), a subtle step off the panel
+    // surface — same treatment as the composer's inline emoji panel.
+    maxHeight: 48,
+    backgroundColor: theme.colors.composerPanelBand,
   },
   categoryTabsContent: {
-    paddingHorizontal: Skin.space(8),
+    paddingHorizontal: Skin.space(6),
+    paddingVertical: Skin.space(6),
+    alignItems: 'center',
+  },
+  categoryTab: {
+    paddingHorizontal: Skin.space(9),
+    paddingVertical: Skin.space(5),
+    marginHorizontal: Skin.space(2),
+    borderRadius: Skin.radius(10),
+  },
+  categoryTabActive: {
+    // Floating pill one step above the band, matching the composer panel.
+    backgroundColor: theme.colors.composerPanelBandActive,
+  },
+  categoryTabEmoji: {
+    fontSize: Skin.font(20),
+    // Explicit line-height so the glyph box is tall enough on Android.
+    lineHeight: Skin.font(26),
   },
   emojiGrid: {
     flex: 1,

--- a/components/Chat/FarcasterDirectMessageView.tsx
+++ b/components/Chat/FarcasterDirectMessageView.tsx
@@ -288,6 +288,7 @@ export function FarcasterDirectMessageView({
         onReply={handleReply}
         onOpenFarcasterCast={onOpenFarcasterCast}
         onLinkPress={onLinkPress}
+        isDM
       />
 
       <ChatBottomChrome tabBarHeight={tabBarHeight} surfaceColor={theme.colors.surface1} isDark={theme.dark}>

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -352,10 +352,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [reactionPickerMessageId, setReactionPickerMessageId] = useState<string | null>(null);
-  // True when the reaction picker was opened directly from the (already-dimmed)
-  // action sheet, so the picker can show its backdrop instantly and avoid a
-  // flash during the handoff.
-  const [reactionPickerFromActionSheet, setReactionPickerFromActionSheet] = useState(false);
   const [actionSheetMessageId, setActionSheetMessageId] = useState<string | null>(null);
   const [editHistoryMessage, setEditHistoryMessage] = useState<DisplayMessage | null>(null);
   // Long-press on a reaction badge opens this modal with pill-filterable
@@ -618,8 +614,6 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     if (onReply || onDelete) {
       setActionSheetMessageId(messageId);
     } else {
-      // Direct open (no action sheet) — fade the backdrop in normally.
-      setReactionPickerFromActionSheet(false);
       setReactionPickerMessageId(messageId);
     }
   }, [onReply, onDelete]);
@@ -651,10 +645,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   }, [actionSheetMessage, onReply]);
 
   const handleReactFromActionSheet = useCallback(() => {
-    // Hand off from the action sheet to the reaction picker. The action sheet
-    // is already dimming the screen; flag the picker to show its backdrop
-    // instantly so there's no undimmed flash between the two modals.
-    setReactionPickerFromActionSheet(true);
+    // Move the message ID to the reaction picker
     setReactionPickerMessageId(actionSheetMessageId);
     setActionSheetMessageId(null);
   }, [actionSheetMessageId]);
@@ -1263,14 +1254,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     />
     <EmojiPicker
       visible={!!reactionPickerMessageId}
-      onClose={() => {
-        setReactionPickerMessageId(null);
-        setReactionPickerFromActionSheet(false);
-      }}
+      onClose={() => setReactionPickerMessageId(null)}
       onSelectEmoji={handleSelectReaction}
       theme={theme}
       customEmojis={customEmojis}
-      instantBackdrop={reactionPickerFromActionSheet}
     />
     <MessageActionSheet
       visible={!!actionSheetMessageId}

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -352,6 +352,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   const styles = useMemo(() => createStyles(theme), [theme]);
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [reactionPickerMessageId, setReactionPickerMessageId] = useState<string | null>(null);
+  // True when the reaction picker was opened directly from the (already-dimmed)
+  // action sheet, so the picker can show its backdrop instantly and avoid a
+  // flash during the handoff.
+  const [reactionPickerFromActionSheet, setReactionPickerFromActionSheet] = useState(false);
   const [actionSheetMessageId, setActionSheetMessageId] = useState<string | null>(null);
   const [editHistoryMessage, setEditHistoryMessage] = useState<DisplayMessage | null>(null);
   // Long-press on a reaction badge opens this modal with pill-filterable
@@ -614,6 +618,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     if (onReply || onDelete) {
       setActionSheetMessageId(messageId);
     } else {
+      // Direct open (no action sheet) — fade the backdrop in normally.
+      setReactionPickerFromActionSheet(false);
       setReactionPickerMessageId(messageId);
     }
   }, [onReply, onDelete]);
@@ -645,7 +651,10 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   }, [actionSheetMessage, onReply]);
 
   const handleReactFromActionSheet = useCallback(() => {
-    // Move the message ID to the reaction picker
+    // Hand off from the action sheet to the reaction picker. The action sheet
+    // is already dimming the screen; flag the picker to show its backdrop
+    // instantly so there's no undimmed flash between the two modals.
+    setReactionPickerFromActionSheet(true);
     setReactionPickerMessageId(actionSheetMessageId);
     setActionSheetMessageId(null);
   }, [actionSheetMessageId]);
@@ -1254,10 +1263,14 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     />
     <EmojiPicker
       visible={!!reactionPickerMessageId}
-      onClose={() => setReactionPickerMessageId(null)}
+      onClose={() => {
+        setReactionPickerMessageId(null);
+        setReactionPickerFromActionSheet(false);
+      }}
       onSelectEmoji={handleSelectReaction}
       theme={theme}
       customEmojis={customEmojis}
+      instantBackdrop={reactionPickerFromActionSheet}
     />
     <MessageActionSheet
       visible={!!actionSheetMessageId}

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -106,6 +106,10 @@ interface MessagesListProps {
    *  message rests above the floating composer + tab bar instead of being
    *  hidden behind them. Older messages still scroll behind the composer. */
   bottomInset?: number;
+  /** True for a 1:1 direct-message conversation. Used to hide the redundant
+   *  reaction count of "1" — in a 2-person chat a single reaction count adds
+   *  no information (issue #29). In spaces the count is always shown. */
+  isDM?: boolean;
 }
 
 export interface MessagesListHandle {
@@ -143,6 +147,7 @@ const ReactionBadge = React.memo(function ReactionBadge({
   styles,
   onToggle,
   onShowDetails,
+  hideCountWhenSingle = false,
 }: {
   reaction: DisplayReaction;
   messageId: string;
@@ -150,7 +155,11 @@ const ReactionBadge = React.memo(function ReactionBadge({
   styles: MessageStyles;
   onToggle: (messageId: string, emoji: string, hasReacted: boolean) => void;
   onShowDetails: (messageId: string) => void;
+  /** In a 1:1 DM, a reaction count of 1 is redundant (only one other person
+   *  could have reacted), so hide the number and show just the emoji (#29). */
+  hideCountWhenSingle?: boolean;
 }) {
+  const showCount = !(hideCountWhenSingle && reaction.count <= 1);
   const handlePress = useCallback(() => {
     onToggle(messageId, reaction.emoji, reaction.hasReacted);
   }, [onToggle, messageId, reaction.emoji, reaction.hasReacted]);
@@ -182,14 +191,16 @@ const ReactionBadge = React.memo(function ReactionBadge({
       ) : (
         <Text style={styles.reactionEmoji}>{reaction.emoji}</Text>
       )}
-      <Text
-        style={[
-          styles.reactionCount,
-          reaction.hasReacted && styles.reactionCountActive,
-        ]}
-      >
-        {reaction.count}
-      </Text>
+      {showCount && (
+        <Text
+          style={[
+            styles.reactionCount,
+            reaction.hasReacted && styles.reactionCountActive,
+          ]}
+        >
+          {reaction.count}
+        </Text>
+      )}
     </TouchableOpacity>
   );
 });
@@ -319,6 +330,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   channelId,
   topInset = 0,
   bottomInset = 0,
+  isDM = false,
 }, ref) {
   const { width: screenWidth } = useWindowDimensions();
   const MESSAGE_IMAGE_MAX_WIDTH = screenWidth - 84;
@@ -703,12 +715,13 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
               styles={styles}
               onToggle={handleToggleReaction}
               onShowDetails={handleShowReactionDetails}
+              hideCountWhenSingle={isDM}
             />
           ))}
         </View>
       );
     },
-    [styles, handleToggleReaction, handleShowReactionDetails, customEmojiMap]
+    [styles, handleToggleReaction, handleShowReactionDetails, customEmojiMap, isDM]
   );
 
   // Render system message (join/leave/kick)

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -4190,17 +4190,10 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             thumbColor={allowSync ? '#ffffff' : '#f4f3f4'}
           />
         </View>
-        <View style={styles.settingRow}>
-          <View style={styles.settingLeft}>
-            <Text style={styles.settingLabel}>Show Online Status</Text>
-            <Text style={styles.settingDescription}>Let others see when you&apos;re active</Text>
-          </View>
-          <Switch
-            value={true}
-            trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
-            thumbColor={'#ffffff'}
-          />
-        </View>
+        {/* "Show Online Status" toggle removed: there is no presence/online-status
+            feature behind it, so the control was a non-functional decoration
+            (hardcoded on, no handler). Re-add a real toggle here if/when presence
+            ships. (issue #58) */}
         {/* Privacy Level — read-only (moved from the old Account Info card). */}
         <View style={styles.settingRow}>
           <View style={styles.settingLeft}>


### PR DESCRIPTION
Three velvilvr iOS issues.

### #57 — Reaction emoji picker: backdrop slides + clumsy dividers
The reaction emoji picker (long-press a message → Add Reaction) is a separate surface from the recently-reworked composer emoji panel, and hadn't been touched. Aligned its **chrome** to the composer panel:
- **Backdrop** now fades in independently while only the panel slides up (was `Modal animationType="slide"`, which dragged the grey backdrop up with the panel). Mirrors `BaseModal`/ProfileModal.
- Removed the **two hairline divider borders** (under the header, under the category band).
- Category strip restyled to the composer's **continuous color band with a floating active pill** (shared `composerPanelBand` / `composerPanelBandActive` / `composerPillBg` tokens). Close button switched to the `xmark` IconSymbol with a hitSlop.

Embedded mode (audio-space overlay) unchanged. Deeper emoji-data unification (People/Travel/Flags divergence) left to the planned lead-gated shared emoji-data-layer task.

**Known minor issue (not addressed here):** opening the picker from the action sheet has a brief flash — two native Modals overlap during the handoff. The proper fix is a single embedded-modal host (the pattern AudioSpaceOverlay already uses); deferred since the flash is very brief.

Closes #57

### #29 — Reaction count "(1)" redundant in 2-person DMs
In a 1:1 DM a reaction count of 1 adds no information. Added a new `isDM` prop threaded through `MessagesList` → `ReactionBadge`; hide the number when `isDM && count <= 1` (emoji still shows). In spaces the count is always shown. Wired on the `<MessagesList>` in both `DMChatArea` and `FarcasterDirectMessageView`.

Closes #29

### #58 — "Show Online Status" toggle is fake
The toggle was hardcoded `value={true}` with no handler and no presence feature behind it. Removed the dead control; a comment marks where to re-add a real toggle if presence ships.

Closes #58

### Testing
Type-checks clean (only pre-existing unrelated errors remain). Device test: long-press → Add Reaction (backdrop fades, no dividers, category band matches composer); react in a 1:1 DM (no "1" — fixed); Settings → Privacy & Sync (no Online Status row).