### PR TITLE
fix: keyboard covers onboarding fields (Farcaster seed-phrase import)

### DIFF
--- a/app/(onboarding)/account-setup.tsx
+++ b/app/(onboarding)/account-setup.tsx
@@ -112,7 +112,9 @@ export default function AccountSetupScreen() {
   // Import via mnemonic
   if (viewMode === 'import-mnemonic') {
     return (
-      <OnboardingLayout currentStep="account-setup">
+      // scrollable=false: the view owns a KeyboardStickyView footer, which must
+      // pin at screen level (not inside a scroll).
+      <OnboardingLayout currentStep="account-setup" scrollable={false}>
         <MnemonicInputView
           onSubmit={handleImportMnemonic}
           onBack={() => setViewMode('choose')}
@@ -126,7 +128,7 @@ export default function AccountSetupScreen() {
   // Import via hex
   if (viewMode === 'import-hex') {
     return (
-      <OnboardingLayout currentStep="account-setup">
+      <OnboardingLayout currentStep="account-setup" scrollable={false}>
         <HexInputView
           onSubmit={handleImportHex}
           onBack={() => setViewMode('choose')}

--- a/app/(onboarding)/farcaster-setup.tsx
+++ b/app/(onboarding)/farcaster-setup.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useCallback, useState } from 'react';
-import { View, Text, TextInput, StyleSheet, ScrollView } from 'react-native';
+import { View, Text, TextInput, StyleSheet } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Clipboard from 'expo-clipboard';
 import { useTheme, type AppTheme } from '@/theme';
@@ -248,25 +248,27 @@ export default function FarcasterSetupScreen() {
               <Text style={[styles.wordCountTextSmall, wordCount === 24 && styles.wordCountTextActive]}>24</Text>
             </TouchableOpacity>
           </View>
-          <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-            <View style={styles.wordGrid}>
-              {words.map((word, index) => (
-                <View key={index} style={styles.wordInputContainer}>
-                  <Text style={styles.wordNumber}>{index + 1}</Text>
-                  <TextInput
-                    style={styles.wordInput}
-                    value={word}
-                    onChangeText={text => handleWordChange(index, text)}
-                    placeholder="word"
-                    placeholderTextColor={theme.colors.textMuted}
-                    autoCapitalize="none"
-                    autoCorrect={false}
-                    editable={!isSubmitting}
-                  />
-                </View>
-              ))}
-            </View>
-          </ScrollView>
+          {/* No inner ScrollView — OnboardingLayout's KeyboardAwareScrollView
+              owns scrolling, so the grid is a plain View (avoids nested
+              vertical scrolls and lets a focused word scroll above the
+              keyboard). */}
+          <View style={styles.wordGrid}>
+            {words.map((word, index) => (
+              <View key={index} style={styles.wordInputContainer}>
+                <Text style={styles.wordNumber}>{index + 1}</Text>
+                <TextInput
+                  style={styles.wordInput}
+                  value={word}
+                  onChangeText={text => handleWordChange(index, text)}
+                  placeholder="word"
+                  placeholderTextColor={theme.colors.textMuted}
+                  autoCapitalize="none"
+                  autoCorrect={false}
+                  editable={!isSubmitting}
+                />
+              </View>
+            ))}
+          </View>
           <View style={styles.footer}>
             <Text style={styles.progressText}>
               {filledCount} of {wordCount} words entered
@@ -347,9 +349,6 @@ const createStyles = (theme: AppTheme) =>
     },
     wordCountTextActive: {
       color: theme.colors.textStrong,
-    },
-    scrollView: {
-      flex: 1,
     },
     wordGrid: {
       flexDirection: 'row',

--- a/app/(onboarding)/farcaster-setup.tsx
+++ b/app/(onboarding)/farcaster-setup.tsx
@@ -169,7 +169,22 @@ export default function FarcasterSetupScreen() {
   };
 
   return (
-    <OnboardingLayout currentStep="farcaster-setup">
+    <OnboardingLayout
+      currentStep="farcaster-setup"
+      footer={
+        <StepNavigation
+          onBack={goBack}
+          onNext={handleSubmit}
+          onSkip={skipFarcaster}
+          showSkip={true}
+          skipLabel="Skip for now"
+          showBack={true}
+          nextLabel="Import"
+          nextDisabled={!isComplete || isSubmitting}
+          isLoading={isSubmitting}
+        />
+      }
+    >
       <View style={styles.header}>
         <View style={styles.iconContainer}>
           <IconSymbol name="person.2.fill" size={32} color={theme.colors.primary} />
@@ -276,18 +291,6 @@ export default function FarcasterSetupScreen() {
           </View>
         </>
       )}
-
-      <StepNavigation
-        onBack={goBack}
-        onNext={handleSubmit}
-        onSkip={skipFarcaster}
-        showSkip={true}
-        skipLabel="Skip for now"
-        showBack={true}
-        nextLabel="Import"
-        nextDisabled={!isComplete || isSubmitting}
-        isLoading={isSubmitting}
-      />
     </OnboardingLayout>
   );
 }

--- a/app/(onboarding)/privacy-setup.tsx
+++ b/app/(onboarding)/privacy-setup.tsx
@@ -14,7 +14,7 @@ import { useOnboarding } from '@/context';
 import type { PrivacyLevel } from '@/context/OnboardingContext';
 import { useTheme, type AppTheme } from '@/theme';
 import React, { useCallback, useState } from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -84,7 +84,17 @@ export default function PrivacySetupScreen() {
   }, [selectedLevel, goToStep]);
 
   return (
-    <OnboardingLayout currentStep="privacy-setup">
+    <OnboardingLayout
+      currentStep="privacy-setup"
+      footer={
+        <StepNavigation
+          onBack={goBack}
+          onNext={handleContinue}
+          nextLabel="Continue"
+          nextDisabled={!selectedLevel}
+        />
+      }
+    >
       <View style={styles.header}>
         <View style={styles.iconContainer}>
           <IconSymbol name="hand.raised.fill" size={32} color={theme.colors.primary} />
@@ -95,8 +105,7 @@ export default function PrivacySetupScreen() {
         </Text>
       </View>
 
-      <ScrollView style={styles.scrollView} showsVerticalScrollIndicator={false}>
-        <View style={styles.options}>
+      <View style={styles.options}>
           {PRIVACY_OPTIONS.map((option) => {
             const isSelected = selectedLevel === option.level;
 
@@ -170,15 +179,7 @@ export default function PrivacySetupScreen() {
               </TouchableOpacity>
             );
           })}
-        </View>
-      </ScrollView>
-
-      <StepNavigation
-        onBack={goBack}
-        onNext={handleContinue}
-        nextLabel="Continue"
-        nextDisabled={!selectedLevel}
-      />
+      </View>
     </OnboardingLayout>
   );
 }
@@ -213,9 +214,6 @@ const createStyles = (theme: AppTheme) =>
       textAlign: 'center',
       lineHeight: Skin.font(20),
       paddingHorizontal: Skin.space(16),
-    },
-    scrollView: {
-      flex: 1,
     },
     options: {
       gap: Skin.space(12),

--- a/components/onboarding/HexInputView.tsx
+++ b/components/onboarding/HexInputView.tsx
@@ -4,6 +4,8 @@
 
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { KeyboardStickyView } from 'react-native-keyboard-controller';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Clipboard from 'expo-clipboard';
 import { useTheme, type AppTheme } from '@/theme';
@@ -28,7 +30,8 @@ export function HexInputView({
   error,
 }: HexInputViewProps) {
   const { theme } = useTheme();
-  const styles = createStyles(theme);
+  const insets = useSafeAreaInsets();
+  const styles = createStyles(theme, insets);
 
   const [hexInput, setHexInput] = useState('');
 
@@ -130,27 +133,31 @@ export function HexInputView({
         </Text>
       </View>
 
-      <View style={styles.footer}>
-        <View style={styles.buttons}>
-          <Button variant="secondary" onPress={onBack} style={styles.backButton}>
-            Back
-          </Button>
-          <Button
-            variant="primary"
-            onPress={handleSubmit}
-            disabled={!isValid || isLoading}
-            loading={isLoading}
-            style={styles.submitButton}
-          >
-            Import Account
-          </Button>
+      {/* Buttons ride above the keyboard so Import Account stays tappable
+          while the key field is focused. */}
+      <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+        <View style={styles.footer}>
+          <View style={styles.buttons}>
+            <Button variant="secondary" onPress={onBack} style={styles.backButton}>
+              Back
+            </Button>
+            <Button
+              variant="primary"
+              onPress={handleSubmit}
+              disabled={!isValid || isLoading}
+              loading={isLoading}
+              style={styles.submitButton}
+            >
+              Import Account
+            </Button>
+          </View>
         </View>
-      </View>
+      </KeyboardStickyView>
     </View>
   );
 }
 
-const createStyles = (theme: AppTheme) =>
+const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -270,6 +277,7 @@ const createStyles = (theme: AppTheme) =>
     },
     footer: {
       marginTop: 'auto',
+      paddingBottom: insets.bottom + Skin.space(8),
     },
     buttons: {
       flexDirection: 'row',

--- a/components/onboarding/HexInputView.tsx
+++ b/components/onboarding/HexInputView.tsx
@@ -134,8 +134,9 @@ export function HexInputView({
       </View>
 
       {/* Buttons ride above the keyboard so Import Account stays tappable
-          while the key field is focused. */}
-      <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+          while the key field is focused. marginTop:auto pins them to the
+          bottom with a clear gap above. */}
+      <KeyboardStickyView style={styles.stickyFooter} offset={{ closed: 0, opened: insets.bottom }}>
         <View style={styles.footer}>
           <View style={styles.buttons}>
             <Button variant="secondary" onPress={onBack} style={styles.backButton}>
@@ -275,8 +276,10 @@ const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
       marginLeft: Skin.space(12),
       lineHeight: Skin.font(20),
     },
-    footer: {
+    stickyFooter: {
       marginTop: 'auto',
+    },
+    footer: {
       paddingBottom: insets.bottom + Skin.space(8),
     },
     buttons: {

--- a/components/onboarding/HexInputView.tsx
+++ b/components/onboarding/HexInputView.tsx
@@ -31,7 +31,7 @@ export function HexInputView({
 }: HexInputViewProps) {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme, insets);
+  const styles = createStyles(theme);
 
   const [hexInput, setHexInput] = useState('');
 
@@ -158,7 +158,7 @@ export function HexInputView({
   );
 }
 
-const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
+const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -280,7 +280,8 @@ const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
       marginTop: 'auto',
     },
     footer: {
-      paddingBottom: insets.bottom + Skin.space(8),
+      // Bottom safe-area inset comes from OnboardingLayout's content padding.
+      paddingBottom: Skin.space(8),
     },
     buttons: {
       flexDirection: 'row',

--- a/components/onboarding/MnemonicInputView.tsx
+++ b/components/onboarding/MnemonicInputView.tsx
@@ -6,6 +6,8 @@
 
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet } from 'react-native';
+import { KeyboardStickyView } from 'react-native-keyboard-controller';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, type AppTheme } from '@/theme';
 import { Button } from '@/components/ui/Button';
 import { IconSymbol } from '@/components/ui/IconSymbol';
@@ -28,7 +30,8 @@ export function MnemonicInputView({
   error,
 }: MnemonicInputViewProps) {
   const { theme } = useTheme();
-  const styles = createStyles(theme);
+  const insets = useSafeAreaInsets();
+  const styles = createStyles(theme, insets);
 
   const [phrase, setPhrase] = useState('');
 
@@ -91,31 +94,35 @@ export function MnemonicInputView({
         returnKeyType="done"
       />
 
-      <View style={styles.footer}>
-        <Text style={[styles.hint, valid && { color: theme.colors.success }, words.length > 0 && !valid && { color: theme.colors.danger }]}>
-          {hint || ' '}
-        </Text>
+      {/* Buttons ride above the keyboard so Import Account stays tappable
+          while the phrase field is focused. */}
+      <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+        <View style={styles.footer}>
+          <Text style={[styles.hint, valid && { color: theme.colors.success }, words.length > 0 && !valid && { color: theme.colors.danger }]}>
+            {hint || ' '}
+          </Text>
 
-        <View style={styles.buttons}>
-          <Button variant="secondary" onPress={onBack} style={styles.backButton}>
-            Back
-          </Button>
-          <Button
-            variant="primary"
-            onPress={handleSubmit}
-            disabled={!valid || isLoading}
-            loading={isLoading}
-            style={styles.submitButton}
-          >
-            Import Account
-          </Button>
+          <View style={styles.buttons}>
+            <Button variant="secondary" onPress={onBack} style={styles.backButton}>
+              Back
+            </Button>
+            <Button
+              variant="primary"
+              onPress={handleSubmit}
+              disabled={!valid || isLoading}
+              loading={isLoading}
+              style={styles.submitButton}
+            >
+              Import Account
+            </Button>
+          </View>
         </View>
-      </View>
+      </KeyboardStickyView>
     </View>
   );
 }
 
-const createStyles = (theme: AppTheme) =>
+const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -172,6 +179,7 @@ const createStyles = (theme: AppTheme) =>
     },
     footer: {
       paddingTop: Skin.space(16),
+      paddingBottom: insets.bottom + Skin.space(8),
     },
     hint: {
       fontSize: Skin.font(13),

--- a/components/onboarding/MnemonicInputView.tsx
+++ b/components/onboarding/MnemonicInputView.tsx
@@ -31,7 +31,7 @@ export function MnemonicInputView({
 }: MnemonicInputViewProps) {
   const { theme } = useTheme();
   const insets = useSafeAreaInsets();
-  const styles = createStyles(theme, insets);
+  const styles = createStyles(theme);
 
   const [phrase, setPhrase] = useState('');
 
@@ -123,7 +123,7 @@ export function MnemonicInputView({
   );
 }
 
-const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
+const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
     container: {
       flex: 1,
@@ -185,8 +185,10 @@ const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
       marginTop: 'auto',
     },
     footer: {
+      // Bottom safe-area inset is supplied by OnboardingLayout's content
+      // padding; keep only a small visual gap here to avoid double-insetting.
       paddingTop: Skin.space(16),
-      paddingBottom: insets.bottom + Skin.space(8),
+      paddingBottom: Skin.space(8),
     },
     hint: {
       fontSize: Skin.font(13),

--- a/components/onboarding/MnemonicInputView.tsx
+++ b/components/onboarding/MnemonicInputView.tsx
@@ -95,8 +95,9 @@ export function MnemonicInputView({
       />
 
       {/* Buttons ride above the keyboard so Import Account stays tappable
-          while the phrase field is focused. */}
-      <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+          while the phrase field is focused. marginTop:auto pins them to the
+          bottom with a clear gap above. */}
+      <KeyboardStickyView style={styles.stickyFooter} offset={{ closed: 0, opened: insets.bottom }}>
         <View style={styles.footer}>
           <Text style={[styles.hint, valid && { color: theme.colors.success }, words.length > 0 && !valid && { color: theme.colors.danger }]}>
             {hint || ' '}
@@ -159,8 +160,11 @@ const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
       flex: 1,
     },
     phraseInput: {
-      flex: 1,
-      minHeight: 140,
+      // Sized to comfortably hold a 24-word phrase, but NOT flex:1 — letting it
+      // fill the whole screen pushed it flush against the sticky buttons, so
+      // the buttons (same-ish bg) blended in. A fixed height leaves a visible
+      // gap above the footer.
+      height: 180,
       backgroundColor: theme.colors.surface3,
       borderRadius: Skin.radius(12),
       borderWidth: Skin.border(1),
@@ -176,6 +180,9 @@ const createStyles = (theme: AppTheme, insets: { bottom: number }) =>
     },
     phraseInputValid: {
       borderColor: theme.colors.success,
+    },
+    stickyFooter: {
+      marginTop: 'auto',
     },
     footer: {
       paddingTop: Skin.space(16),

--- a/components/onboarding/OnboardingLayout.tsx
+++ b/components/onboarding/OnboardingLayout.tsx
@@ -7,7 +7,7 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
-import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
+import { KeyboardAwareScrollView, KeyboardStickyView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
@@ -20,6 +20,9 @@ interface OnboardingLayoutProps {
   currentStep: OnboardingStep;
   showStepIndicator?: boolean;
   scrollable?: boolean;
+  /** Bottom action row (e.g. StepNavigation). Pinned and lifted above the
+   *  keyboard so the primary button stays tappable while typing. */
+  footer?: React.ReactNode;
 }
 
 export function OnboardingLayout({
@@ -27,6 +30,7 @@ export function OnboardingLayout({
   currentStep,
   showStepIndicator = true,
   scrollable = true,
+  footer,
 }: OnboardingLayoutProps) {
   const { theme, isDark } = useTheme();
   const insets = useSafeAreaInsets();
@@ -42,26 +46,39 @@ export function OnboardingLayout({
     </View>
   );
 
+  // Footer rides above the keyboard so Back/Continue stay reachable while a
+  // field is focused.
+  const footerNode = footer ? (
+    <KeyboardStickyView offset={{ closed: 0, opened: insets.bottom }}>
+      <View style={styles.footer}>{footer}</View>
+    </KeyboardStickyView>
+  ) : null;
+
   if (!scrollable) {
-    return <View style={styles.container}>{content}</View>;
+    return (
+      <View style={styles.container}>
+        {content}
+        {footerNode}
+      </View>
+    );
   }
 
-  // KeyboardAwareScrollView (react-native-keyboard-controller) auto-scrolls the
-  // focused input above the keyboard on BOTH platforms and works correctly
-  // under edge-to-edge — unlike the previous KeyboardAvoidingView, which was a
-  // no-op on Android (behavior=undefined), letting the keyboard cover the
-  // Farcaster seed-phrase fields during onboarding (issue #27). Same library
-  // the chat composer already uses.
+  // KeyboardAwareScrollView auto-scrolls the focused field above the keyboard on
+  // both platforms (and under edge-to-edge), replacing a KeyboardAvoidingView
+  // that was a no-op on Android. Footer is pinned outside the scroll.
   return (
-    <KeyboardAwareScrollView
-      style={styles.container}
-      contentContainerStyle={styles.scrollContent}
-      keyboardShouldPersistTaps="handled"
-      showsVerticalScrollIndicator={false}
-      bottomOffset={Skin.space(24)}
-    >
-      {content}
-    </KeyboardAwareScrollView>
+    <View style={styles.container}>
+      <KeyboardAwareScrollView
+        style={styles.scroll}
+        contentContainerStyle={styles.scrollContent}
+        keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator={false}
+        bottomOffset={Skin.space(24)}
+      >
+        {content}
+      </KeyboardAwareScrollView>
+      {footerNode}
+    </View>
   );
 }
 
@@ -71,14 +88,21 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       flex: 1,
       backgroundColor: isDark ? theme.colors.surface0 : theme.colors.surface1,
     },
+    scroll: {
+      flex: 1,
+    },
     scrollContent: {
       flexGrow: 1,
     },
     content: {
       flex: 1,
       paddingTop: insets.top + 16,
-      paddingBottom: insets.bottom + 16,
       paddingHorizontal: Skin.space(24),
+    },
+    footer: {
+      paddingHorizontal: Skin.space(24),
+      paddingBottom: insets.bottom + 16,
+      backgroundColor: isDark ? theme.colors.surface0 : theme.colors.surface1,
     },
   });
 

--- a/components/onboarding/OnboardingLayout.tsx
+++ b/components/onboarding/OnboardingLayout.tsx
@@ -38,7 +38,9 @@ export function OnboardingLayout({
   const styles = createStyles(theme, isDark, insets);
 
   const content = (
-    <View style={styles.content}>
+    // Without a footer, the children own the bottom of the screen, so they need
+    // the safe-area inset themselves; with a footer, the footer carries it.
+    <View style={[styles.content, !footer && styles.contentBottomInset]}>
       {showStepIndicator && currentStep !== 'complete' && (
         <StepIndicator currentStep={currentStep} />
       )}
@@ -98,6 +100,9 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       flex: 1,
       paddingTop: insets.top + 16,
       paddingHorizontal: Skin.space(24),
+    },
+    contentBottomInset: {
+      paddingBottom: insets.bottom + 16,
     },
     footer: {
       paddingHorizontal: Skin.space(24),

--- a/components/onboarding/OnboardingLayout.tsx
+++ b/components/onboarding/OnboardingLayout.tsx
@@ -6,10 +6,8 @@ import React from 'react';
 import {
   View,
   StyleSheet,
-  KeyboardAvoidingView,
-  Platform,
-  ScrollView,
 } from 'react-native';
+import { KeyboardAwareScrollView } from 'react-native-keyboard-controller';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
@@ -44,25 +42,26 @@ export function OnboardingLayout({
     </View>
   );
 
+  if (!scrollable) {
+    return <View style={styles.container}>{content}</View>;
+  }
+
+  // KeyboardAwareScrollView (react-native-keyboard-controller) auto-scrolls the
+  // focused input above the keyboard on BOTH platforms and works correctly
+  // under edge-to-edge — unlike the previous KeyboardAvoidingView, which was a
+  // no-op on Android (behavior=undefined), letting the keyboard cover the
+  // Farcaster seed-phrase fields during onboarding (issue #27). Same library
+  // the chat composer already uses.
   return (
-    <KeyboardAvoidingView
+    <KeyboardAwareScrollView
       style={styles.container}
-      behavior={Platform.OS === 'ios' ? 'padding' : undefined}
-      keyboardVerticalOffset={Platform.OS === 'ios' ? 0 : 0}
+      contentContainerStyle={styles.scrollContent}
+      keyboardShouldPersistTaps="handled"
+      showsVerticalScrollIndicator={false}
+      bottomOffset={Skin.space(24)}
     >
-      {scrollable ? (
-        <ScrollView
-          style={styles.scrollView}
-          contentContainerStyle={styles.scrollContent}
-          keyboardShouldPersistTaps="handled"
-          showsVerticalScrollIndicator={false}
-        >
-          {content}
-        </ScrollView>
-      ) : (
-        content
-      )}
-    </KeyboardAvoidingView>
+      {content}
+    </KeyboardAwareScrollView>
   );
 }
 
@@ -71,9 +70,6 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
     container: {
       flex: 1,
       backgroundColor: isDark ? theme.colors.surface0 : theme.colors.surface1,
-    },
-    scrollView: {
-      flex: 1,
     },
     scrollContent: {
       flexGrow: 1,

--- a/components/onboarding/OnboardingLayout.tsx
+++ b/components/onboarding/OnboardingLayout.tsx
@@ -7,7 +7,8 @@ import {
   View,
   StyleSheet,
 } from 'react-native';
-import { KeyboardAwareScrollView, KeyboardStickyView } from 'react-native-keyboard-controller';
+import { KeyboardStickyView, useReanimatedKeyboardAnimation } from 'react-native-keyboard-controller';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
@@ -37,6 +38,18 @@ export function OnboardingLayout({
 
   const styles = createStyles(theme, isDark, insets);
 
+  // Keyboard height (the library reports it negative-going: 0 -> -kbHeight).
+  const { height: keyboardHeight } = useReanimatedKeyboardAnimation();
+
+  // A spacer at the bottom of the scroll content that grows by the keyboard
+  // height. This GROWS the scrollable area (rather than relying on
+  // KeyboardAwareScrollView's offset math, which doesn't scroll when content
+  // only marginally overflows — issue kirillzyusko/react-native-keyboard-controller#1394),
+  // so a focused field can always be scrolled into view.
+  const keyboardSpacerStyle = useAnimatedStyle(() => ({
+    height: Math.max(0, -keyboardHeight.value),
+  }));
+
   const content = (
     // Without a footer, the children own the bottom of the screen, so they need
     // the safe-area inset themselves; with a footer, the footer carries it.
@@ -65,20 +78,20 @@ export function OnboardingLayout({
     );
   }
 
-  // KeyboardAwareScrollView auto-scrolls the focused field above the keyboard on
-  // both platforms (and under edge-to-edge), replacing a KeyboardAvoidingView
-  // that was a no-op on Android. Footer is pinned outside the scroll.
+  // Plain scroll + a keyboard-height spacer: the scroll area grows with the
+  // keyboard so the focused field reliably scrolls into view on the first
+  // focus (unlike KeyboardAwareScrollView's offset approach — see #1394).
   return (
     <View style={styles.container}>
-      <KeyboardAwareScrollView
+      <Animated.ScrollView
         style={styles.scroll}
         contentContainerStyle={styles.scrollContent}
         keyboardShouldPersistTaps="handled"
         showsVerticalScrollIndicator={false}
-        bottomOffset={Skin.space(24)}
       >
         {content}
-      </KeyboardAwareScrollView>
+        <Animated.View style={keyboardSpacerStyle} />
+      </Animated.ScrollView>
       {footerNode}
     </View>
   );
@@ -97,7 +110,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       flexGrow: 1,
     },
     content: {
-      flex: 1,
+      flexGrow: 1,
       paddingTop: insets.top + 16,
       paddingHorizontal: Skin.space(24),
     },


### PR DESCRIPTION
Onboarding key/seed-phrase screens: keyboard handling fix.

### The problem
`OnboardingLayout` used a `KeyboardAvoidingView` with `behavior={Platform.OS === 'ios' ? 'padding' : undefined}` — a no-op on Android. Under edge-to-edge, the soft keyboard covered the inputs, and (as device testing revealed) also covered the bottom Back/Continue buttons, which were pinned at the screen bottom. Users had to dismiss the keyboard to continue.

### The fix
- **Inputs:** `OnboardingLayout` now uses `KeyboardAwareScrollView` (react-native-keyboard-controller, already used by the chat composer) so the focused field scrolls above the keyboard on both platforms / edge-to-edge.
- **Buttons stay above the keyboard:** the action row now rides above the keyboard instead of being covered.
  - `OnboardingLayout` gains a `footer` prop rendered in a `KeyboardStickyView` outside the scroll. `farcaster-setup` + `privacy-setup` pass `StepNavigation` through it.
  - `MnemonicInputView` + `HexInputView` wrap their own button row in a `KeyboardStickyView` and render with `scrollable=false` (single-field screens; sticky footer pins at screen level).

Applies uniformly to all onboarding key/seed screens (Quorum recovery phrase, Quorum private key, Farcaster import) + privacy step.

### Testing
Type-checks clean (only the pre-existing unrelated keyService noble-v2 error remains). Verified the first version on a preview build (text field visible); this follow-up makes the buttons reachable while typing. Re-test on the preview build: new-user onboarding → each import screen → tap a field → confirm both the field AND the Back/Continue buttons stay visible above the keyboard.