### PR TITLE
perf: smoother Farcaster feed scrolling

### DIFF
--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -4907,9 +4907,13 @@ const FeedPostCard = React.memo(function FeedPostCard({
       <Pressable onPress={navigateToThread} style={styles.postHeader}>
         <TouchableOpacity onPress={navigateToProfile} style={styles.avatarContainer}>
           <ApexAvatarRing active={authorIsApex} size={44}>
-            <Image
+            {/* expo-image: off-thread decode + cache so avatars don't stall scroll. */}
+            <ExpoImage
               source={post.authorAvatar ? { uri: post.authorAvatar } : AVATAR_FALLBACK}
               style={styles.avatar}
+              cachePolicy="memory-disk"
+              recyclingKey={post.authorAvatar ?? `fallback-${post.authorFid}`}
+              transition={0}
             />
           </ApexAvatarRing>
           {!isFollowing && post.authorFid > 0 && (
@@ -5607,6 +5611,11 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
   const handleDeleteCast = useCallback((castHash: string) => {
     void optimistic.deleteCast(castHash);
   }, [optimistic.deleteCast]);
+
+  // Stable ref so FeedPostCard's memo survives extraData (like/recast) changes.
+  const handleFeedImagePress = useCallback((images: string[], index: number) => {
+    setFeedViewerState({ images, index });
+  }, []);
 
   const {
     data: farcasterItems,
@@ -6518,6 +6527,19 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
               // accurate slot positions without measuring during scroll.
               extraData={likeStates}
               keyExtractor={(item) => item.id}
+              // Recycle cells within same-shape pools so a video row isn't
+              // reused as a text row (lighter rebind on scroll).
+              getItemType={(item) =>
+                activeFilter === 'media'
+                  ? 'media-grid'
+                  : item.isProposal
+                    ? 'proposal'
+                    : item.videos.length > 0
+                      ? 'video'
+                      : item.mediaUrls.length > 0
+                        ? 'image'
+                        : 'text'
+              }
               showsVerticalScrollIndicator={false}
               // Let taps reach buttons (e.g. the proposal "Post vote") while a
               // text input's keyboard is open, instead of being swallowed to
@@ -6771,7 +6793,7 @@ function SocialFeedModal({ visible, token, onClose: _onClose, initialThread, ini
                       onOpenChannel={openChannel}
                       onMentionPress={handleMentionPress}
                       onLinkPress={openMiniApp}
-                      onImagePress={(images, index) => setFeedViewerState({ images, index })}
+                      onImagePress={handleFeedImagePress}
                       onLikeToggle={handleLikeToggle}
                       onOpenShareSheet={handleOpenShareSheet}
                       onFollow={handleFollow}


### PR DESCRIPTION
Low-risk perf wins for the Farcaster feed scroll (reported as laggy/wonky on Android). No behavior change — these reduce per-frame work during scroll.

- **Stable `onImagePress`** — was an inline arrow recreated on every render, which broke `FeedPostCard`'s `React.memo` whenever `extraData` changed (i.e. every like/recast), re-rendering all cards. Now a stable `useCallback`.
- **Feed author avatar → expo-image** — was plain RN `Image`, which decodes on the JS thread once per new author URL during scroll. Switched to expo-image (off-thread decode + memory-disk cache + recyclingKey), matching the media components.
- **`getItemType` on the feed list** — lets FlashList recycle cells within same-shape pools (text / image / video / proposal) instead of forcing a full subtree re-render when a recycled cell switches shape.

**Not done (on purpose):** `estimatedItemSize` — removed in FlashList v2 (this repo is on 2.0.2, which auto-measures), so adding it would be a no-op.

### Testing
Type-checks clean. Best validated by scrolling the feed on a mid-range Android device (the reported platform) and comparing smoothness — the change is conservative, so worst case is no visible difference. Addresses the feed-scroll lag report; closing that issue should wait until it's confirmed on-device since it's a perceptual/perf change.