### PR TITLE
fix: Farcaster DMs with no timestamp sort to bottom, not top

### DIFF
--- a/hooks/chat/useFarcasterDirectCasts.ts
+++ b/hooks/chat/useFarcasterDirectCasts.ts
@@ -66,7 +66,10 @@ function toUnifiedConversation(fc: DirectCastConversation, currentUserFid?: numb
   return {
     conversationId: `farcaster:${fc.conversationId}`,
     type: fc.isGroup ? 'group' : 'direct',
-    timestamp: fc.lastMessage?.serverTimestamp ?? Date.now(),
+    // Fall back to 0 (sorts to the bottom), never Date.now() — a conversation
+    // with a missing/last-message-less timestamp must not float to the top of
+    // the inbox as if it were the most recent activity.
+    timestamp: fc.lastMessage?.serverTimestamp ?? 0,
     address: `fid:${counterParty?.fid ?? 0}`,
     icon: iconUrl ?? '',
     displayName: fc.name ?? counterParty?.displayName ?? counterParty?.username ?? 'Unknown',


### PR DESCRIPTION
### #54 — FC DMs show 'now' and stay pinned to the top
A Farcaster DM conversation whose last message lacked a `serverTimestamp` fell back to `Date.now()`, so it perpetually sorted to the top of the inbox at the current time (moving with the clock). The empty-conversation case was already filtered earlier; this closes the remaining missing-timestamp edge by falling back to `0` (sorts to the bottom) instead of `Date.now()`.

Closes #54

### Note
One-line change. Diagnostic logging confirmed unnecessary — the fix is safe regardless of whether the edge currently fires.