### PR TITLE
DM mute background suppression + Save Edit History + chat UI polish

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -216,6 +216,28 @@ export default function DMChatScreen() {
     toggleMute(conversationId);
   }, [conversationId, toggleMute]);
 
+  // Persist a per-conversation setting onto the stored Conversation, then
+  // invalidate both the detail (drives the settings toggles) and the list query.
+  const updateConversationSetting = useCallback(
+    async (patch: Partial<Conversation>) => {
+      if (!conversationId) return;
+      const stored = await storage.getConversation(conversationId);
+      if (!stored) return;
+      await storage.saveConversation({ ...stored, ...patch });
+      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.detail(conversationId) });
+      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
+    },
+    [conversationId, storage, queryClient]
+  );
+
+  // The edit hooks (useEditDirectMessage) read conversation.saveEditHistory and,
+  // when off, drop prior versions instead of accumulating — matching desktop
+  // (default false).
+  const handleToggleEditHistory = useCallback(
+    (value: boolean) => updateConversationSetting({ saveEditHistory: value }),
+    [updateConversationSetting]
+  );
+
   // Delete this conversation locally (DMs are E2E-encrypted, so this only
   // removes it from this device). The confirm lives in DMSettingsSheet; this
   // is the previously-unwired effect. Refresh the conversation list and leave
@@ -414,8 +436,8 @@ export default function DMChatScreen() {
             displayName={title}
             theme={theme}
             onDeleteConversation={handleDeleteConversation}
-            isRepudiable={conversation.isRepudiable}
             saveEditHistory={conversation.saveEditHistory}
+            onToggleEditHistory={handleToggleEditHistory}
             isMuted={conversationMuted}
             onToggleMute={handleToggleMute}
           />

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -140,6 +140,7 @@ export function DMSettingsSheet({
         {onToggleEditHistory && (
           <ActionRowGroup style={styles.group}>
             <ActionRow
+              icon="clock.arrow.circlepath"
               label="Save Edit History"
               sublabel="Keep previous versions of edits"
               trailing={

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -121,8 +121,12 @@ export function DMSettingsSheet({
           </Text>
         </View>
 
-        {onToggleMute && (
-          <ActionRowGroup style={styles.group}>
+        {/* One card, flat list of rows — the canonical ActionRowGroup pattern
+            (see MessageActionSheet and the modal-row audit). The group handles
+            dividers between rows and drops the last one; no arbitrary
+            sub-grouping. */}
+        <ActionRowGroup style={styles.group}>
+          {onToggleMute && (
             <ActionRow
               icon="bell.slash"
               label="Mute Conversation"
@@ -134,11 +138,8 @@ export function DMSettingsSheet({
                 />
               }
             />
-          </ActionRowGroup>
-        )}
-
-        {onToggleEditHistory && (
-          <ActionRowGroup style={styles.group}>
+          )}
+          {onToggleEditHistory && (
             <ActionRow
               icon="clock.arrow.circlepath"
               label="Save Edit History"
@@ -152,10 +153,7 @@ export function DMSettingsSheet({
                 />
               }
             />
-          </ActionRowGroup>
-        )}
-
-        <ActionRowGroup style={styles.group}>
+          )}
           <ActionRow
             icon="arrow.triangle.2.circlepath"
             label="Fix Encryption"

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -25,8 +25,12 @@ interface DMSettingsSheetProps {
   avatarUri?: string;
   address?: string;
   onDeleteConversation?: () => void;
+  /** The "Always sign messages" (repudiability) control is NOT surfaced yet —
+   *  making it functional needs the send-path signing gate + per-message
+   *  composer lock button ported from desktop. Tracked separately; until then
+   *  these props stay optional/unused so a future wire-up is a one-liner. */
   isRepudiable?: boolean;
-  onToggleRepudiable?: (value: boolean) => void;
+  onToggleRepudiable?: (isRepudiable: boolean) => void;
   saveEditHistory?: boolean;
   onToggleEditHistory?: (value: boolean) => void;
   isMuted?: boolean;
@@ -133,34 +137,20 @@ export function DMSettingsSheet({
           </ActionRowGroup>
         )}
 
-        {(onToggleRepudiable || onToggleEditHistory) && (
+        {onToggleEditHistory && (
           <ActionRowGroup style={styles.group}>
-            {onToggleRepudiable && (
-              <ActionRow
-                label="Repudiable Messages"
-                sublabel="Messages can't be proven as yours"
-                trailing={
-                  <Switch
-                    value={isRepudiable ?? false}
-                    onValueChange={onToggleRepudiable}
-                    trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                  />
-                }
-              />
-            )}
-            {onToggleEditHistory && (
-              <ActionRow
-                label="Save Edit History"
-                sublabel="Keep previous versions of edits"
-                trailing={
-                  <Switch
-                    value={saveEditHistory ?? true}
-                    onValueChange={onToggleEditHistory}
-                    trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                  />
-                }
-              />
-            )}
+            <ActionRow
+              label="Save Edit History"
+              sublabel="Keep previous versions of edits"
+              trailing={
+                <Switch
+                  // Default OFF, matching desktop (keeping history is opt-in).
+                  value={saveEditHistory ?? false}
+                  onValueChange={onToggleEditHistory}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                />
+              }
+            />
           </ActionRowGroup>
         )}
 

--- a/components/Chat/EditHistoryModal.tsx
+++ b/components/Chat/EditHistoryModal.tsx
@@ -93,8 +93,11 @@ export const EditHistoryModal = React.memo(function EditHistoryModal({
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
-            {timeline.map((entry, i) => (
-              <View key={`${entry.date}-${entry.index}`} style={styles.editEntry}>
+            {timeline.map((entry) => (
+              <View
+                key={`${entry.date}-${entry.index}`}
+                style={[styles.editCard, entry.isOriginal && styles.originalCard]}
+              >
                 <View style={styles.editHeader}>
                   <Text style={styles.editLabel}>
                     {entry.isOriginal ? 'Original' : `Edit #${entry.index}`}
@@ -104,7 +107,6 @@ export const EditHistoryModal = React.memo(function EditHistoryModal({
                   </Text>
                 </View>
                 <Text style={styles.editText}>{entry.text}</Text>
-                {i < timeline.length - 1 && <View style={styles.divider} />}
               </View>
             ))}
           </ScrollView>
@@ -138,8 +140,6 @@ const createStyles = (theme: AppTheme) =>
       justifyContent: 'space-between',
       paddingHorizontal: Skin.space(20),
       paddingVertical: Skin.space(16),
-      borderBottomWidth: Skin.border(1),
-      borderBottomColor: theme.colors.border ?? theme.colors.surface3,
     },
     headerTitle: {
       fontSize: Skin.font(18),
@@ -156,10 +156,20 @@ const createStyles = (theme: AppTheme) =>
       flexShrink: 1,
     },
     scrollContent: {
-      padding: Skin.space(16),
+      paddingHorizontal: Skin.space(16),
+      paddingTop: Skin.space(4),
+      paddingBottom: Skin.space(16),
+      gap: Skin.space(10),
     },
-    editEntry: {
-      marginBottom: Skin.space(4),
+    editCard: {
+      backgroundColor: theme.colors.surface3,
+      borderRadius: Skin.radius(12),
+      padding: Skin.space(12),
+    },
+    // The Original message is highlighted with a subtle accent-tinted
+    // background so it reads as the baseline the edits diverge from.
+    originalCard: {
+      backgroundColor: theme.colors.accentSoft,
     },
     editHeader: {
       flexDirection: 'row',
@@ -183,11 +193,6 @@ const createStyles = (theme: AppTheme) =>
       fontFamily: theme.fonts.regular.fontFamily,
       color: theme.colors.textMain,
       lineHeight: Skin.font(22),
-    },
-    divider: {
-      height: 1,
-      backgroundColor: theme.colors.border ?? theme.colors.surface3,
-      marginVertical: Skin.space(12),
     },
   });
 

--- a/components/Chat/EditHistoryModal.tsx
+++ b/components/Chat/EditHistoryModal.tsx
@@ -148,7 +148,12 @@ const createStyles = (theme: AppTheme) =>
       color: theme.colors.textStrong,
     },
     scrollView: {
-      flex: 1,
+      // No flex:1 here — the container sizes to its content (capped at
+      // maxHeight 70%), so a flex child would collapse to 0 height and the
+      // body would render blank. Letting the ScrollView size to content makes
+      // it grow with the entries and scroll only once it hits the cap.
+      flexGrow: 0,
+      flexShrink: 1,
     },
     scrollContent: {
       padding: Skin.space(16),

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -251,6 +251,9 @@ export function MessageActionSheet({
                   onPress={handleReply}
                 />
               )}
+              {messageText && (
+                <ActionRow icon="doc.on.doc" label="Copy Text" onPress={handleCopyText} />
+              )}
               {canEdit && onEdit && (
                 <ActionRow icon="pencil" label="Edit Message" onPress={handleEdit} />
               )}
@@ -261,12 +264,8 @@ export function MessageActionSheet({
                   onPress={handleViewEditHistory}
                 />
               )}
-              {canPin && (onPin || onUnpin) && (
-                <ActionRow
-                  icon={isPinned ? 'pin.slash' : 'pin.fill'}
-                  label={isPinned ? 'Unpin Message' : 'Pin Message'}
-                  onPress={handlePin}
-                />
+              {canTranslate && (
+                <ActionRow icon="globe" label="Translate" onPress={handleTranslate} />
               )}
               {onBookmark && (
                 <ActionRow
@@ -275,13 +274,13 @@ export function MessageActionSheet({
                   onPress={handleBookmark}
                 />
               )}
-              {messageText && (
-                <ActionRow icon="doc.on.doc" label="Copy Text" onPress={handleCopyText} />
+              {canPin && (onPin || onUnpin) && (
+                <ActionRow
+                  icon={isPinned ? 'pin.slash' : 'pin'}
+                  label={isPinned ? 'Unpin Message' : 'Pin Message'}
+                  onPress={handlePin}
+                />
               )}
-              {canTranslate && (
-                <ActionRow icon="globe" label="Translate" onPress={handleTranslate} />
-              )}
-              <ActionRow icon="face.smiling" label="Add Reaction" onPress={handleReact} />
               {onReport && (
                 <ActionRow icon="flag" label="Report" destructive onPress={handleReport} />
               )}

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1279,7 +1279,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
       onBookmark={actionSheetMessage?.renderType === 'cast' ? undefined : (onBookmark ? handleBookmarkFromActionSheet : undefined)}
       isBookmarked={actionSheetMessage && actionSheetMessage.renderType !== 'cast' && isBookmarked ? isBookmarked(actionSheetMessage.id) : false}
       onViewEditHistory={actionSheetMessage?.renderType === 'cast' ? undefined : handleViewEditHistory}
-      hasEditHistory={actionSheetMessage?.renderType !== 'cast' && (actionSheetMessage?.isEdited ?? false)}
+      hasEditHistory={actionSheetMessage?.renderType !== 'cast' && (actionSheetMessage?.hasEditHistory ?? false)}
       messageText={actionSheetMessage?.content}
       onReport={onReport ? handleReportFromActionSheet : undefined}
       theme={theme}

--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -106,6 +106,10 @@ export interface DisplayMessage {
   // Edit info
   isEdited?: boolean;
   editedAt?: number;
+  // True only when prior versions are actually retained (saveEditHistory on).
+  // `isEdited` shows the "(edited)" marker on ANY edit; this gates the
+  // "View Edit History" action, which has nothing to show without stored edits.
+  hasEditHistory?: boolean;
   // Reply info
   isReply?: boolean;
   replyToMessageId?: string;
@@ -473,10 +477,18 @@ export function toDisplayMessage(
     displayMessage.reactions = toDisplayReactions(message.reactions, currentUserId);
   }
 
-  // Add edit info
+  // Add edit info. The "(edited)" marker must show on ANY edit, independent of
+  // whether prior versions are retained: a message whose saveEditHistory is off
+  // still bumps modifiedDate past createdDate but carries an empty edits array.
+  // Driving isEdited off edits.length alone would hide the marker for every
+  // history-off edit. hasEditHistory stays tied to the actual stored edits.
   if (message.edits && message.edits.length > 0) {
     displayMessage.isEdited = true;
+    displayMessage.hasEditHistory = true;
     displayMessage.editedAt = message.edits[message.edits.length - 1].modifiedDate;
+  } else if (message.modifiedDate > message.createdDate) {
+    displayMessage.isEdited = true;
+    displayMessage.editedAt = message.modifiedDate;
   }
 
   // Add reply info

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -803,6 +803,8 @@ export default function SpaceSettingsModal({
   const [iconUrl, setIconUrl] = useState('');
   const [bannerUrl, setBannerUrl] = useState('');
   const [isRepudiable, setIsRepudiable] = useState(true);
+  // Default false, matching desktop (keeping edit history is opt-in).
+  const [saveEditHistory, setSaveEditHistory] = useState(false);
 
   // Initialize form when space loads
   useEffect(() => {
@@ -812,6 +814,7 @@ export default function SpaceSettingsModal({
       setIconUrl(space.iconUrl || '');
       setBannerUrl(space.bannerUrl || '');
       setIsRepudiable(space.isRepudiable);
+      setSaveEditHistory(space.saveEditHistory ?? false);
     }
   }, [space]);
 
@@ -885,9 +888,10 @@ export default function SpaceSettingsModal({
       description.trim() !== (space.description || '') ||
       iconUrl !== (space.iconUrl || '') ||
       bannerUrl !== (space.bannerUrl || '') ||
-      isRepudiable !== space.isRepudiable
+      isRepudiable !== space.isRepudiable ||
+      saveEditHistory !== (space.saveEditHistory ?? false)
     );
-  }, [space, spaceName, description, iconUrl, bannerUrl, isRepudiable]);
+  }, [space, spaceName, description, iconUrl, bannerUrl, isRepudiable, saveEditHistory]);
 
   // Handlers
   const handleClose = useCallback(() => {
@@ -912,6 +916,7 @@ export default function SpaceSettingsModal({
         iconUrl: iconUrl || undefined,
         bannerUrl: bannerUrl || undefined,
         isRepudiable,
+        saveEditHistory,
       });
       // Reload space
       const updated = getSpace(spaceId);
@@ -919,7 +924,7 @@ export default function SpaceSettingsModal({
     } catch (error) {
       Alert.alert('Error', 'Failed to save changes');
     }
-  }, [spaceId, spaceName, description, iconUrl, bannerUrl, isRepudiable, nameError, descriptionError, updateSpaceMutation]);
+  }, [spaceId, spaceName, description, iconUrl, bannerUrl, isRepudiable, saveEditHistory, nameError, descriptionError, updateSpaceMutation]);
 
   const handlePickIcon = useCallback(async () => {
     const result = await pickImage('library');
@@ -1416,6 +1421,22 @@ export default function SpaceSettingsModal({
         <Switch
           value={!isRepudiable}
           onValueChange={(value) => setIsRepudiable(!value)}
+          trackColor={{ false: theme.colors.surface4, true: theme.colors.primary }}
+          thumbColor="#fff"
+        />
+      </View>
+
+      {/* Save edit history toggle */}
+      <View style={styles.toggleRow}>
+        <View style={styles.toggleInfo}>
+          <Text style={styles.toggleLabel}>Save Edit History</Text>
+          <Text style={styles.toggleDescription}>
+            When enabled, previous versions of edited messages are kept and can be viewed. When disabled, only the latest version is shown.
+          </Text>
+        </View>
+        <Switch
+          value={saveEditHistory}
+          onValueChange={setSaveEditHistory}
           trackColor={{ false: theme.colors.surface4, true: theme.colors.primary }}
           thumbColor="#fff"
         />

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -805,6 +805,9 @@ export default function SpaceSettingsModal({
   const [isRepudiable, setIsRepudiable] = useState(true);
   // Default false, matching desktop (keeping edit history is opt-in).
   const [saveEditHistory, setSaveEditHistory] = useState(false);
+  // Inline save confirmation for the General tab. Inline (not a toast) because
+  // this sits inside a native modal, mirroring the Apex section above.
+  const [generalSaved, setGeneralSaved] = useState(false);
 
   // Initialize form when space loads
   useEffect(() => {
@@ -921,10 +924,17 @@ export default function SpaceSettingsModal({
       // Reload space
       const updated = getSpace(spaceId);
       setSpace(updated);
+      setGeneralSaved(true);
     } catch (error) {
       Alert.alert('Error', 'Failed to save changes');
     }
   }, [spaceId, spaceName, description, iconUrl, bannerUrl, isRepudiable, saveEditHistory, nameError, descriptionError, updateSpaceMutation]);
+
+  // Clear the "Saved" confirmation as soon as the user edits something again,
+  // so it never lingers next to a now-stale form.
+  useEffect(() => {
+    if (hasGeneralChanges) setGeneralSaved(false);
+  }, [hasGeneralChanges]);
 
   const handlePickIcon = useCallback(async () => {
     const result = await pickImage('library');
@@ -1459,6 +1469,19 @@ export default function SpaceSettingsModal({
           <Text style={styles.saveButtonText}>Save Changes</Text>
         )}
       </TouchableOpacity>
+
+      {generalSaved && !updateSpaceMutation.isPending && (
+        <Text
+          style={{
+            fontSize: Skin.font(13),
+            textAlign: 'center',
+            marginTop: Skin.space(8),
+            color: theme.colors.success ?? '#22c55e',
+          }}
+        >
+          Changes saved.
+        </Text>
+      )}
 
       {/* Quorum Apex — owner-only (the General tab is owner-gated) */}
       <ApexConfigSection spaceAddress={spaceId} theme={theme} styles={styles} />

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -35,6 +35,7 @@ import { recordSpaceActivity } from '@/hooks/chat/useSpaceActivity';
 import { logMentionOrReply } from '@/services/notifications/logMentionOrReply';
 import { shouldNotifyForContext } from '@/services/notifications/notificationPrefs';
 import { messagePreview as getSpaceMessagePreview, messageSenderName } from '@/utils/messagePreview';
+import { applyReceivedEdit } from '@/utils/editHistory';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type {
   Channel,
@@ -1872,7 +1873,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
             if (contentType === 'edit-message') {
               // Update existing message with edit
-              const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number };
+              const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number; editNonce?: string };
 
               // Honor the space's "Save Edit History" setting, matching desktop:
               // when OFF, don't retain prior versions (edits: []). Default false.
@@ -1886,23 +1887,22 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     ...page,
                     messages: page.messages.map((msg) => {
                       if (msg.messageId === editContent.originalMessageId && msg.content.type === 'post') {
+                        const applied = applyReceivedEdit(msg, {
+                          newText: editContent.editedText,
+                          editedAt: editContent.editedAt,
+                          editNonce: editContent.editNonce,
+                          saveEditHistory,
+                        });
+                        if (!applied.changed) return msg;
                         return {
                           ...msg,
-                          modifiedDate: editContent.editedAt,
+                          modifiedDate: applied.modifiedDate,
+                          lastModifiedHash: applied.lastModifiedHash,
                           content: {
                             ...msg.content,
                             text: editContent.editedText,
                           },
-                          edits: saveEditHistory
-                            ? [
-                                ...(msg.edits || []),
-                                {
-                                  text: editContent.editedText,
-                                  modifiedDate: editContent.editedAt,
-                                  lastModifiedHash: '',
-                                },
-                              ]
-                            : [],
+                          edits: applied.edits,
                         };
                       }
                       return msg;
@@ -1916,15 +1916,24 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // query refetches from MMKV.
               const existingMsg = await storage.getMessage({ spaceId, channelId, messageId: editContent.originalMessageId });
               if (existingMsg && existingMsg.content.type === 'post') {
-                const updated: Message = {
-                  ...existingMsg,
-                  modifiedDate: editContent.editedAt,
-                  content: { ...existingMsg.content, text: editContent.editedText },
-                  edits: saveEditHistory
-                    ? [...(existingMsg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }]
-                    : [],
-                };
-                await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
+                const applied = applyReceivedEdit(existingMsg, {
+                  newText: editContent.editedText,
+                  editedAt: editContent.editedAt,
+                  editNonce: editContent.editNonce,
+                  saveEditHistory,
+                });
+                // Skip the write when the edit was already applied — a replayed
+                // edit-message must not clobber stored history.
+                if (applied.changed) {
+                  const updated: Message = {
+                    ...existingMsg,
+                    modifiedDate: applied.modifiedDate,
+                    lastModifiedHash: applied.lastModifiedHash,
+                    content: { ...existingMsg.content, text: editContent.editedText },
+                    edits: applied.edits,
+                  };
+                  await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
+                }
               }
               // Delete edit-message from inbox after processing
               if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
@@ -3322,19 +3331,27 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           }
 
           if (contentType === 'edit-message') {
-            const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number };
+            const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number; editNonce?: string };
             // Honor the space's "Save Edit History" setting, matching desktop:
             // when OFF, don't retain prior versions (edits: []). Default false.
             const saveEditHistory = space?.saveEditHistory ?? false;
             const applyEdit = (msg: Message): Message => {
               if (msg.content.type !== 'post') return msg;
+              const applied = applyReceivedEdit(msg, {
+                newText: editContent.editedText,
+                editedAt: editContent.editedAt,
+                editNonce: editContent.editNonce,
+                saveEditHistory,
+              });
+              // Replayed edit already applied → leave the message untouched so a
+              // duplicate delivery can't wipe stored history.
+              if (!applied.changed) return msg;
               return {
                 ...msg,
-                modifiedDate: editContent.editedAt,
+                modifiedDate: applied.modifiedDate,
+                lastModifiedHash: applied.lastModifiedHash,
                 content: { ...msg.content, text: editContent.editedText },
-                edits: saveEditHistory
-                  ? [...(msg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }]
-                  : [],
+                edits: applied.edits,
               };
             };
             queueCacheTransform(messagesKey, editContent.originalMessageId, applyEdit);

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -1874,6 +1874,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // Update existing message with edit
               const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number };
 
+              // Honor the space's "Save Edit History" setting, matching desktop:
+              // when OFF, don't retain prior versions (edits: []). Default false.
+              const saveEditHistory = space?.saveEditHistory ?? false;
+
               queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
                 if (!old) return old;
                 return {
@@ -1889,14 +1893,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                             ...msg.content,
                             text: editContent.editedText,
                           },
-                          edits: [
-                            ...(msg.edits || []),
-                            {
-                              text: editContent.editedText,
-                              modifiedDate: editContent.editedAt,
-                              lastModifiedHash: '',
-                            },
-                          ],
+                          edits: saveEditHistory
+                            ? [
+                                ...(msg.edits || []),
+                                {
+                                  text: editContent.editedText,
+                                  modifiedDate: editContent.editedAt,
+                                  lastModifiedHash: '',
+                                },
+                              ]
+                            : [],
                         };
                       }
                       return msg;
@@ -1914,7 +1920,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   ...existingMsg,
                   modifiedDate: editContent.editedAt,
                   content: { ...existingMsg.content, text: editContent.editedText },
-                  edits: [...(existingMsg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }],
+                  edits: saveEditHistory
+                    ? [...(existingMsg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }]
+                    : [],
                 };
                 await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
               }
@@ -3315,13 +3323,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
           if (contentType === 'edit-message') {
             const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number };
+            // Honor the space's "Save Edit History" setting, matching desktop:
+            // when OFF, don't retain prior versions (edits: []). Default false.
+            const saveEditHistory = space?.saveEditHistory ?? false;
             const applyEdit = (msg: Message): Message => {
               if (msg.content.type !== 'post') return msg;
               return {
                 ...msg,
                 modifiedDate: editContent.editedAt,
                 content: { ...msg.content, text: editContent.editedText },
-                edits: [...(msg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }],
+                edits: saveEditHistory
+                  ? [...(msg.edits || []), { text: editContent.editedText, modifiedDate: editContent.editedAt, lastModifiedHash: '' }]
+                  : [],
               };
             };
             queueCacheTransform(messagesKey, editContent.originalMessageId, applyEdit);

--- a/hooks/chat/useEditDirectMessage.ts
+++ b/hooks/chat/useEditDirectMessage.ts
@@ -40,6 +40,13 @@ export function useEditDirectMessage() {
         throw new Error('Messages can only be edited within 15 minutes of sending');
       }
 
+      // Honor the conversation's "Save Edit History" setting, matching
+      // desktop (MessageEditTextarea.tsx / MessageService.ts): when OFF, drop
+      // prior versions (edits: []) instead of accumulating. Default false to
+      // match desktop's default everywhere — keeping history is opt-in.
+      const conversation = await storage.getConversation(params.conversationId);
+      const saveEditHistory = conversation?.saveEditHistory ?? false;
+
       // For DMs, editing is local-only (the encrypted message was already sent)
       // We update the local message in storage
       const key = queryKeys.messages.infinite(params.recipientAddress, params.recipientAddress);
@@ -57,14 +64,16 @@ export function useEditDirectMessage() {
                 ...msg.content,
                 text: params.newText,
               } as Message['content'],
-              edits: [
-                ...(msg.edits || []),
-                {
-                  text: params.newText,
-                  modifiedDate: Date.now(),
-                  lastModifiedHash: '',
-                },
-              ],
+              edits: saveEditHistory
+                ? [
+                    ...(msg.edits || []),
+                    {
+                      text: params.newText,
+                      modifiedDate: Date.now(),
+                      lastModifiedHash: '',
+                    },
+                  ]
+                : [],
             };
             await storage.saveMessage(
               updatedMsg,
@@ -91,6 +100,11 @@ export function useEditDirectMessage() {
       // Snapshot previous value
       const previousData = queryClient.getQueryData<InfiniteMessagesData>(key);
 
+      // Same "Save Edit History" gate as the storage write, so the optimistic
+      // cache and persisted message don't diverge (default false → desktop).
+      const conversation = await storage.getConversation(params.conversationId);
+      const saveEditHistory = conversation?.saveEditHistory ?? false;
+
       // Optimistically update the message text in cache
       queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
         if (!old) return old;
@@ -108,14 +122,16 @@ export function useEditDirectMessage() {
                     ...m.content,
                     text: params.newText,
                   },
-                  edits: [
-                    ...(m.edits || []),
-                    {
-                      text: params.newText,
-                      modifiedDate: Date.now(),
-                      lastModifiedHash: '',
-                    },
-                  ],
+                  edits: saveEditHistory
+                    ? [
+                        ...(m.edits || []),
+                        {
+                          text: params.newText,
+                          modifiedDate: Date.now(),
+                          lastModifiedHash: '',
+                        },
+                      ]
+                    : [],
                 };
               }
               return m;

--- a/hooks/chat/useEditDirectMessage.ts
+++ b/hooks/chat/useEditDirectMessage.ts
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth } from '@/context';
 import { useStorageAdapter } from '@/context/StorageContext';
 import { queryKeys, type Message } from '@quilibrium/quorum-shared';
+import { buildLocalEdits } from '@/utils/editHistory';
 
 const EDIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -64,16 +65,7 @@ export function useEditDirectMessage() {
                 ...msg.content,
                 text: params.newText,
               } as Message['content'],
-              edits: saveEditHistory
-                ? [
-                    ...(msg.edits || []),
-                    {
-                      text: params.newText,
-                      modifiedDate: Date.now(),
-                      lastModifiedHash: '',
-                    },
-                  ]
-                : [],
+              edits: buildLocalEdits(msg.edits, params.newText, Date.now(), saveEditHistory),
             };
             await storage.saveMessage(
               updatedMsg,
@@ -122,16 +114,7 @@ export function useEditDirectMessage() {
                     ...m.content,
                     text: params.newText,
                   },
-                  edits: saveEditHistory
-                    ? [
-                        ...(m.edits || []),
-                        {
-                          text: params.newText,
-                          modifiedDate: Date.now(),
-                          lastModifiedHash: '',
-                        },
-                      ]
-                    : [],
+                  edits: buildLocalEdits(m.edits, params.newText, Date.now(), saveEditHistory),
                 };
               }
               return m;

--- a/hooks/chat/useEditSpaceMessage.ts
+++ b/hooks/chat/useEditSpaceMessage.ts
@@ -92,6 +92,15 @@ export function useEditSpaceMessage() {
         messageId: params.messageId,
       });
 
+      // Honor the space's "Save Edit History" setting, matching desktop
+      // (MessageService.ts): when OFF, drop prior versions (edits: []) instead
+      // of accumulating. Default false to match desktop — keeping history is
+      // opt-in. The receive path (WebSocketContext edit-message blocks) applies
+      // the same gate so the sender's own echoed edit and edits from others
+      // stay consistent.
+      const space = await adapter.getSpace(params.spaceId);
+      const saveEditHistory = space?.saveEditHistory ?? false;
+
       const editedAt = Date.now();
 
       // Optimistically update the message text in cache
@@ -113,14 +122,16 @@ export function useEditSpaceMessage() {
                       ...m.content,
                       text: params.newText,
                     },
-                    edits: [
-                      ...(m.edits || []),
-                      {
-                        text: params.newText,
-                        modifiedDate: editedAt,
-                        lastModifiedHash: '',
-                      },
-                    ],
+                    edits: saveEditHistory
+                      ? [
+                          ...(m.edits || []),
+                          {
+                            text: params.newText,
+                            modifiedDate: editedAt,
+                            lastModifiedHash: '',
+                          },
+                        ]
+                      : [],
                   };
                 }
                 return m;
@@ -139,10 +150,12 @@ export function useEditSpaceMessage() {
           ...previousStored,
           modifiedDate: editedAt,
           content: { ...previousStored.content, text: params.newText },
-          edits: [
-            ...(previousStored.edits || []),
-            { text: params.newText, modifiedDate: editedAt, lastModifiedHash: '' },
-          ],
+          edits: saveEditHistory
+            ? [
+                ...(previousStored.edits || []),
+                { text: params.newText, modifiedDate: editedAt, lastModifiedHash: '' },
+              ]
+            : [],
         };
         await adapter.saveMessage(updated, updated.createdDate, '', '', '', '');
       }

--- a/hooks/chat/useEditSpaceMessage.ts
+++ b/hooks/chat/useEditSpaceMessage.ts
@@ -9,6 +9,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth, useWebSocket } from '@/context';
 import { sendEditMessage } from '@/services/space/spaceMessageService';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
+import { buildLocalEdits } from '@/utils/editHistory';
 import type { Message, GetMessagesResult } from '@quilibrium/quorum-shared';
 
 const EDIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
@@ -122,16 +123,7 @@ export function useEditSpaceMessage() {
                       ...m.content,
                       text: params.newText,
                     },
-                    edits: saveEditHistory
-                      ? [
-                          ...(m.edits || []),
-                          {
-                            text: params.newText,
-                            modifiedDate: editedAt,
-                            lastModifiedHash: '',
-                          },
-                        ]
-                      : [],
+                    edits: buildLocalEdits(m.edits, params.newText, editedAt, saveEditHistory),
                   };
                 }
                 return m;
@@ -150,12 +142,7 @@ export function useEditSpaceMessage() {
           ...previousStored,
           modifiedDate: editedAt,
           content: { ...previousStored.content, text: params.newText },
-          edits: saveEditHistory
-            ? [
-                ...(previousStored.edits || []),
-                { text: params.newText, modifiedDate: editedAt, lastModifiedHash: '' },
-              ]
-            : [],
+          edits: buildLocalEdits(previousStored.edits, params.newText, editedAt, saveEditHistory),
         };
         await adapter.saveMessage(updated, updated.createdDate, '', '', '', '');
       }

--- a/services/notifications/pushReceivedTask.ts
+++ b/services/notifications/pushReceivedTask.ts
@@ -20,6 +20,7 @@ import {
   getChannelNotificationsEnabled,
 } from './notificationPrefs';
 import { getSpaceByHubAddress } from '@/services/config/spaceStorage';
+import { isConversationMutedForCurrentUser } from '@/services/config/configService';
 
 // AuthContext stores the user object under this key in MMKV. Inlined
 // here to avoid a circular import — the constant is small and stable.
@@ -80,6 +81,43 @@ if (!taskDefined) {
     }
 
     const hubAddress = inferred.hub_address ?? inferred.hub;
+
+    // Per-DM mute — suppress the native banner for a muted conversation
+    // when the app is woken in the background/killed. The foreground path
+    // (showMessageNotification) already gates on the same mute state; this
+    // closes the background gap. Mirrors the per-space / per-channel gates
+    // below: resolve the routing key locally, check the synced mute list,
+    // bail before checkForNewMessages renders anything.
+    //
+    // The push payload carries only the conversation-specific inbox_address
+    // (E2E: the server can't know the conversationId). Resolve it the same
+    // way the deep-link router does (NotificationService 'inbox' case), via
+    // the per-DM inbox keypair record. MMKV-backed and synchronous, so it
+    // works in this background task.
+    //
+    // Fail open: if the inbox can't be resolved (brand-new / never-decrypted
+    // conversation) we do NOT suppress — better a stray banner than a
+    // silently dropped message.
+    const inboxAddress = inferred.inbox_address ?? inferred.inbox;
+    if (inferred.type === 'inbox' && inboxAddress) {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const cryptoMod = require('@/services/crypto/encryption-state-storage');
+        const encryptionStateStorage = cryptoMod.encryptionStateStorage as {
+          getConversationInboxKeypairByAddress: (
+            addr: string,
+          ) => { conversationId?: string } | null;
+        };
+        const kp = encryptionStateStorage.getConversationInboxKeypairByAddress(inboxAddress);
+        const conversationId = kp?.conversationId;
+        if (conversationId && isConversationMutedForCurrentUser(conversationId)) {
+          return;
+        }
+      } catch {
+        // Lookup failed — fall through and let the normal flow render the
+        // notification rather than risk swallowing a real one.
+      }
+    }
 
     // Per-space mute — anyone can opt out of an entire space.
     // Hub-log pushes carry hub_address; resolve to spaceId locally to

--- a/utils/editHistory.ts
+++ b/utils/editHistory.ts
@@ -1,0 +1,85 @@
+/**
+ * Shared edit-history logic for message edits (DM + space), so the send,
+ * optimistic-cache, and receive paths can't drift apart.
+ *
+ * Mirrors desktop (`MessageService.ts` ~1100-1160):
+ * - `saveEditHistory` OFF  → no prior versions are retained (`edits: []`).
+ * - `saveEditHistory` ON   → the new version is appended to `edits`.
+ * - On the RECEIVE path, a replayed edit-message (same `editNonce` already
+ *   applied) is a no-op so a duplicate delivery can't clobber stored history.
+ *   `lastModifiedHash` records the applied nonce to make that check possible.
+ */
+
+import type { Message } from '@quilibrium/quorum-shared';
+
+type EditEntry = NonNullable<Message['edits']>[number];
+
+/**
+ * Build the `edits` array for an edited message on the SEND / optimistic path,
+ * where the editing device applies its own edit exactly once (no replay risk).
+ *
+ * @param existingEdits prior `edits` on the message (may be undefined)
+ * @param newText       the edited text
+ * @param editedAt      timestamp of this edit
+ * @param saveEditHistory whether to retain prior versions
+ */
+export function buildLocalEdits(
+  existingEdits: Message['edits'] | undefined,
+  newText: string | string[],
+  editedAt: number,
+  saveEditHistory: boolean,
+): EditEntry[] {
+  if (!saveEditHistory) return [];
+  return [
+    ...(existingEdits || []),
+    { text: newText, modifiedDate: editedAt, lastModifiedHash: '' },
+  ];
+}
+
+/** Result of applying a received edit to a stored/cached message. */
+export interface AppliedEdit {
+  /** When false, the edit was already applied — leave the message untouched. */
+  changed: boolean;
+  modifiedDate: number;
+  /** Records the applied nonce so a later replay is detected and skipped. */
+  lastModifiedHash: string;
+  edits: EditEntry[];
+}
+
+/**
+ * Decide how a RECEIVED edit-message should mutate a message's edit metadata.
+ *
+ * Returns `changed: false` when this exact edit (by `editNonce`) was already
+ * applied — the caller must then make NO change, preventing a replayed
+ * edit-message from wiping previously-stored history. When `editNonce` is empty
+ * (legacy senders that don't stamp one) the guard is skipped and the edit is
+ * always applied, matching the prior always-apply behavior.
+ */
+export function applyReceivedEdit(
+  current: { edits?: Message['edits']; lastModifiedHash?: string },
+  params: { newText: string | string[]; editedAt: number; editNonce?: string; saveEditHistory: boolean },
+): AppliedEdit {
+  const { newText, editedAt, editNonce, saveEditHistory } = params;
+
+  // Replay guard: same edit already applied → no-op (don't touch edits).
+  if (editNonce && current.lastModifiedHash === editNonce) {
+    return {
+      changed: false,
+      modifiedDate: editedAt,
+      lastModifiedHash: current.lastModifiedHash ?? '',
+      edits: current.edits ?? [],
+    };
+  }
+
+  return {
+    changed: true,
+    modifiedDate: editedAt,
+    lastModifiedHash: editNonce ?? '',
+    edits: saveEditHistory
+      ? [
+          ...(current.edits || []),
+          { text: newText, modifiedDate: editedAt, lastModifiedHash: editNonce ?? '' },
+        ]
+      : [],
+  };
+}


### PR DESCRIPTION
## Summary

Three related areas of DM/chat work:

### Notifications
- Suppress the native OS notification for a **muted DM** when the app is backgrounded or killed. The foreground path already honored mute; this closes the background gap by checking the synced mute state before the wake-task renders a banner (fails open if the conversation can't be resolved).

### Save Edit History
- The `saveEditHistory` setting now actually takes effect. Previously every edit kept full history regardless of the setting. Now, when off (the default, matching desktop), prior versions are dropped; when on, they accumulate. Applied across the DM edit hook, the space edit hook, and the space edit-message receive paths, centralized in one helper so the paths can't drift.
- Surfaced the **Save Edit History** toggle in the DM conversation settings sheet, and added the matching toggle to **Space Settings** (it was desktop-only before).
- The `(edited)` marker now shows on any edit even when history is off (it was incorrectly tied to the stored-history array); "View Edit History" is gated on actually-retained versions.
- Guard against a replayed edit-message wiping stored history (mirrors desktop's already-applied check).

### Chat UI polish
- Edit History modal: fixed a blank body (a flex child collapsed to zero height), redesigned as boxed cards with the original highlighted, removed separators.
- DM settings sheet: collapsed into one consistent card (no arbitrary row grouping) and gave the Save Edit History row an icon.
- Message action sheet: reordered actions, switched the pin icon to its outline variant, and removed the redundant "Add Reaction" row (the quick-emoji strip's + button already opens the full picker).
- Inline "Changes saved" confirmation on the Space Settings General tab.

## Notes
- No shared-package changes; uses already-published types.
- Translate still uses the globe icon — swapping it to a language glyph needs a new icon added to the shared package first, tracked separately.
- Type-check: no new errors over baseline.