### PR TITLE
Delete own DM messages for everyone (match desktop)

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2421,6 +2421,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         let conversationId = '';
         let decryptedMessage: Message;
 
+        // Session-authenticated sender, captured before the self-sync rewrite
+        // below repoints conversationId to the partner. Used for remove-message auth.
+        let authenticatedDmSender = '';
+
         // Track user profile info (display name, icon) from InitializationEnvelope
         let userProfileFromEnvelope: { displayName?: string; userIcon?: string } | undefined;
 
@@ -2444,6 +2448,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }
 
             conversationId = sessionResult.conversationId;
+            authenticatedDmSender = conversationId.split('/')[0]; // init path never self-sync-rewrites
             userProfileFromEnvelope = sessionResult.userProfile;
 
             // The message should now be properly decrypted plaintext JSON
@@ -2669,6 +2674,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // the conversation should be with the actual recipient (channelId), not ourselves.
           // This matches desktop behavior in MessageService.ts lines 2082-2086
           const senderAddress = conversationId.split('/')[0];
+          authenticatedDmSender = senderAddress; // before the rewrite below
           if (senderAddress === user?.address && decryptedMessage.channelId) {
             const actualRecipient = decryptedMessage.channelId;
             conversationId = `${actualRecipient}/${actualRecipient}`;
@@ -2683,6 +2689,42 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // parse branches above (new-session + subsequent-message) since both
         // converge here. Best-effort: delete from server so it doesn't replay.
         if (await applyDmProfileUpdate(decryptedMessage, senderAddress)) {
+          getDeviceKeyset().then(dk => {
+            if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+          });
+          return;
+        }
+
+        // remove-message on the fallback path (defensive — the batch path folds
+        // these; without this a control message reaching here is a ghost post).
+        if (decryptedMessage.content?.type === 'remove-message') {
+          const removeContent = decryptedMessage.content as RemoveMessage;
+          const targetMsg = await storage.getMessage({
+            spaceId: senderAddress,
+            channelId: senderAddress,
+            messageId: removeContent.removeMessageId,
+          });
+          // Auth: deleter must be the target's author, judged by the
+          // session-authenticated sender, not the spoofable payload senderId.
+          const authorized = removeContent.senderId === authenticatedDmSender &&
+            (!targetMsg || targetMsg.content?.senderId === authenticatedDmSender);
+          if (authorized && targetMsg) {
+            const key = queryKeys.messages.infinite(senderAddress, senderAddress);
+            queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
+              if (!old) return old;
+              return { ...old, pages: old.pages.map((page) => ({
+                ...page,
+                messages: page.messages.filter((m) => m.messageId !== removeContent.removeMessageId),
+              })) };
+            });
+            await storage.deleteMessage(removeContent.removeMessageId);
+            scheduleConversationRefresh(conversationId);
+          } else if (!authorized) {
+            logger.debug(
+              `[DM-fallback] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+            );
+          }
+          // Best-effort: clear the control message from the inbox.
           getDeviceKeyset().then(dk => {
             if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
           });
@@ -3864,14 +3906,73 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           if (originalReactionMsg) {
             const conversationKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(originalReactionMsg.inboxAddress);
             if (conversationKeypair?.signingPrivateKey && conversationKeypair?.signingPublicKey) {
+              // Hex-encode the byte-array keypair to match the signing-key shape
+              // (same as the post path below).
               const signingKey = {
-                publicKey: conversationKeypair.signingPublicKey,
-                privateKey: conversationKeypair.signingPrivateKey,
+                publicKey: bytesToHex(conversationKeypair.signingPublicKey),
+                privateKey: bytesToHex(conversationKeypair.signingPrivateKey),
               };
-              deleteInboxMessages(originalReactionMsg.inboxAddress, [originalReactionMsg.timestamp], signingKey).catch(() => {});
+              deleteConversationInboxMessages(originalReactionMsg.inboxAddress, [originalReactionMsg.timestamp], signingKey).catch(() => {});
             } else {
               getDeviceKeyset().then(dk => {
                 if (dk) deleteInboxMessages(originalReactionMsg.inboxAddress, [originalReactionMsg.timestamp], dk).catch(() => {});
+              });
+            }
+          }
+          continue;
+        }
+
+        // remove-message: delete-for-everyone control message. Fold it (don't
+        // persist as a ghost post), authorizing per the check below.
+        if (dmContentType === 'remove-message') {
+          const removeContent = decryptedMessage.content as RemoveMessage;
+          const targetMsg = await storage.getMessage({
+            spaceId: resolvedSenderAddress,
+            channelId: resolvedSenderAddress,
+            messageId: removeContent.removeMessageId,
+          });
+
+          // Auth: deleter must be the target's author. "Deleter" is the
+          // session-authenticated sender (pre-self-sync `senderAddress`), NOT
+          // the spoofable payload `senderId` — else a peer could claim your
+          // address and delete a message you wrote. Pre-self-sync keeps your own
+          // echo authorized (it's you, deleting your own message).
+          const authenticatedSender = senderAddress;
+          const authorized = removeContent.senderId === authenticatedSender &&
+            (!targetMsg || targetMsg.content?.senderId === authenticatedSender);
+
+          if (authorized && targetMsg) {
+            queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
+              if (!old) return old;
+              return { ...old, pages: old.pages.map(page => ({
+                ...page,
+                messages: page.messages.filter(msg => msg.messageId !== removeContent.removeMessageId),
+              })) };
+            });
+            await storage.deleteMessage(removeContent.removeMessageId);
+            // Refresh the conversation row so its lastMessagePreview isn't stale
+            // when the deleted message was the latest. Matches the fallback path.
+            scheduleConversationRefresh(conversationId);
+          } else if (!authorized) {
+            logger.debug(
+              `[DM] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+            );
+          }
+
+          // Best-effort: delete processed control message from inbox (same as
+          // the reaction branch / the post path below).
+          const originalRemoveMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalRemoveMsg) {
+            const conversationKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(originalRemoveMsg.inboxAddress);
+            if (conversationKeypair?.signingPrivateKey && conversationKeypair?.signingPublicKey) {
+              const signingKey = {
+                publicKey: bytesToHex(conversationKeypair.signingPublicKey),
+                privateKey: bytesToHex(conversationKeypair.signingPrivateKey),
+              };
+              deleteConversationInboxMessages(originalRemoveMsg.inboxAddress, [originalRemoveMsg.timestamp], signingKey).catch(() => {});
+            } else {
+              getDeviceKeyset().then(dk => {
+                if (dk) deleteInboxMessages(originalRemoveMsg.inboxAddress, [originalRemoveMsg.timestamp], dk).catch(() => {});
               });
             }
           }

--- a/hooks/chat/useDeleteDirectMessage.ts
+++ b/hooks/chat/useDeleteDirectMessage.ts
@@ -1,14 +1,25 @@
 /**
- * useDeleteDirectMessage - Hook for deleting direct messages locally
+ * useDeleteDirectMessage - delete your own DM, for everyone (matches desktop).
  *
- * Since DMs are end-to-end encrypted, deletion only removes the message
- * from the current user's device. The other participant will still have
- * the message on their device.
+ * After the optimistic local removal, sends a `remove-message` control message
+ * over the SAME multi-device transport a normal text message uses
+ * (sendEncryptedMessageToAllDevices) — fanning out to every device of the
+ * recipient AND your own other devices, bootstrapping sessions as needed. This
+ * is deliberately NOT the single-session reaction transport, which only reaches
+ * one inbox and so misses devices. Receive-side auth (WebSocketContext) honors
+ * the removal only when the cryptographically-authenticated sender authored the
+ * target.
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useStorageAdapter } from '@/context/StorageContext';
-import { queryKeys, type Message } from '@quilibrium/quorum-shared';
+import { useAuth, useWebSocket } from '@/context';
+import { getQuorumClient } from '@/services/api/quorumClient';
+import { encryptionService } from '@/services/crypto/encryption-service';
+import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
+import { logger, queryKeys } from '@quilibrium/quorum-shared';
+import type { Message, RemoveMessage } from '@quilibrium/quorum-shared';
+import { sendEncryptedMessageToAllDevices } from './useSendDirectMessage';
 
 export interface UseDeleteDirectMessageParams {
   conversationId: string;
@@ -16,16 +27,110 @@ export interface UseDeleteDirectMessageParams {
   messageId: string;
 }
 
+type DeviceInfo = {
+  identityKey: number[];
+  signedPreKey: number[];
+  inboxAddress: string;
+  inboxEncryptionKey: number[];
+};
+
 import type { MessagesPage, InfiniteMessagesData } from './queryTypes';
 
 export function useDeleteDirectMessage() {
   const queryClient = useQueryClient();
   const storage = useStorageAdapter();
+  const { user } = useAuth();
+  const { enqueueOutbound, subscribe } = useWebSocket();
+  const apiClient = getQuorumClient();
 
   return useMutation({
     mutationFn: async (params: UseDeleteDirectMessageParams) => {
-      // Delete from local storage
       await storage.deleteMessage(params.messageId);
+
+      // Best-effort: propagate a `remove-message` control message to the
+      // counterparty and our own devices. A send failure must not undo the
+      // local delete, so swallow errors.
+      try {
+        const senderId = user?.address;
+        if (!senderId) return params.messageId;
+
+        // NOTE: deliberately do NOT gate on isConnected. enqueueOutbound queues
+        // the message and the WS client flushes its queue on (re)connect, so a
+        // transient disconnect must not silently drop the delete. We only need
+        // device keys to be able to encrypt. (A normal text send throws on
+        // !isConnected so the user can retry; a delete has no retry UI, so
+        // dropping it silently is worse — enqueue and let it flush.)
+        if (!encryptionService.hasDeviceKeys()) return params.messageId;
+
+        const deviceKeyset = await getDeviceKeyset();
+        if (!deviceKeyset) return params.messageId;
+
+        const nonce = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          const v = c === 'x' ? r : (r & 0x3) | 0x8;
+          return v.toString(16);
+        });
+        const createdDate = Date.now();
+        const controlMessageId = `${nonce}-${createdDate}`;
+
+        // Control message: transported only, never persisted as a chat row.
+        const message: Message = {
+          messageId: controlMessageId,
+          channelId: params.recipientAddress,
+          spaceId: params.recipientAddress,
+          digestAlgorithm: 'SHA-256',
+          nonce,
+          createdDate,
+          modifiedDate: createdDate,
+          lastModifiedHash: '',
+          content: {
+            type: 'remove-message',
+            senderId,
+            removeMessageId: params.messageId,
+          } as RemoveMessage,
+          reactions: [],
+          mentions: { memberIds: [], roleIds: [], channelIds: [] },
+        };
+
+        // Resolve all target devices the same way a normal DM send does:
+        // recipient's devices + our own OTHER devices. sendEncryptedMessageToAllDevices
+        // also reuses existing sessions and bootstraps new ones per device.
+        const { toAllDeviceInfos } = await import('./useRecipientRegistration');
+        let allTargetDevices: DeviceInfo[] = [];
+        try {
+          const recipientReg = await apiClient.fetchUserRegistration(params.recipientAddress);
+          if (recipientReg) allTargetDevices.push(...toAllDeviceInfos(recipientReg));
+          const senderReg = await apiClient.fetchUserRegistration(senderId);
+          if (senderReg) {
+            allTargetDevices.push(
+              ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
+            );
+          }
+        } catch {
+          // Registration fetch failed — fall through; with no devices the send
+          // is skipped below and the local delete still stands.
+        }
+
+        if (allTargetDevices.length === 0) return params.messageId;
+
+        await sendEncryptedMessageToAllDevices(
+          params.conversationId,
+          params.recipientAddress,
+          message,
+          allTargetDevices,
+          enqueueOutbound,
+          subscribe,
+          {
+            identityPublicKey: deviceKeyset.identityPublicKey,
+            inboxAddress: deviceKeyset.inboxAddress,
+            inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+          },
+          senderId,
+          user?.displayName,
+        );
+      } catch (err) {
+        logger.debug('[useDeleteDirectMessage] remove-message send failed (local delete stands)', err);
+      }
 
       return params.messageId;
     },

--- a/hooks/chat/useSendDirectReaction.ts
+++ b/hooks/chat/useSendDirectReaction.ts
@@ -383,29 +383,14 @@ export function useRemoveDirectReaction() {
 }
 
 /**
- * Send an encrypted reaction message via WebSocket
- * Reuses the same encryption infrastructure as text messages
+ * Encrypt + seal + enqueue a DM control message (reaction, remove-reaction,
+ * remove-message, …). Requires an established session.
  */
-async function sendEncryptedReaction(
+export async function sendEncryptedControlMessage(
   conversationId: string,
   recipientAddress: string,
   message: Message,
-  recipientInfo:
-    | {
-        identityKey: number[];
-        signedPreKey: number[];
-        inboxAddress: string;
-        inboxEncryptionKey: number[];
-      }
-    | undefined,
   enqueueOutbound: (prepareMessage: () => Promise<string[]>) => void,
-  deviceKeyset: {
-    identityPublicKey: number[];
-    inboxAddress: string;
-    inboxEncryptionPublicKey: number[];
-  },
-  userAddress: string,
-  displayName?: string
 ): Promise<void> {
   const { NativeCryptoProvider } = await import('@/services/crypto/native-provider');
   const cryptoProvider = new NativeCryptoProvider();
@@ -413,7 +398,6 @@ async function sendEncryptedReaction(
   enqueueOutbound(async () => {
     const outbounds: string[] = [];
 
-    // Use existing session - reactions should only be sent in established conversations
     const latestState = encryptionStateStorage.getLatestState(conversationId);
     if (!latestState) {
       throw new Error('No encryption session found for conversation');
@@ -428,7 +412,6 @@ async function sendEncryptedReaction(
       throw new Error('Encryption state not found');
     }
 
-    // Encrypt the reaction message
     const encrypted = await encryptWithExistingSession(
       conversationId,
       latestState.inboxId,
@@ -462,11 +445,39 @@ async function sendEncryptedReaction(
 
       outbounds.push(JSON.stringify(sealedMessage));
     } else {
-      throw new Error('No sendingInbox available for sending reaction');
+      throw new Error('No sendingInbox available for sending control message');
     }
 
     return outbounds;
   });
+}
+
+/**
+ * Thin wrapper over sendEncryptedControlMessage, kept for the reaction call
+ * sites' signature (the extra args were never used by the transport).
+ */
+async function sendEncryptedReaction(
+  conversationId: string,
+  recipientAddress: string,
+  message: Message,
+  _recipientInfo:
+    | {
+        identityKey: number[];
+        signedPreKey: number[];
+        inboxAddress: string;
+        inboxEncryptionKey: number[];
+      }
+    | undefined,
+  enqueueOutbound: (prepareMessage: () => Promise<string[]>) => void,
+  _deviceKeyset: {
+    identityPublicKey: number[];
+    inboxAddress: string;
+    inboxEncryptionPublicKey: number[];
+  },
+  _userAddress: string,
+  _displayName?: string
+): Promise<void> {
+  await sendEncryptedControlMessage(conversationId, recipientAddress, message, enqueueOutbound);
 }
 
 /**


### PR DESCRIPTION
## What

Deleting your own DM message now removes it for the other person and on your own other devices, matching desktop's "delete for everyone." Previously mobile only deleted it locally.

## How

**Send** (`useDeleteDirectMessage.ts`)
- After the optimistic local delete, sends a `remove-message` control message through the **same all-devices transport a normal DM uses** (`sendEncryptedMessageToAllDevices`) — reaching every device a normal message reaches, not just one session.
- Does **not** gate the send on `isConnected`: it enqueues and the WS client flushes on reconnect, so a transient disconnect no longer silently drops the delete.

**Receive** (`WebSocketContext.tsx`, both the batch and JS-fallback DM paths)
- Folds an incoming `remove-message` (removes the target; never persists the control message as a chat row).
- **Authorization:** honors the delete only when the message author equals the **cryptographically-authenticated session sender**, not the spoofable `content.senderId` payload field — so a peer cannot delete a message you authored. The authenticated sender is captured *before* the multi-device self-sync rewrite, so your own delete still syncs to your other devices.

**Drive-by fix:** the DM reaction-branch inbox cleanup was calling the wrong helper with unencoded keys (silently no-op'd); now uses `deleteConversationInboxMessages` with hex keys.

## Security note

This includes the receive-side authorization hardening for DM `remove-message`. Desktop is landing the equivalent fix in parallel; the security logic is identical on both platforms. Group-chat (space) delete/edit have the same pattern and are intentionally left for a follow-up (tracked separately) so the two apps stay in agreement.

## Testing

- `tsc` and `eslint` clean on all changed files.
- Reaction send behavior unchanged (the encrypt/send helper was extracted verbatim and reused).
- Normal DM/space receive unaffected (new branches only run for `type === 'remove-message'`).
- Live cross-device propagation could not be confirmed end-to-end due to the pre-existing desktop↔mobile delivery reliability issue (affects normal messages too) — the delete was confirmed leaving mobile correctly and the desktop handler honors it.