### PR TITLE
feat: adopt shared format address

### DIFF
--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -9,6 +9,7 @@ import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import type { Conversation } from '@/hooks/chat';
 import { coerceMessagePreview, previewKindIcon } from '@/utils/messagePreview';
+import { truncateAddress } from '@/utils/formatAddress';
 import React, { useCallback, useMemo } from 'react';
 import { ActivityIndicator, Alert, Image, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
@@ -101,13 +102,7 @@ const DMConversationItem = React.memo(function DMConversationItem({
 
   let displayName = item.displayName;
   if (!displayName && item.address) {
-    if (item.address.startsWith('@')) {
-      displayName = item.address;
-    } else if (item.address.length > 12) {
-      displayName = `${item.address.slice(0, 8)}...${item.address.slice(-4)}`;
-    } else {
-      displayName = item.address;
-    }
+    displayName = truncateAddress(item.address, 'long');
   }
   displayName = displayName || 'Unknown';
 

--- a/components/Chat/MessageMarkdownRenderer.native.tsx
+++ b/components/Chat/MessageMarkdownRenderer.native.tsx
@@ -28,6 +28,7 @@ import {
   shouldUseScrollContainer,
 } from '@quilibrium/quorum-shared';
 import { getEmojiByName } from '@/data/emojiNames';
+import { truncateAddress } from '@/utils/formatAddress';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { haptics } from '@/utils/haptics';
 import * as Skin from '@/theme/skins/geometry';
@@ -350,7 +351,7 @@ function MessageMarkdownRendererBase({
             return <Spoiler key={key} content={node.content} styles={styles} />;
           case 'mention_user': {
             const member = memberByAddress[node.address];
-            const display = member?.display_name || member?.name || truncate(node.address);
+            const display = member?.display_name || member?.name || truncateAddress(node.address);
             if (onMentionPress) {
               return (
                 <Text
@@ -569,11 +570,6 @@ const CodeBlock = React.memo(function CodeBlock({
 // ---------------------------------------------------------------------------
 // Helpers + styles
 // ---------------------------------------------------------------------------
-
-function truncate(address: string): string {
-  if (address.length <= 12) return address;
-  return `${address.slice(0, 6)}…${address.slice(-4)}`;
-}
 
 const createStyles = (theme: AppTheme) =>
   StyleSheet.create({

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -1227,7 +1227,7 @@ export default function ProfileModal({
       // and returns a proper Qm... base58 address
       const address = deriveAddress(hexKey);
       // Truncate for display
-      return `${address.slice(0, 8)}...${address.slice(-6)}`;
+      return truncateAddress(address, 'long');
     } catch {
       return hexKey.slice(0, 16) + '...';
     }
@@ -4346,9 +4346,7 @@ const DeviceKeysSection = React.memo(function DeviceKeysSection({
           {visibleDevices.map((device) => {
             const isCurrentDevice = device.inbox_registration.inbox_address === currentDeviceInboxAddress;
             const inboxAddr = device.inbox_registration.inbox_address;
-            const displayAddr = inboxAddr.length > 16
-              ? `${inboxAddr.slice(0, 8)}...${inboxAddr.slice(-6)}`
-              : inboxAddr;
+            const displayAddr = truncateAddress(inboxAddr, 'long');
 
             return (
               <View key={device.identity_public_key} style={styles.deviceItem}>

--- a/components/ShareInviteSheet.tsx
+++ b/components/ShareInviteSheet.tsx
@@ -14,6 +14,7 @@
 
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
+import { truncateAddress } from '@/utils/formatAddress';
 import { ActionRow, ActionRowGroup } from '@/components/shared';
 import { useToast } from '@/context/ToastContext';
 import { useConversations } from '@/hooks/chat/useConversations';
@@ -169,8 +170,8 @@ export default function ShareInviteSheet({
                         style={styles.avatar}
                       />
                     }
-                    label={conv.displayName || conv.address.slice(0, 12)}
-                    sublabel={`${conv.address.slice(0, 16)}…`}
+                    label={conv.displayName || truncateAddress(conv.address)}
+                    sublabel={truncateAddress(conv.address, 'medium')}
                     trailing={
                       sending ? (
                         <ActivityIndicator size="small" color={theme.colors.accent} />

--- a/components/SocialFeedModal.tsx
+++ b/components/SocialFeedModal.tsx
@@ -1,4 +1,5 @@
 import { useMiniappOverlay } from '@/context/MiniappOverlayContext';
+import { truncateAddress } from '@/utils/formatAddress';
 import ComposeChannelPickerModal from '@/components/ComposeChannelPickerModal';
 import { InviteLinkCard, containsInviteLink } from '@/components/Chat/InviteLinkCard';
 import type { ComposeCastOptions, ComposeCastResult } from '@/services/miniapp';
@@ -716,7 +717,7 @@ function ShareToChatModal({
                           }
                           label={
                             conv.displayName ||
-                            (isFarcaster ? conv.farcasterUsername : conv.address?.slice(0, 12) + '...') ||
+                            (isFarcaster ? conv.farcasterUsername : truncateAddress(conv.address)) ||
                             'Unknown'
                           }
                           sublabel={showHandle ? `@${conv.farcasterUsername}` : undefined}

--- a/services/notifications/sharedKeystore.ts
+++ b/services/notifications/sharedKeystore.ts
@@ -16,6 +16,7 @@
  */
 
 import { Platform } from 'react-native';
+import { truncateAddress } from '@/utils/formatAddress';
 import { getAllSpaces, getSpaceKey } from '@/services/config/spaceStorage';
 import { encryptionStateStorage } from '@/services/crypto/encryption-state-storage';
 import { storage as mmkv } from '@/services/offline/storage';
@@ -125,7 +126,7 @@ function buildDMCatalog(): Record<string, CatalogEntryDM> {
       conv?.metadata?.displayName ||
       // Fallback: if metadata isn't populated, show the truncated
       // remote address rather than the inbox address.
-      (conv?.participants?.[0] ? `${conv.participants[0].slice(0, 6)}…` : 'Direct message');
+      (conv?.participants?.[0] ? truncateAddress(conv.participants[0]) : 'Direct message');
     out[inboxAddress] = { display_name: display };
   }
   return out;

--- a/utils/formatAddress.ts
+++ b/utils/formatAddress.ts
@@ -1,10 +1,26 @@
-import { Dimensions } from 'react-native';
+// Address/name truncation helpers for display.
+//
+// The actual address slicing is delegated to the canonical, Qm-aware
+// `formatAddress` in @quilibrium/quorum-shared so a given preset renders
+// IDENTICALLY on desktop and mobile. The old device-width `scaleFactor`
+// (which scaled leading chars by phone size, not by the label's container)
+// has been dropped for true cross-platform parity.
+//
+// `formatAddress(address, start, end)` keeps the constant `Qm` CIDv0 prefix
+// visible but counts `start` AFTER it, so `start`/`end` are meaningful entropy
+// chars. See the shared helper's docstring for the full rationale.
+import { formatAddress } from '@quilibrium/quorum-shared';
 
-const { width: SCREEN_WIDTH } = Dimensions.get('window');
+// Re-export the canonical helper so call sites can use it directly.
+export { formatAddress };
 
-// Scale factor: iPhone 15 Pro is 393pt wide. Larger screens get more chars.
-const BASE_WIDTH = 393;
-const scaleFactor = Math.min(SCREEN_WIDTH / BASE_WIDTH, 1.5);
+// Fixed start/end pairs per mode, frozen from the old phone (scaleFactor ≈ 1.0)
+// values and matching desktop's presets.
+const MODES = {
+  short: [4, 3],
+  medium: [6, 4],
+  long: [8, 6],
+} as const;
 
 export function truncateAddress(
   address: string | undefined,
@@ -13,33 +29,11 @@ export function truncateAddress(
   if (!address) return 'Unknown';
   if (address.startsWith('@')) return address;
 
-  const lengths = {
-    short:  { start: Math.round(4 * scaleFactor), end: 3 },
-    medium: { start: Math.round(6 * scaleFactor), end: 4 },
-    long:   { start: Math.round(8 * scaleFactor), end: 6 },
-  };
-
-  const { start, end } = lengths[mode];
-  const minFull = start + end + 3;
-
-  if (address.length <= minFull) return address;
-  return `${address.slice(0, start)}\u2026${address.slice(-end)}`;
+  const [start, end] = MODES[mode];
+  return formatAddress(address, start, end);
 }
 
-/**
- * Format address for display (shortened) using a character count.
- * Shows the first and last `chars` characters separated by an ellipsis.
- */
-export function formatAddress(address: string, chars: number = 6): string {
-  if (address.length <= chars * 2) return address;
-  return `${address.slice(0, chars)}\u2026${address.slice(-chars)}`;
-}
-
-export function truncateName(
-  name: string,
-  maxLength?: number,
-): string {
-  const max = maxLength ?? Math.round(16 * scaleFactor);
-  if (name.length <= max) return name;
-  return `${name.slice(0, max)}\u2026`;
+export function truncateName(name: string, maxLength: number = 16): string {
+  if (name.length <= maxLength) return name;
+  return `${name.slice(0, maxLength)}…`;
 }


### PR DESCRIPTION
Delegate `truncateAddress` to the canonical Qm-aware `formatAddress` from `@quilibrium/quorum-shared` so a given preset renders identically on desktop and mobile.

Modes now map to fixed start/end pairs (short 4/3, medium 6/4, long 8/6) instead of scaling the leading char count by device width (the dropped `scaleFactor`). This gives true cross-platform parity and removes the one non-portable, RN-only piece.

Also migrates the inline Quilibrium-address truncation sites onto `truncateAddress` and standardizes on the Unicode ellipsis:
- DM conversation list
- message `@mention` fallback (markdown renderer)
- profile account/device addresses + resolved-key address
- social-feed share-to-chat rows and invite share sheet
- notification DM catalog

Wallet, QNS, tx-hash and other non-`Qm` addresses are intentionally left untouched. `truncateName` loses its `scaleFactor`-scaled default (now fixed 16).