### PR TITLE
Message signing controls for DMs and spaces

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -238,6 +238,13 @@ export default function DMChatScreen() {
     [updateConversationSetting]
   );
 
+  // "Always sign messages" persists the inverse as isRepudiable. The send path
+  // and composer lock read it back from the conversation.
+  const handleToggleRepudiable = useCallback(
+    (value: boolean) => updateConversationSetting({ isRepudiable: value }),
+    [updateConversationSetting]
+  );
+
   // Delete this conversation locally (DMs are E2E-encrypted, so this only
   // removes it from this device). The confirm lives in DMSettingsSheet; this
   // is the previously-unwired effect. Refresh the conversation list and leave
@@ -436,6 +443,8 @@ export default function DMChatScreen() {
             displayName={title}
             theme={theme}
             onDeleteConversation={handleDeleteConversation}
+            isRepudiable={conversation.isRepudiable}
+            onToggleRepudiable={handleToggleRepudiable}
             saveEditHistory={conversation.saveEditHistory}
             onToggleEditHistory={handleToggleEditHistory}
             isMuted={conversationMuted}

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -106,6 +106,8 @@ export const DMChatArea = React.memo(function DMChatArea({
   const [replyToMessage, setReplyToMessage] = useState<{ messageId: string; senderName: string; text: string; authorId: string } | null>(null);
   const [editingMessage, setEditingMessage] = useState<EditingMessage | null>(null);
   const [bookmarksPanelVisible, setBookmarksPanelVisible] = useState(false);
+  // Per-message signing lock; only meaningful when the conversation is repudiable.
+  const [skipSigning, setSkipSigning] = useState(false);
 
   const dmMessagesListRef = useRef<MessagesListHandle>(null);
   const dmMessageInputRef = useRef<MessageInputHandle>(null);
@@ -295,13 +297,15 @@ export const DMChatArea = React.memo(function DMChatArea({
         repliesToMessageId: replyToMessage?.messageId,
         replyToAuthorAddress: replyToMessage?.authorId,
         recipientInfo,
+        isRepudiable: conversationData.isRepudiable,
+        skipSigning,
       }, {
         onSettled: refocusInput,
       });
       setMessageText('');
       setReplyToMessage(null);
     }
-  }, [conversationId, recipientAddress, sendDirectMessageMutation, sendDirectEmbedMutation, hasExistingSession, recipientRegistration, messageText, pendingAttachment, replyToMessage, editingMessage, editDirectMessageMutation, dmMessagesPages, draftsRef]);
+  }, [conversationId, recipientAddress, sendDirectMessageMutation, sendDirectEmbedMutation, hasExistingSession, recipientRegistration, messageText, pendingAttachment, replyToMessage, editingMessage, editDirectMessageMutation, dmMessagesPages, draftsRef, conversationData.isRepudiable, skipSigning]);
 
   const handleAttachmentPress = useCallback(async () => {
     const result = await pickImage('library');
@@ -506,6 +510,9 @@ export const DMChatArea = React.memo(function DMChatArea({
           onDismissReply={handleDismissReply}
           editingMessage={editingMessage}
           onCancelEdit={handleCancelEdit}
+          signingOptional={!!conversationData.isRepudiable}
+          skipSigning={skipSigning}
+          onToggleSkipSigning={() => setSkipSigning((s) => !s)}
         />
       </ChatBottomChrome>
 

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -283,6 +283,8 @@ export const DMChatArea = React.memo(function DMChatArea({
         height: pendingAttachment.height,
         text: messageText.trim() || undefined,
         recipientInfo,
+        isRepudiable: conversationData.isRepudiable,
+        skipSigning,
       }, {
         onSettled: refocusInput,
       });

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -25,10 +25,8 @@ interface DMSettingsSheetProps {
   avatarUri?: string;
   address?: string;
   onDeleteConversation?: () => void;
-  /** The "Always sign messages" (repudiability) control is NOT surfaced yet —
-   *  making it functional needs the send-path signing gate + per-message
-   *  composer lock button ported from desktop. Tracked separately; until then
-   *  these props stay optional/unused so a future wire-up is a one-liner. */
+  /** Repudiability. The UI shows the inverse ("Always sign messages"): signing
+   *  ON ⇔ isRepudiable false. Unset ⇒ signed by default. */
   isRepudiable?: boolean;
   onToggleRepudiable?: (isRepudiable: boolean) => void;
   saveEditHistory?: boolean;
@@ -134,6 +132,21 @@ export function DMSettingsSheet({
                 <Switch
                   value={isMuted ?? false}
                   onValueChange={onToggleMute}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                />
+              }
+            />
+          )}
+          {onToggleRepudiable && (
+            <ActionRow
+              icon="lock.fill"
+              label="Always sign messages"
+              sublabel="Proves messages come from your key"
+              trailing={
+                <Switch
+                  // ON ⇔ signed ⇔ isRepudiable false. Default ON.
+                  value={!(isRepudiable ?? false)}
+                  onValueChange={(signOn) => onToggleRepudiable(!signOn)}
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
                 />
               }

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -148,6 +148,7 @@ export function DMSettingsSheet({
                   value={!(isRepudiable ?? false)}
                   onValueChange={(signOn) => onToggleRepudiable(!signOn)}
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  thumbColor="#fff"
                 />
               }
             />

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -86,6 +86,12 @@ interface MessageInputProps {
   castReplyAvailable?: boolean;
   alsoReplyOnFarcaster?: boolean;
   onToggleAlsoReplyOnFarcaster?: (next: boolean) => void;
+  /** Show the per-message signing lock button. Only true when the conversation/
+   *  space left signing optional (DM: isRepudiable; Space: space.isRepudiable). */
+  signingOptional?: boolean;
+  /** Lock open ⇒ this message will be sent unsigned (repudiable). */
+  skipSigning?: boolean;
+  onToggleSkipSigning?: () => void;
 }
 
 export interface MessageInputHandle {
@@ -257,6 +263,9 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   castReplyAvailable = false,
   alsoReplyOnFarcaster = false,
   onToggleAlsoReplyOnFarcaster,
+  signingOptional = false,
+  skipSigning = false,
+  onToggleSkipSigning,
 }, ref) {
   const { width: screenWidth } = useWindowDimensions();
   const styles = useMemo(() => createStyles(theme), [theme]);
@@ -1113,6 +1122,24 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
               strokeWidth={1.5}
             />
           </TouchableOpacity>
+          {/* Per-message signing lock — only when the conversation/space allows
+              opt-out. Closed lock = signed (default), open = repudiable. */}
+          {signingOptional && (
+            <TouchableOpacity
+              style={styles.inputIconButton}
+              onPress={onToggleSkipSigning}
+              disabled={disabled}
+              accessibilityRole="button"
+              accessibilityLabel={skipSigning ? 'Message signing off (unsigned)' : 'Message signing on (signed)'}
+            >
+              <IconSymbol
+                name={skipSigning ? 'lock.open' : 'lock.fill'}
+                color={skipSigning ? theme.colors.textMuted : theme.colors.primary}
+                size={24}
+                strokeWidth={1.5}
+              />
+            </TouchableOpacity>
+          )}
         </View>
 
         <TextInput

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -1188,13 +1188,14 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
                 style={styles.inputIconButton}
                 onPress={handleToggleSigning}
                 disabled={disabled || isComposing}
+                hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
                 accessibilityRole="button"
                 accessibilityLabel={skipSigning ? 'Message signing off (unsigned)' : 'Message signing on (signed)'}
               >
                 <IconSymbol
                   name={skipSigning ? 'lock.open' : 'lock'}
                   color={skipSigning ? theme.colors.textMuted : theme.colors.primary}
-                  size={25}
+                  size={27}
                   strokeWidth={1.5}
                 />
               </TouchableOpacity>

--- a/components/Chat/MessageInput.tsx
+++ b/components/Chat/MessageInput.tsx
@@ -669,6 +669,20 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
   // when the input is empty. Emoji toggle always stays.
   const isComposing = value.trim().length > 0;
 
+  // Brief feedback pill shown above the composer when the signing lock is tapped.
+  const [signingHint, setSigningHint] = useState<string | null>(null);
+  const signingHintTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(() => () => {
+    if (signingHintTimer.current) clearTimeout(signingHintTimer.current);
+  }, []);
+  const handleToggleSigning = useCallback(() => {
+    onToggleSkipSigning?.();
+    // skipSigning is the value BEFORE the toggle, so invert it for the new state.
+    setSigningHint(skipSigning ? 'Messages will be signed' : "Messages won't be signed");
+    if (signingHintTimer.current) clearTimeout(signingHintTimer.current);
+    signingHintTimer.current = setTimeout(() => setSigningHint(null), 1800);
+  }, [onToggleSkipSigning, skipSigning]);
+
   // --- Composer focus/compose micro-animations ---------------------------
   // Two driven progress values so the transitions are smooth instead of
   // snapping:
@@ -934,6 +948,20 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
           + attachment preview + autocomplete anchor + pill). Measured so the
           chat list can lift to clear the composer exactly in every state. */}
       <View onLayout={handleFootprintLayout}>
+      {/* Brief signing-state feedback when the lock is tapped. */}
+      {signingHint && (
+        <View style={styles.signingHintRow} pointerEvents="none">
+          <View style={styles.signingHintPill}>
+            <IconSymbol
+              name={skipSigning ? 'lock.open' : 'lock'}
+              size={13}
+              color={theme.colors.textSubtle}
+              strokeWidth={1.5}
+            />
+            <Text style={styles.signingHintText}>{signingHint}</Text>
+          </View>
+        </View>
+      )}
       {/* Edit mode preview */}
       {editingMessage && (
         <View style={styles.editContainer}>
@@ -1122,24 +1150,6 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
               strokeWidth={1.5}
             />
           </TouchableOpacity>
-          {/* Per-message signing lock — only when the conversation/space allows
-              opt-out. Closed lock = signed (default), open = repudiable. */}
-          {signingOptional && (
-            <TouchableOpacity
-              style={styles.inputIconButton}
-              onPress={onToggleSkipSigning}
-              disabled={disabled}
-              accessibilityRole="button"
-              accessibilityLabel={skipSigning ? 'Message signing off (unsigned)' : 'Message signing on (signed)'}
-            >
-              <IconSymbol
-                name={skipSigning ? 'lock.open' : 'lock.fill'}
-                color={skipSigning ? theme.colors.textMuted : theme.colors.primary}
-                size={24}
-                strokeWidth={1.5}
-              />
-            </TouchableOpacity>
-          )}
         </View>
 
         <TextInput
@@ -1169,6 +1179,27 @@ export const MessageInput = forwardRef<MessageInputHandle, MessageInputProps>(fu
         />
 
         <View style={styles.rightButtons}>
+          {/* Per-message signing lock — only when the conversation/space allows
+              opt-out. Collapses while composing like the attach button. Outline
+              lock = signed (default), open = repudiable. */}
+          {signingOptional && (
+            <Reanimated.View style={[styles.attachContainer, attachAnimatedStyle]}>
+              <TouchableOpacity
+                style={styles.inputIconButton}
+                onPress={handleToggleSigning}
+                disabled={disabled || isComposing}
+                accessibilityRole="button"
+                accessibilityLabel={skipSigning ? 'Message signing off (unsigned)' : 'Message signing on (signed)'}
+              >
+                <IconSymbol
+                  name={skipSigning ? 'lock.open' : 'lock'}
+                  color={skipSigning ? theme.colors.textMuted : theme.colors.primary}
+                  size={25}
+                  strokeWidth={1.5}
+                />
+              </TouchableOpacity>
+            </Reanimated.View>
+          )}
           {/* Attach slides right + fades out while composing to give the text
               room; it slides back when the input is cleared. Kept mounted (not
               conditionally unmounted) so it can animate in both directions, with
@@ -1421,6 +1452,26 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   },
   inputIconButton: {
     padding: Skin.space(6),
+  },
+  signingHintRow: {
+    alignItems: 'center',
+    paddingBottom: Skin.space(6),
+  },
+  signingHintPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: Skin.space(6),
+    paddingVertical: Skin.space(5),
+    paddingHorizontal: Skin.space(10),
+    borderRadius: Skin.radius(14),
+    backgroundColor: theme.colors.composerPillBg,
+    borderWidth: StyleSheet.hairlineWidth,
+    borderColor: theme.colors.composerPillBorder,
+  },
+  signingHintText: {
+    fontSize: Skin.font(12),
+    color: theme.colors.textSubtle,
+    fontFamily: theme.fonts.medium?.fontFamily || theme.fonts.regular.fontFamily,
   },
   // Clips the paperclip as its width animates to 0 while composing, so the
   // icon slides out cleanly instead of overflowing the collapsing container.

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -719,7 +719,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
               message: 'Message does not have a valid signature, this may not be from the sender.',
             })
           }
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          hitSlop={{ top: 16, bottom: 16, left: 16, right: 16 }}
           accessibilityRole="button"
           accessibilityLabel="Unsigned message"
           style={styles.unsignedWarning}

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1539,11 +1539,10 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   },
   unsignedWarning: {
     marginLeft: Skin.space(6),
-    // Pin to the text line so the icon never grows the baseline-aligned header
-    // row (which would push the message body down). Height matches the 12pt glyph.
-    height: Skin.font(12),
-    justifyContent: 'center',
-    alignSelf: 'flex-end',
+    alignSelf: 'center',
+    // Nudge down 1px to sit level with the name/time text. transform (not
+    // margin) so centering doesn't cancel it out.
+    transform: [{ translateY: 1 }],
   },
   // Reply indicator
   replyIndicator: {

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -7,6 +7,7 @@ import Animated, { useSharedValue, useAnimatedStyle, withTiming, withDelay, with
 import { ChatKeyboardScrollView } from './ChatKeyboardScrollView';
 import BrowserLink from '@/components/BrowserLink';
 import { haptics } from '@/utils/haptics';
+import { useToast } from '@/context/ToastContext';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { CachedAvatar } from '@/components/ui/CachedAvatar';
@@ -350,6 +351,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     [everyoneSpaceShim]
   );
   const styles = useMemo(() => createStyles(theme), [theme]);
+  const { showToast } = useToast();
   const [viewerImage, setViewerImage] = useState<string | null>(null);
   const [reactionPickerMessageId, setReactionPickerMessageId] = useState<string | null>(null);
   const [actionSheetMessageId, setActionSheetMessageId] = useState<string | null>(null);
@@ -700,6 +702,39 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
   }, [actionSheetMessage]);
 
   // Render reactions row
+  // Warning shown on any unsigned message (matches desktop). Tap reveals the
+  // explanation via a toast — the mobile equivalent of desktop's touch-tooltip.
+  // Its own onPress consumes the tap so it doesn't fight the row's long-press.
+  const renderUnsignedWarning = useCallback(
+    (item: DisplayMessage) => {
+      if (item.renderType === 'system' || item.renderType === 'error') return null;
+      if (item.originalMessage?.signature) return null;
+      if (item.sendStatus === 'sending' || item.sendStatus === 'failed') return null;
+      return (
+        <TouchableOpacity
+          onPress={() =>
+            showToast({
+              type: 'info',
+              title: 'Unsigned message',
+              message: 'Message does not have a valid signature, this may not be from the sender.',
+            })
+          }
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          accessibilityRole="button"
+          accessibilityLabel="Unsigned message"
+          style={styles.unsignedWarning}
+        >
+          <IconSymbol
+            name="exclamationmark.triangle.fill"
+            size={12}
+            color={theme.colors.warning ?? '#f59e0b'}
+          />
+        </TouchableOpacity>
+      );
+    },
+    [showToast, styles, theme]
+  );
+
   const renderReactions = useCallback(
     (reactions: DisplayReaction[], messageId: string) => {
       if (!reactions || reactions.length === 0) return null;
@@ -868,6 +903,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
               <View style={styles.messageHeader}>
                 <Text style={styles.messageUser} numberOfLines={1}>{item.userName}</Text>
                 <Text style={styles.messageTime}>{item.timeString}</Text>
+                {renderUnsignedWarning(item)}
               </View>
               {imageUrl && (
                 <View style={styles.embedImageContainer}>
@@ -913,7 +949,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         </Pressable>
       );
     },
-    [styles, renderReactions, renderAvatar, handleMessageLongPress, handleImagePress, MESSAGE_IMAGE_MAX_WIDTH, highlightedMessageId, highlightAnimStyle, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, theme, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress]
+    [styles, renderReactions, renderAvatar, renderUnsignedWarning, handleMessageLongPress, handleImagePress, MESSAGE_IMAGE_MAX_WIDTH, highlightedMessageId, highlightAnimStyle, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, theme, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress]
   );
 
   // Render sticker message
@@ -933,6 +969,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
               <View style={styles.messageHeader}>
                 <Text style={styles.messageUser} numberOfLines={1}>{item.userName}</Text>
                 <Text style={styles.messageTime}>{item.timeString}</Text>
+                {renderUnsignedWarning(item)}
               </View>
               {sticker ? (
                 <View style={styles.stickerContainer}>
@@ -953,7 +990,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         </Pressable>
       );
     },
-    [styles, renderReactions, stickerMap, renderAvatar, handleMessageLongPress, highlightedMessageId, highlightAnimStyle]
+    [styles, renderReactions, stickerMap, renderAvatar, renderUnsignedWarning, handleMessageLongPress, highlightedMessageId, highlightAnimStyle]
   );
 
   // Helper to get reply preview from parent message
@@ -1018,6 +1055,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                 {item.isEdited && (
                   <Text style={styles.editedIndicator}>(edited)</Text>
                 )}
+                {renderUnsignedWarning(item)}
                 {isSending && (
                   <ActivityIndicator
                     size="small"
@@ -1113,7 +1151,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         </Pressable>
       );
     },
-    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress]
+    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, renderUnsignedWarning, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress]
   );
 
   const renderCast = useCallback(
@@ -1498,6 +1536,10 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontSize: Skin.font(11),
     fontFamily: theme.fonts.regular.fontFamily,
     marginLeft: Skin.space(6),
+  },
+  unsignedWarning: {
+    marginLeft: Skin.space(6),
+    alignSelf: 'center',
   },
   // Reply indicator
   replyIndicator: {

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1539,7 +1539,11 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   },
   unsignedWarning: {
     marginLeft: Skin.space(6),
-    alignSelf: 'center',
+    // Pin to the text line so the icon never grows the baseline-aligned header
+    // row (which would push the message body down). Height matches the 12pt glyph.
+    height: Skin.font(12),
+    justifyContent: 'center',
+    alignSelf: 'flex-end',
   },
   // Reply indicator
   replyIndicator: {

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -468,6 +468,8 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         spaceRoles: spaceData?.roles?.map((r) => ({ roleId: r.roleId, roleTag: r.roleTag })),
         spaceChannels: channelsData?.map((c) => ({ channelId: c.channelId, channelName: c.channelName })),
         allowEveryone: canMentionEveryone,
+        isRepudiable: spaceData?.isRepudiable,
+        skipSigning,
       }, {
         onSettled: refocusInput,
       });

--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -134,6 +134,8 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
   const [messageText, setMessageText] = useState('');
   const [pendingAttachment, setPendingAttachment] = useState<ProcessedAttachment | null>(null);
   const [replyToMessage, setReplyToMessage] = useState<{ messageId: string; senderName: string; text: string; authorId: string } | null>(null);
+  // Per-message signing lock; only meaningful when the space is repudiable.
+  const [skipSigning, setSkipSigning] = useState(false);
   // Opt-in per-send. Reset whenever the reply target changes; user must
   // explicitly check the box again for each cast reply.
   const [alsoReplyOnFarcaster, setAlsoReplyOnFarcaster] = useState(false);
@@ -483,6 +485,8 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         spaceRoles: spaceData?.roles?.map((r) => ({ roleId: r.roleId, roleTag: r.roleTag })),
         spaceChannels: channelsData?.map((c) => ({ channelId: c.channelId, channelName: c.channelName })),
         allowEveryone: canMentionEveryone,
+        isRepudiable: spaceData?.isRepudiable,
+        skipSigning,
       }, {
         onSettled: refocusInput,
       });
@@ -513,7 +517,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
       setAlsoReplyOnFarcaster(false);
       replyCastHashRef.current = null;
     }
-  }, [messageText, spaceId, channelId, sendMessageMutation, sendEmbedMutation, pendingAttachment, replyToMessage, editingMessage, editSpaceMessageMutation, draftsRef, alsoReplyOnFarcaster, isCastReply, farcasterAuthToken, spaceData, channelsData, canMentionEveryone]);
+  }, [messageText, spaceId, channelId, sendMessageMutation, sendEmbedMutation, pendingAttachment, replyToMessage, editingMessage, editSpaceMessageMutation, draftsRef, alsoReplyOnFarcaster, isCastReply, farcasterAuthToken, spaceData, channelsData, canMentionEveryone, skipSigning]);
 
   const handleAttachmentPress = useCallback(async () => {
     const result = await pickImage('library');
@@ -809,6 +813,9 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
             editingMessage={editingMessage}
             onCancelEdit={handleCancelEdit}
             disabled={!canPost}
+            signingOptional={!!spaceData?.isRepudiable}
+            skipSigning={skipSigning}
+            onToggleSkipSigning={() => setSkipSigning((s) => !s)}
           />
         )}
       </ChatBottomChrome>

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -135,6 +135,7 @@ const SF_TO_TABLER = {
 
   // Security
   'lock.fill': tabler('IconLock', 'IconLockFilled'),
+  'lock.open': tabler('IconLockOpen'),
   'lock.shield.fill': tabler('IconShieldLock', 'IconShieldLockFilled'),
   'shield': tabler('IconShield', 'IconShieldFilled'),
   'shield.fill': tabler('IconShield', 'IconShieldFilled'),

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -135,6 +135,7 @@ const SF_TO_TABLER = {
 
   // Security
   'lock.fill': tabler('IconLock', 'IconLockFilled'),
+  'lock': tabler('IconLock'),
   'lock.open': tabler('IconLockOpen'),
   'lock.shield.fill': tabler('IconShieldLock', 'IconShieldLockFilled'),
   'shield': tabler('IconShield', 'IconShieldFilled'),

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -163,6 +163,7 @@ import IconLink from '@tabler/icons-react-native/IconLink';
 import IconLinkPlus from '@tabler/icons-react-native/IconLinkPlus';
 import IconLock from '@tabler/icons-react-native/IconLock';
 import IconLockFilled from '@tabler/icons-react-native/IconLockFilled';
+import IconLockOpen from '@tabler/icons-react-native/IconLockOpen';
 import IconMail from '@tabler/icons-react-native/IconMail';
 import IconMailFilled from '@tabler/icons-react-native/IconMailFilled';
 import IconMailOpened from '@tabler/icons-react-native/IconMailOpened';
@@ -423,6 +424,7 @@ export const TablerIcons = {
   IconLinkPlus,
   IconLock,
   IconLockFilled,
+  IconLockOpen,
   IconMail,
   IconMailFilled,
   IconMailOpened,

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -10,11 +10,38 @@ import { useAuth, useWebSocket } from '@/context';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
-import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
+import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
 import { queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type EmbedMessage } from '@quilibrium/quorum-shared';
 import type { Message } from '@quilibrium/quorum-shared';
 import type { MessagePreview } from '@/utils/messagePreview';
+import { NativeSigningProvider } from '@/services/crypto/native-signing-provider';
+import { sha256 } from '@noble/hashes/sha2.js';
+
+/** SHA-256 messageId hash, matching desktop: nonce + 'post' + sender + JSON.stringify(content). */
+function embedMessageIdHash(nonce: string, senderAddress: string, content: object): { messageId: string; messageIdBytes: Uint8Array } {
+  const input = nonce + 'post' + senderAddress + JSON.stringify(content);
+  const hashBytes = sha256(new TextEncoder().encode(input));
+  return { messageId: bytesToHex(Array.from(hashBytes)), messageIdBytes: hashBytes };
+}
+
+/** Sign the messageId hash with the user's Ed448 key. Returns null on any failure. */
+async function signEmbedMessageId(messageIdBytes: Uint8Array): Promise<{ signature: string; publicKey: string } | null> {
+  try {
+    const privateKeyHex = await getPrivateKey();
+    const publicKeyHex = await getPublicKey();
+    if (!privateKeyHex || !publicKeyHex) return null;
+    const messageBase64 = btoa(String.fromCharCode(...messageIdBytes));
+    const privateKeyBase64 = btoa(String.fromCharCode(...hexToBytes(privateKeyHex)));
+    const signatureBase64 = await new NativeSigningProvider().signEd448(privateKeyBase64, messageBase64);
+    const signatureHex = Array.from(atob(signatureBase64))
+      .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
+      .join('');
+    return { signature: signatureHex, publicKey: publicKeyHex };
+  } catch {
+    return null;
+  }
+}
 
 export interface SendDirectEmbedMessageParams {
   conversationId: string;
@@ -32,6 +59,10 @@ export interface SendDirectEmbedMessageParams {
     inboxAddress: string;
     inboxEncryptionKey: number[];
   };
+  /** Conversation repudiability (inverse of "Always sign"). Unset/false ⇒ always sign. */
+  isRepudiable?: boolean;
+  /** Per-message lock state; only consulted when isRepudiable is true. */
+  skipSigning?: boolean;
 }
 
 import type { MessagesPage, InfiniteMessagesData } from './queryTypes';
@@ -53,6 +84,8 @@ export function useSendDirectEmbedMessage() {
       height,
       text,
       recipientInfo,
+      isRepudiable,
+      skipSigning,
     }: SendDirectEmbedMessageParams): Promise<Message> => {
       const senderId = user?.address ?? 'unknown';
 
@@ -62,7 +95,20 @@ export function useSendDirectEmbedMessage() {
         return v.toString(16);
       });
       const createdDate = Date.now();
-      const messageId = `${nonce}-${createdDate}`;
+
+      const content = {
+        type: 'embed',
+        senderId,
+        imageUrl,
+        thumbnailUrl,
+        width: width?.toString(),
+        height: height?.toString(),
+        text,
+      } as EmbedMessage & { text?: string };
+
+      // messageId is the SHA-256 hash of the content, matching desktop so a
+      // desktop recipient can verify the signature.
+      const { messageId, messageIdBytes } = embedMessageIdHash(nonce, senderId, content);
 
       // Create embed message object
       const message: Message = {
@@ -74,18 +120,20 @@ export function useSendDirectEmbedMessage() {
         createdDate,
         modifiedDate: createdDate,
         lastModifiedHash: '',
-        content: {
-          type: 'embed',
-          senderId,
-          imageUrl,
-          thumbnailUrl,
-          width: width?.toString(),
-          height: height?.toString(),
-          text,
-        } as EmbedMessage & { text?: string },
+        content,
         reactions: [],
         mentions: { memberIds: [], roleIds: [], channelIds: [] },
       };
+
+      // Sign unless the conversation is repudiable AND the lock was opened.
+      const effectiveSkip = isRepudiable ? !!skipSigning : false;
+      if (!effectiveSkip) {
+        const sig = await signEmbedMessageId(messageIdBytes);
+        if (sig) {
+          message.signature = sig.signature;
+          message.publicKey = sig.publicKey;
+        }
+      }
 
       // E2E encryption is required for direct messages
       const hasDeviceKeys = encryptionService.hasDeviceKeys();
@@ -268,7 +316,12 @@ export function useSendDirectEmbedMessage() {
       const key = queryKeys.messages.infinite(recipientAddress, recipientAddress);
 
       const sentMessage: Message = context?.optimisticMessage
-        ? { ...context.optimisticMessage, sendStatus: 'sent' as const }
+        ? {
+            ...context.optimisticMessage,
+            sendStatus: 'sent' as const,
+            signature: message.signature,
+            publicKey: message.publicKey,
+          }
         : message;
 
       queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -465,9 +465,16 @@ export function useSendDirectMessage() {
       const key = queryKeys.messages.infinite(recipientAddress, recipientAddress);
 
       // The returned message has a different ID than the optimistic one
-      // Use the optimistic message ID but update the status
+      // Use the optimistic message ID but update the status. Carry the real
+      // signature/publicKey across (optimistic msg has neither) so signed
+      // messages don't render the unsigned-warning icon.
       const sentMessage: Message = context?.optimisticMessage
-        ? { ...context.optimisticMessage, sendStatus: 'sent' as const }
+        ? {
+            ...context.optimisticMessage,
+            sendStatus: 'sent' as const,
+            signature: message.signature,
+            publicKey: message.publicKey,
+          }
         : message;
 
       // Update cache with sent status

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -52,6 +52,10 @@ interface SendDirectMessageParams {
   _messageId?: string;
   _nonce?: string;
   _createdDate?: number;
+  /** Conversation repudiability (inverse of "Always sign"). Unset/false ⇒ always sign. */
+  isRepudiable?: boolean;
+  /** Per-message lock state; only consulted when isRepudiable is true. */
+  skipSigning?: boolean;
 }
 
 /**
@@ -146,6 +150,8 @@ export function useSendDirectMessage() {
       _messageId,
       _nonce,
       _createdDate,
+      isRepudiable,
+      skipSigning,
     }: SendDirectMessageParams): Promise<Message> => {
       const senderId = user?.address ?? 'unknown';
 
@@ -194,12 +200,15 @@ export function useSendDirectMessage() {
           : {}),
       };
 
-      // Sign the message hash with the user's Ed448 key (non-repudiation)
-      // This is done before encryption so the signature is included in the encrypted payload
-      const signatureData = await signMessageIdHash(new Uint8Array(messageIdBytes));
-      if (signatureData) {
-        message.signature = signatureData.signature;
-        message.publicKey = signatureData.publicKey;
+      // Sign unless the conversation is repudiable AND the lock was opened for
+      // this message. Mirrors desktop's effectiveSkip.
+      const effectiveSkip = isRepudiable ? !!skipSigning : false;
+      if (!effectiveSkip) {
+        const signatureData = await signMessageIdHash(new Uint8Array(messageIdBytes));
+        if (signatureData) {
+          message.signature = signatureData.signature;
+          message.publicKey = signatureData.publicKey;
+        }
       }
 
       // E2E encryption is required for direct messages

--- a/hooks/chat/useSendEmbedMessage.ts
+++ b/hooks/chat/useSendEmbedMessage.ts
@@ -24,6 +24,10 @@ export interface UseSendEmbedMessageParams {
   spaceChannels?: Array<{ channelId: string; channelName: string }>;
   /** Sender has mention:everyone — gates @everyone in an image caption. */
   allowEveryone?: boolean;
+  /** Space repudiability (inverse of "Require Message Signing"). */
+  isRepudiable?: boolean;
+  /** Per-message lock state; only consulted when isRepudiable is true. */
+  skipSigning?: boolean;
 }
 
 export function useSendEmbedMessage() {
@@ -53,6 +57,8 @@ export function useSendEmbedMessage() {
         spaceRoles: params.spaceRoles,
         spaceChannels: params.spaceChannels,
         allowEveryone: params.allowEveryone,
+        // Sign unless the space left it optional AND the lock was opened.
+        skipSigning: params.isRepudiable ? !!params.skipSigning : false,
       });
 
       // Send via WebSocket

--- a/hooks/chat/useSendSpaceMessage.ts
+++ b/hooks/chat/useSendSpaceMessage.ts
@@ -27,6 +27,10 @@ export interface UseSendSpaceMessageParams {
   spaceChannels?: Array<{ channelId: string; channelName: string }>;
   /** Sender has the mention:everyone permission (gates @everyone extraction). */
   allowEveryone?: boolean;
+  /** Space repudiability (inverse of "Require Message Signing"). */
+  isRepudiable?: boolean;
+  /** Per-message lock state; only consulted when isRepudiable is true. */
+  skipSigning?: boolean;
 }
 
 export function useSendSpaceMessage() {
@@ -54,6 +58,8 @@ export function useSendSpaceMessage() {
         spaceRoles: params.spaceRoles,
         spaceChannels: params.spaceChannels,
         allowEveryone: params.allowEveryone,
+        // Sign unless the space left it optional AND the lock was opened.
+        skipSigning: params.isRepudiable ? !!params.skipSigning : false,
       });
 
       // Send via WebSocket

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -617,6 +617,8 @@ export interface SendGenericMessageParams {
    *  (edit, embed caption). Defaults to empty for text-less content (reactions,
    *  deletes, calls, profile updates). */
   mentions?: Mentions;
+  /** Skip signing (per-message lock). Already gated on space.isRepudiable by the caller. */
+  skipSigning?: boolean;
 }
 
 export interface SendGenericMessageResult {
@@ -628,7 +630,7 @@ export interface SendGenericMessageResult {
 async function sendGenericMessage(
   params: SendGenericMessageParams
 ): Promise<SendGenericMessageResult> {
-  const { spaceId, channelId, senderAddress, content, mentions } = params;
+  const { spaceId, channelId, senderAddress, content, mentions, skipSigning } = params;
 
   const cryptoProvider = new NativeCryptoProvider();
   const timestamp = Date.now();
@@ -668,19 +670,21 @@ async function sendGenericMessage(
     publicKey: inboxKey.publicKey,
   };
 
-  // Sign the messageId hash (NOT the whole message JSON)
-  // This matches desktop implementation for non-repudiability
-  const messageIdBase64 = bytesToBase64(messageIdBytes);
-  const inboxPrivateKeyBytes = hexToBytes(inboxKey.privateKey);
-  const inboxPrivateKeyBase64 = bytesToBase64(inboxPrivateKeyBytes);
-  const signatureBase64 = await cryptoProvider.signEd448(inboxPrivateKeyBase64, messageIdBase64);
+  // Sign the messageId hash (NOT the whole message JSON), unless this message
+  // opted out via the per-message lock. Gated on space.isRepudiable by the caller.
+  if (!skipSigning) {
+    const messageIdBase64 = bytesToBase64(messageIdBytes);
+    const inboxPrivateKeyBytes = hexToBytes(inboxKey.privateKey);
+    const inboxPrivateKeyBase64 = bytesToBase64(inboxPrivateKeyBytes);
+    const signatureBase64 = await cryptoProvider.signEd448(inboxPrivateKeyBase64, messageIdBase64);
 
-  const signatureBinary = atob(signatureBase64);
-  let signatureHex = '';
-  for (let i = 0; i < signatureBinary.length; i++) {
-    signatureHex += signatureBinary.charCodeAt(i).toString(16).padStart(2, '0');
+    const signatureBinary = atob(signatureBase64);
+    let signatureHex = '';
+    for (let i = 0; i < signatureBinary.length; i++) {
+      signatureHex += signatureBinary.charCodeAt(i).toString(16).padStart(2, '0');
+    }
+    message.signature = signatureHex;
   }
-  message.signature = signatureHex;
 
 
   // Hub-envelope only (no TR): config key rotates on kick.
@@ -1050,6 +1054,8 @@ export interface SendEmbedMessageParams {
   spaceChannels?: Array<{ channelId: string; channelName: string }>;
   /** Sender may use @everyone (has mention:everyone) — gates @everyone in captions. */
   allowEveryone?: boolean;
+  /** Skip signing (per-message lock); gated on space.isRepudiable by the caller. */
+  skipSigning?: boolean;
 }
 
 /**
@@ -1089,6 +1095,7 @@ export async function sendEmbedMessage(
     spaceRoles,
     spaceChannels,
     allowEveryone,
+    skipSigning,
   } = params;
 
   const content = buildPostWithEmbeddedMedia(senderAddress, imageUrl, thumbnailUrl, text, repliesToMessageId);
@@ -1098,6 +1105,7 @@ export async function sendEmbedMessage(
     senderAddress,
     content,
     mentions: text ? extractMentionsFromText(text, { spaceRoles, spaceChannels, allowEveryone }) : undefined,
+    skipSigning,
   });
 }
 

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -107,6 +107,8 @@ export interface SendSpaceMessageParams {
    * is never set and @everyone never notifies anyone.
    */
   allowEveryone?: boolean;
+  /** Skip signing this message (per-message lock); gated on space.isRepudiable at the call site. */
+  skipSigning?: boolean;
 }
 
 export interface SendSpaceMessageResult {
@@ -263,7 +265,7 @@ function hexToNumberArray(hex: string): number[] {
 export async function sendSpaceMessage(
   params: SendSpaceMessageParams
 ): Promise<SendSpaceMessageResult> {
-  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress, spaceRoles, spaceChannels, allowEveryone } = params;
+  const { spaceId, channelId, text, senderAddress, repliesToMessageId, replyToAuthorAddress, spaceRoles, spaceChannels, allowEveryone, skipSigning } = params;
 
   const cryptoProvider = new NativeCryptoProvider();
   const timestamp = Date.now();
@@ -324,20 +326,21 @@ export async function sendSpaceMessage(
       : {}),
   };
 
-  // 6. Sign the messageId hash (NOT the whole message JSON)
-  // This matches desktop implementation for non-repudiability
-  const messageIdBase64 = bytesToBase64(messageIdBytes);
-  const inboxPrivateKeyBytes = hexToBytes(inboxKey.privateKey);
-  const inboxPrivateKeyBase64 = bytesToBase64(inboxPrivateKeyBytes);
-  const signatureBase64 = await cryptoProvider.signEd448(inboxPrivateKeyBase64, messageIdBase64);
+  // 6. Sign the messageId hash (NOT the whole message JSON), unless this message
+  // opted out via the per-message lock. Gated on space.isRepudiable at the call site.
+  if (!skipSigning) {
+    const messageIdBase64 = bytesToBase64(messageIdBytes);
+    const inboxPrivateKeyBytes = hexToBytes(inboxKey.privateKey);
+    const inboxPrivateKeyBase64 = bytesToBase64(inboxPrivateKeyBytes);
+    const signatureBase64 = await cryptoProvider.signEd448(inboxPrivateKeyBase64, messageIdBase64);
 
-  // Convert signature to hex for message
-  const signatureBinary = atob(signatureBase64);
-  let signatureHex = '';
-  for (let i = 0; i < signatureBinary.length; i++) {
-    signatureHex += signatureBinary.charCodeAt(i).toString(16).padStart(2, '0');
+    const signatureBinary = atob(signatureBase64);
+    let signatureHex = '';
+    for (let i = 0; i < signatureBinary.length; i++) {
+      signatureHex += signatureBinary.charCodeAt(i).toString(16).padStart(2, '0');
+    }
+    message.signature = signatureHex;
   }
-  message.signature = signatureHex;
 
 
   // Hub-envelope only (no TR): the config key rotates on kick, giving


### PR DESCRIPTION
Adds per-conversation and per-space message signing controls, matching desktop's "Always sign messages" / "Require Message Signing" pattern.

## What's included
- **Send-path gating** (DM + Space): messages are signed by default; a conversation/space can opt into repudiable (unsigned) messages.
- **Per-message lock** in the composer: when signing is optional, a lock/unlock button lets the sender send a single message signed or unsigned. Collapses while typing like the attach button. A small pill above the composer confirms the state on tap.
- **DM "Always sign messages" toggle** in Conversation Settings (the Space owner's "Require Message Signing" already existed; its send path now works).
- **Unsigned-message warning**: any message without a signature shows a small warning icon; tapping it explains "Message does not have a valid signature, this may not be from the sender" (mobile stand-in for desktop's tap-tooltip).
- **Images honor signing too** (DM + Space), signing the SHA-256 messageId hash like text.

## Notes
- Additive and mobile-only; `isRepudiable` already exists on the shared Conversation/Space types — no shared publish needed.
- Receiver tolerates intentionally-unsigned messages (chat posts aren't signature-verified on receive; only space-manifest control messages are).
- Text signing verified on-device (DM + Space, both directions). Image signing is static-verified (mirrors desktop's hash scheme) but not yet runtime-tested.

## Follow-up (separate, for the lead)
The signed/unsigned gate (`isRepudiable ? skipSigning : false`) is computed identically here and in desktop — a small candidate for a shared `computeEffectiveSkip` helper in quorum-shared.