### PR TITLE
Channel icon picker: rendering fixes + layout polish

### DIFF
--- a/components/Chat/ChannelSettingsSheet.tsx
+++ b/components/Chat/ChannelSettingsSheet.tsx
@@ -390,7 +390,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
           <>
             <ActionRowGroup style={styles.group}>
               <ActionRow
-                icon="lock.fill"
+                icon="lock"
                 label="Read-only"
                 sublabel="Only managers can post, pin & delete"
                 trailing={
@@ -405,7 +405,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
               />
               {channel?.isReadOnly && (
                 <ActionRow
-                  icon="shield.fill"
+                  icon="shield"
                   label="Managers"
                   sublabel={managerNames || 'No roles selected'}
                   trailing="chevron"
@@ -422,7 +422,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
 
             <ActionRowGroup style={styles.group}>
               <ActionRow
-                icon="star.fill"
+                icon="star"
                 label="Set as default channel"
                 sublabel={
                   channel?.channelId === space?.defaultChannelId
@@ -448,7 +448,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
           <>
             <ActionRowGroup style={styles.group}>
               <ActionRow
-                icon="lock.fill"
+                icon="lock"
                 label="Read-only"
                 sublabel="Only managers can post, pin & delete"
                 trailing={
@@ -463,7 +463,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
               />
               {draftReadOnly && (
                 <ActionRow
-                  icon="shield.fill"
+                  icon="shield"
                   label="Managers"
                   sublabel={
                     draftManagerRoleIds.length > 0
@@ -487,7 +487,7 @@ export function ChannelSettingsSheet({ visible, target, onClose, onChanged }: Ch
 
             <ActionRowGroup style={styles.group}>
               <ActionRow
-                icon="star.fill"
+                icon="star"
                 label="Set as default channel"
                 sublabel="New members land here first"
                 trailing={

--- a/components/shared/ActionRow.tsx
+++ b/components/shared/ActionRow.tsx
@@ -104,7 +104,9 @@ export function ActionRow(props: ActionRowProps) {
           {props.label}
         </Text>
         {props.sublabel ? (
-          <Text style={styles.sublabel} numberOfLines={1}>
+          // No numberOfLines — sublabels wrap to as many lines as needed so the
+          // full text always shows (never truncated on narrow screens).
+          <Text style={styles.sublabel}>
             {props.sublabel}
           </Text>
         ) : null}

--- a/components/ui/ChannelIconPickerSheet.tsx
+++ b/components/ui/ChannelIconPickerSheet.tsx
@@ -79,17 +79,6 @@ export function ChannelIconPickerSheet({
 
   const previewHex = getIconColorHex(pickedColor);
 
-  // Pick black/white text for contrast against the chosen swatch color.
-  const applyTextColor = (() => {
-    const h = previewHex.replace('#', '');
-    if (h.length < 6) return '#fff';
-    const r = parseInt(h.slice(0, 2), 16);
-    const g = parseInt(h.slice(2, 4), 16);
-    const b = parseInt(h.slice(4, 6), 16);
-    const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-    return lum > 0.6 ? '#1a1a1a' : '#fff';
-  })();
-
   const handleConfirm = () => {
     onSelect(pickedIcon, pickedColor, pickedVariant);
     onClose();
@@ -102,7 +91,7 @@ export function ChannelIconPickerSheet({
   };
 
   return (
-    <BaseModal visible={visible} onClose={onClose} height={0.7} showHandle>
+    <BaseModal visible={visible} onClose={onClose} height={0.85} showHandle>
       <View style={styles.container}>
         <Text style={styles.title}>Icon</Text>
 
@@ -173,9 +162,15 @@ export function ChannelIconPickerSheet({
           </View>
         </ScrollView>
 
-        {/* Color row (wraps to any count) */}
+        {/* Color — single row, scrolls horizontally so it stays one line on any
+            screen and never pushes the buttons off the bottom. */}
         <Text style={styles.sectionLabel}>Color</Text>
-        <View style={styles.colorRow}>
+        <ScrollView
+          horizontal
+          showsHorizontalScrollIndicator={false}
+          style={styles.colorRow}
+          contentContainerStyle={styles.colorRowContent}
+        >
           {PICKER_COLORS.map((token) => {
             const hex = getIconColorHex(token);
             return (
@@ -188,11 +183,11 @@ export function ChannelIconPickerSheet({
                 ]}
                 onPress={() => setPickedColor(token)}
                 accessibilityLabel={token}
-                hitSlop={{ top: 8, bottom: 8, left: 6, right: 6 }}
+                hitSlop={{ top: 8, bottom: 4, left: 6, right: 6 }}
               />
             );
           })}
-        </View>
+        </ScrollView>
 
         {/* Actions */}
         <View style={styles.actions}>
@@ -200,10 +195,10 @@ export function ChannelIconPickerSheet({
             <Text style={styles.clearButtonText}>Reset</Text>
           </TouchableOpacity>
           <TouchableOpacity
-            style={[styles.confirmButton, { backgroundColor: previewHex }]}
+            style={styles.confirmButton}
             onPress={handleConfirm}
           >
-            <Text style={[styles.confirmButtonText, { color: applyTextColor }]}>Apply</Text>
+            <Text style={styles.confirmButtonText}>Apply</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -213,13 +208,10 @@ export function ChannelIconPickerSheet({
 
 const createStyles = (theme: AppTheme) =>
   StyleSheet.create({
-    // Hug content instead of flex:1 stretching to the sheet's maxHeight, which
-    // pushed the Reset/Apply row (last child, outside the grid's own ScrollView)
-    // off the bottom edge under the Android nav bar. The icon grid keeps its own
-    // maxHeight:200 ScrollView; everything else is fixed-height and bounded, so
-    // the column hugs and BaseModal's paddingBottom: insets.bottom keeps the
-    // buttons clear of the system bar.
-    container: { paddingHorizontal: Skin.space(20), paddingTop: Skin.space(8) },
+    // Hug content; BaseModal caps the sheet at SCREEN_HEIGHT*height (adaptive
+    // with a cap). The icon grid (flexShrink + maxHeight) is the part that gives
+    // when the cap is hit, so the color row + Reset/Apply always stay on screen.
+    container: { flexShrink: 1, paddingHorizontal: Skin.space(20), paddingTop: Skin.space(8) },
     title: {
       ...theme.textStyles.headline,
       color: theme.colors.textStrong,
@@ -263,7 +255,11 @@ const createStyles = (theme: AppTheme) =>
       marginBottom: Skin.space(8),
       textTransform: 'uppercase',
     },
-    iconGrid: { maxHeight: 200, marginBottom: Skin.space(16) },
+    // The grid is the part that gives when the sheet hits its height cap:
+    // flexShrink + minHeight:0 lets the ScrollView shrink below its content;
+    // maxHeight caps it on tall screens so the sheet hugs content there.
+    // Color row + Reset/Apply stay fully visible on every device.
+    iconGrid: { flexShrink: 1, minHeight: 0, maxHeight: 240, marginBottom: Skin.space(12) },
     gridRow: { flexDirection: 'row', flexWrap: 'wrap', gap: Skin.space(8) },
     iconCell: {
       width: 44,
@@ -275,7 +271,12 @@ const createStyles = (theme: AppTheme) =>
       borderWidth: Skin.border(2),
       borderColor: 'transparent',
     },
-    colorRow: { flexDirection: 'row', flexWrap: 'wrap', gap: Skin.space(10), marginBottom: Skin.space(20) },
+    // Single horizontal row, edge-to-edge: negative margins cancel the
+    // container's horizontal padding so the scroll track reaches both screen
+    // edges; the content re-adds that padding so the first/last swatch sit at a
+    // comfortable inset. flexGrow:0 so it doesn't fill leftover column space.
+    colorRow: { flexGrow: 0, marginHorizontal: -Skin.space(20), marginBottom: Skin.space(16) },
+    colorRowContent: { flexDirection: 'row', gap: Skin.space(10), paddingHorizontal: Skin.space(20), paddingVertical: Skin.space(3), alignItems: 'center' },
     colorSwatch: { width: 32, height: 32, borderRadius: Skin.radius(16) },
     colorSwatchActive: {
       borderWidth: Skin.border(3),
@@ -300,6 +301,9 @@ const createStyles = (theme: AppTheme) =>
       paddingVertical: Skin.space(12),
       borderRadius: Skin.radius(10),
       alignItems: 'center',
+      // Stable primary color — NOT the picked icon color (that washed the button
+      // out / broke text contrast for light picks, and conflated two choices).
+      backgroundColor: theme.colors.primary,
     },
     confirmButtonText: { ...theme.textStyles.body, color: '#fff' },
   });

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -57,7 +57,7 @@ const SF_TO_TABLER = {
   // Status & flags
   'flag': tabler('IconFlag', 'IconFlagFilled'),
   'flag.fill': tabler('IconFlag', 'IconFlagFilled'),
-  'flask': tabler('IconFlask'),
+  'flask': tabler('IconFlask', 'IconFlaskFilled'),
   'nosign': tabler('IconBan'),
   'ellipsis': tabler('IconDots'),
   'ellipsis.vertical': tabler('IconDotsVertical'),
@@ -84,6 +84,9 @@ const SF_TO_TABLER = {
   'rectangle.grid.2x2': tabler('IconLayoutGrid'),
   'square.stack': tabler('IconStack2'),
   'rectangle.stack.fill': tabler('IconStack2', 'IconStack2Filled'),
+  // Picker uses the bare semantic name 'stack'; without this it falls through to
+  // IconStack (single layer), not the intended IconStack2 (layers).
+  'stack': tabler('IconStack2', 'IconStack2Filled'),
   'number': tabler('IconHash'),
 
   // Home & navigation
@@ -135,7 +138,7 @@ const SF_TO_TABLER = {
 
   // Security
   'lock.fill': tabler('IconLock', 'IconLockFilled'),
-  'lock': tabler('IconLock'),
+  'lock': tabler('IconLock', 'IconLockFilled'),
   'lock.open': tabler('IconLockOpen'),
   'lock.shield.fill': tabler('IconShieldLock', 'IconShieldLockFilled'),
   'shield': tabler('IconShield', 'IconShieldFilled'),
@@ -331,7 +334,10 @@ const SF_TO_TABLER = {
   // doesn't match Tabler's actual export, so they need explicit mapping).
   'bullhorn': tabler('IconSpeakerphone'),
   'hashtag': tabler('IconHash'),
-  'hand-peace': tabler('IconHandTwoFingers'),
+  'hand-peace': tabler('IconHandLoveYou'),
+  // 'ghost' must map to IconGhost3 (the picker's intended ghost); pascalCase
+  // would otherwise resolve the different IconGhost.
+  'ghost': tabler('IconGhost3', 'IconGhost3Filled'),
   'smile': tabler('IconMoodSmile', 'IconMoodSmileFilled'),
   'party': tabler('IconConfetti', 'IconConfettiFilled'),
   'envelope': tabler('IconMail', 'IconMailFilled'),

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -278,6 +278,27 @@ import IconWifiOff from '@tabler/icons-react-native/IconWifiOff';
 import IconWorld from '@tabler/icons-react-native/IconWorld';
 import IconWorldMap from '@tabler/icons-react-native/IconWorldMap';
 import IconX from '@tabler/icons-react-native/IconX';
+// Channel-icon-picker additions (2026-06-26).
+import IconSticker from '@tabler/icons-react-native/IconSticker';
+import IconTank from '@tabler/icons-react-native/IconTank';
+import IconGenderFemale from '@tabler/icons-react-native/IconGenderFemale';
+import IconGenderMale from '@tabler/icons-react-native/IconGenderMale';
+import IconBomb from '@tabler/icons-react-native/IconBomb';
+import IconBombFilled from '@tabler/icons-react-native/IconBombFilled';
+import IconOm from '@tabler/icons-react-native/IconOm';
+import IconCross from '@tabler/icons-react-native/IconCross';
+import IconCrossFilled from '@tabler/icons-react-native/IconCrossFilled';
+import IconMenorah from '@tabler/icons-react-native/IconMenorah';
+import IconAnkh from '@tabler/icons-react-native/IconAnkh';
+import IconJewishStar from '@tabler/icons-react-native/IconJewishStar';
+import IconJewishStarFilled from '@tabler/icons-react-native/IconJewishStarFilled';
+import IconConfucius from '@tabler/icons-react-native/IconConfucius';
+import IconGhost3 from '@tabler/icons-react-native/IconGhost3';
+import IconGhost3Filled from '@tabler/icons-react-native/IconGhost3Filled';
+import IconSpiral from '@tabler/icons-react-native/IconSpiral';
+import IconHeartHandshake from '@tabler/icons-react-native/IconHeartHandshake';
+import IconFlower from '@tabler/icons-react-native/IconFlower';
+import IconHandLoveYou from '@tabler/icons-react-native/IconHandLoveYou';
 
 export const TablerIcons = {
   IconAi,
@@ -539,4 +560,25 @@ export const TablerIcons = {
   IconWorld,
   IconWorldMap,
   IconX,
+  // Channel-icon-picker additions (2026-06-26).
+  IconSticker,
+  IconTank,
+  IconGenderFemale,
+  IconGenderMale,
+  IconBomb,
+  IconBombFilled,
+  IconOm,
+  IconCross,
+  IconCrossFilled,
+  IconMenorah,
+  IconAnkh,
+  IconJewishStar,
+  IconJewishStarFilled,
+  IconConfucius,
+  IconGhost3,
+  IconGhost3Filled,
+  IconSpiral,
+  IconHeartHandshake,
+  IconFlower,
+  IconHandLoveYou,
 };


### PR DESCRIPTION
Fixes and polish for the channel/group icon picker.

## Rendering
- 'lock' and 'flask' rendered outline in the Filled tab (their SF_TO_TABLER entries were missing the filled variant) — fixed.
- 'stack' resolved IconStack (single) instead of the intended IconStack2 (layers) — added an explicit mapping.
- 'ghost' → IconGhost3, 'hand-peace' → IconHandLoveYou (was a stop/two-fingers hand).
- Registered the new shared picker icons (tank, genders, bomb, religion set, spiral, heart-handshake, flower, sticker, IconHandLoveYou) so they render once mobile bumps quorum-shared.

## Layout
- Colors are a single horizontal-scrolling row, edge to edge — no longer wraps to two rows that pushed the buttons off small screens.
- Icon grid is the only flexible child (shrinks/scrolls at the height cap), so the color row + Reset/Apply stay visible on every device.
- Apply uses a stable primary color instead of the picked icon color (light picks washed it out / broke text contrast).

## Polish
- Channel-settings icons (Read-only / Managers / default) use outline lock/shield/star.
- ActionRow sublabels wrap to multiple lines instead of truncating, so the full text always shows.

The new picker icons themselves come from a separate quorum-shared PR; mobile sees them after the next shared publish + bump. The rendering wiring here is ready for that.