### PR TITLE
feat(dm): signal counterparty to reset encryption session on conversation delete

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -8,6 +8,7 @@ import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useConversation } from '@/hooks/chat/useConversations';
 import { useDMMute } from '@/hooks/chat/useDMMute';
+import { useDeleteConversationSignal } from '@/hooks/chat/useDeleteConversationSignal';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
 import { useStorageAdapter } from '@/context/StorageContext';
 import { useQueryClient } from '@tanstack/react-query';
@@ -245,16 +246,23 @@ export default function DMChatScreen() {
     [updateConversationSetting]
   );
 
-  // Delete this conversation locally (DMs are E2E-encrypted, so this only
-  // removes it from this device). The confirm lives in DMSettingsSheet; this
-  // is the previously-unwired effect. Refresh the conversation list and leave
-  // the now-deleted screen.
+  // Delete this conversation. Like desktop, we FIRST signal the counterparty
+  // (a `delete-conversation` control message) so they reset their encryption
+  // session and the next message cleanly re-handshakes — they do NOT delete
+  // their copy. Then we delete locally (DMs are E2E-encrypted; this only removes
+  // it from this device). The confirm lives in DMSettingsSheet.
+  const sendDeleteConversationSignal = useDeleteConversationSignal();
   const handleDeleteConversation = useCallback(async () => {
     if (!conversationId) return;
+    // Best-effort signal first (Quorum DMs only — Farcaster has no such control
+    // message and no recipientAddress). Failure must not block the local delete.
+    if (recipientAddress && !isFarcasterConversation) {
+      await sendDeleteConversationSignal(conversationId, recipientAddress);
+    }
     await storage.deleteConversation(conversationId);
     queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
     router.back();
-  }, [conversationId, storage, queryClient]);
+  }, [conversationId, recipientAddress, isFarcasterConversation, sendDeleteConversationSignal, storage, queryClient]);
 
   const { initiateCall } = useCall();
   const handleCallPress = useCallback(() => {

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2731,6 +2731,25 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           return;
         }
 
+        // delete-conversation, fallback path (defensive — mirrors the batch
+        // branch): reset the session only, before the save.
+        if (decryptedMessage.content?.type === 'delete-conversation') {
+          encryptionStateStorage.deleteAllEncryptionStates(conversationId);
+          getDeviceKeyset().then(dk => {
+            if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+          });
+          return;
+        }
+
+        // delete-conversation-self: not implemented on mobile yet — drop it so
+        // it isn't saved as a ghost row (forward-compat until mobile Part 2).
+        if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
+          getDeviceKeyset().then(dk => {
+            if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+          });
+          return;
+        }
+
         // Save conversation to storage (creates new or updates existing)
         const existingConversation = await storage.getConversation(conversationId);
         // Get sender display name for preview
@@ -3807,6 +3826,45 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         }
 
         const resolvedSenderAddress = conversationId.split('/')[0];
+
+        // delete-conversation: counterparty deleted this DM. Reset our encryption
+        // session only (next message re-handshakes); do NOT delete our copy.
+        // Before the conversation-save below so it can't resurrect a deleted row.
+        if (decryptedMessage.content?.type === 'delete-conversation') {
+          encryptionStateStorage.deleteAllEncryptionStates(conversationId);
+
+          // Best-effort: clear the processed control message from the inbox.
+          const originalDeleteMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalDeleteMsg) {
+            const conversationKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(originalDeleteMsg.inboxAddress);
+            if (conversationKeypair?.signingPrivateKey && conversationKeypair?.signingPublicKey) {
+              const signingKey = {
+                publicKey: bytesToHex(conversationKeypair.signingPublicKey),
+                privateKey: bytesToHex(conversationKeypair.signingPrivateKey),
+              };
+              deleteConversationInboxMessages(originalDeleteMsg.inboxAddress, [originalDeleteMsg.timestamp], signingKey).catch(() => {});
+            } else {
+              getDeviceKeyset().then(dk => {
+                if (dk) deleteInboxMessages(originalDeleteMsg.inboxAddress, [originalDeleteMsg.timestamp], dk).catch(() => {});
+              });
+            }
+          }
+          continue;
+        }
+
+        // delete-conversation-self: self-device delete-sync (desktop sends it).
+        // Mobile doesn't implement the wipe yet — drop it so it isn't saved as a
+        // ghost row. Forward-compat until mobile Part 2 lands. Never act on it
+        // from a non-self sender regardless.
+        if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
+          const originalSelfMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalSelfMsg) {
+            getDeviceKeyset().then(dk => {
+              if (dk) deleteInboxMessages(originalSelfMsg.inboxAddress, [originalSelfMsg.timestamp], dk).catch(() => {});
+            });
+          }
+          continue;
+        }
 
         // Save conversation
         const existingConversation = await storage.getConversation(conversationId);

--- a/hooks/chat/useDeleteConversationSignal.ts
+++ b/hooks/chat/useDeleteConversationSignal.ts
@@ -1,0 +1,112 @@
+/**
+ * useDeleteConversationSignal - tell the counterparty we deleted this DM.
+ *
+ * Matches desktop: send a `delete-conversation` control message before the local
+ * delete. On receive the counterparty only resets its encryption session (it does
+ * NOT delete its copy) so the next message re-handshakes cleanly. Best-effort —
+ * a send failure must never block the local delete. Reuses the all-devices DM
+ * transport.
+ */
+
+import { useCallback } from 'react';
+import { useAuth, useWebSocket } from '@/context';
+import { getQuorumClient } from '@/services/api/quorumClient';
+import { encryptionService } from '@/services/crypto/encryption-service';
+import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
+import { logger } from '@quilibrium/quorum-shared';
+import type { Message, DeleteConversationMessage } from '@quilibrium/quorum-shared';
+import { sendEncryptedMessageToAllDevices } from './useSendDirectMessage';
+
+type DeviceInfo = {
+  identityKey: number[];
+  signedPreKey: number[];
+  inboxAddress: string;
+  inboxEncryptionKey: number[];
+};
+
+export function useDeleteConversationSignal() {
+  const { user } = useAuth();
+  const { enqueueOutbound, subscribe } = useWebSocket();
+  const apiClient = getQuorumClient();
+
+  // conversationId is `${recipientAddress}/${recipientAddress}` for a DM.
+  return useCallback(
+    async (conversationId: string, recipientAddress: string) => {
+      try {
+        const senderId = user?.address;
+        if (!senderId) return;
+
+        // Mirror the message-delete send: don't gate on isConnected (enqueue and
+        // let the WS client flush on reconnect); we only need device keys to encrypt.
+        if (!encryptionService.hasDeviceKeys()) return;
+
+        const deviceKeyset = await getDeviceKeyset();
+        if (!deviceKeyset) return;
+
+        const nonce = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          const v = c === 'x' ? r : (r & 0x3) | 0x8;
+          return v.toString(16);
+        });
+        const createdDate = Date.now();
+        const controlMessageId = `${nonce}-${createdDate}`;
+
+        // Control message: transported only, never persisted as a chat row.
+        const message: Message = {
+          messageId: controlMessageId,
+          channelId: recipientAddress,
+          spaceId: recipientAddress,
+          digestAlgorithm: 'SHA-256',
+          nonce,
+          createdDate,
+          modifiedDate: createdDate,
+          lastModifiedHash: '',
+          content: {
+            type: 'delete-conversation',
+            senderId,
+          } as DeleteConversationMessage,
+          reactions: [],
+          mentions: { memberIds: [], roleIds: [], channelIds: [] },
+        };
+
+        // Resolve target devices the same way a normal DM send does: the
+        // recipient's devices + our own OTHER devices.
+        const { toAllDeviceInfos } = await import('./useRecipientRegistration');
+        const allTargetDevices: DeviceInfo[] = [];
+        try {
+          const recipientReg = await apiClient.fetchUserRegistration(recipientAddress);
+          if (recipientReg) allTargetDevices.push(...toAllDeviceInfos(recipientReg));
+          const senderReg = await apiClient.fetchUserRegistration(senderId);
+          if (senderReg) {
+            allTargetDevices.push(
+              ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
+            );
+          }
+        } catch {
+          // Registration fetch failed — with no devices the send is skipped.
+        }
+
+        if (allTargetDevices.length === 0) return;
+
+        await sendEncryptedMessageToAllDevices(
+          conversationId,
+          recipientAddress,
+          message,
+          allTargetDevices,
+          enqueueOutbound,
+          subscribe,
+          {
+            identityPublicKey: deviceKeyset.identityPublicKey,
+            inboxAddress: deviceKeyset.inboxAddress,
+            inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+          },
+          senderId,
+          user?.displayName,
+        );
+      } catch (err) {
+        logger.debug('[useDeleteConversationSignal] send failed (local delete stands)', err);
+      }
+    },
+    [user?.address, user?.displayName, enqueueOutbound, subscribe, apiClient],
+  );
+}


### PR DESCRIPTION
Deleting a DM conversation now sends a `delete-conversation` control message to the other person before the local delete, matching desktop. On receive the counterparty does NOT delete their copy: it only resets the encryption session so the next message cleanly re-handshakes instead of getting stuck on a half-torn-down session.

- **Send:** new `useDeleteConversationSignal` hook reusing the all-devices DM transport (same as message-delete in #139), wired into `handleDeleteConversation`.
- **Receive:** `delete-conversation` branch in both DM receive paths (`applyDMGroupResults` + `handleIncomingMessage` fallback), placed before the conversation-save so a signal can't resurrect a row we already deleted.
- **Forward-compat:** silently drop the new `delete-conversation-self` control type (sent by desktop self-sync) instead of saving it as a ghost row; the mobile wipe behavior lands later once shared is published.

**Verified:** tsc + lint clean on changed files; cross-repo correctness review; runtime-verified live — send (to 13 devices), counterparty receive (session reset, conversation kept), and the forward-compat drop (no ghost, no crash) all observed via temporary probes (removed).