### PR TITLE
style: adopt canonical Button across modal/dialog footers + add success/outline/color variants

### DIFF
--- a/components/BlockUserModal.tsx
+++ b/components/BlockUserModal.tsx
@@ -12,8 +12,8 @@
 import { truncateAddress } from '@/utils/formatAddress';
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, Image } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { BaseModal } from '@/components/shared/BaseModal';
+import { Button } from '@/components/ui/Button';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import * as Skin from '@/theme/skins/geometry';
@@ -80,20 +80,12 @@ export function BlockUserModal({
         </Text>
 
         <View style={styles.buttonRow}>
-          <TouchableOpacity
-            style={[styles.button, styles.cancelButton]}
-            onPress={onClose}
-          >
-            <Text style={styles.cancelButtonText}>Cancel</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.button, styles.primaryButton]}
-            onPress={handleConfirm}
-          >
-            <Text style={styles.primaryButtonText}>
-              {isUnblocking ? 'Unblock' : 'Block'}
-            </Text>
-          </TouchableOpacity>
+          <Button variant="secondary" size="lg" onPress={onClose} style={styles.button}>
+            Cancel
+          </Button>
+          <Button variant="primary" size="lg" onPress={handleConfirm} style={styles.button}>
+            {isUnblocking ? 'Unblock' : 'Block'}
+          </Button>
         </View>
       </View>
     </BaseModal>
@@ -161,26 +153,6 @@ const createStyles = (theme: AppTheme) =>
     },
     button: {
       flex: 1,
-      paddingVertical: Skin.space(14),
-      borderRadius: Skin.radius(8),
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cancelButton: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    cancelButtonText: {
-      color: theme.colors.textMain,
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
-    },
-    primaryButton: {
-      backgroundColor: theme.colors.primary,
-    },
-    primaryButtonText: {
-      color: '#fff',
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
     },
   });
 

--- a/components/KickUserModal.tsx
+++ b/components/KickUserModal.tsx
@@ -11,8 +11,8 @@
 import { truncateAddress } from '@/utils/formatAddress';
 import React, { useEffect, useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Image } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { BaseModal } from '@/components/shared/BaseModal';
+import { Button } from '@/components/ui/Button';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import { useUserKicking } from '@/hooks/chat/useUserKicking';
@@ -121,24 +121,24 @@ export function KickUserModal({
 
         {/* Buttons */}
         <View style={styles.buttonRow}>
-          <TouchableOpacity
-            style={[styles.button, styles.cancelButton]}
+          <Button
+            variant="secondary"
+            size="lg"
             onPress={onClose}
             disabled={isSaving}
+            style={styles.button}
           >
-            <Text style={styles.cancelButtonText}>Cancel</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[
-              styles.button,
-              styles.kickButton,
-              (isSaving || kicking) && styles.buttonDisabled,
-            ]}
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            size="lg"
             onPress={handleKickWithOverlay}
             disabled={isSaving || kicking}
+            style={styles.button}
           >
-            <Text style={styles.kickButtonText}>Kick</Text>
-          </TouchableOpacity>
+            Kick
+          </Button>
         </View>
       </View>
     </BaseModal>
@@ -217,29 +217,6 @@ const createStyles = (theme: AppTheme) =>
     },
     button: {
       flex: 1,
-      paddingVertical: Skin.space(14),
-      borderRadius: Skin.radius(8),
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cancelButton: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    cancelButtonText: {
-      color: theme.colors.textMain,
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
-    },
-    kickButton: {
-      backgroundColor: theme.colors.danger ?? '#ef4444',
-    },
-    kickButtonText: {
-      color: '#fff',
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
-    },
-    buttonDisabled: {
-      opacity: 0.5,
     },
   });
 

--- a/components/MiniAppApprovalModal.tsx
+++ b/components/MiniAppApprovalModal.tsx
@@ -10,11 +10,11 @@
 
 import { BaseModal } from '@/components/shared';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
+import { Button } from '@/components/ui/Button';
 import WalletSelector from '@/components/wallet/WalletSelector';
 import { useTheme, type AppTheme } from '@/theme';
 import React from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import {
   TransactionForApproval,
   MessageForApproval,
@@ -300,27 +300,26 @@ export default function MiniAppApprovalModal({
 
         {/* Actions - fixed at bottom */}
         <View style={styles.actions}>
-          <TouchableOpacity
-            style={styles.rejectButton}
+          <Button
+            variant="secondary"
+            size="lg"
             onPress={handleReject}
             disabled={isProcessing}
+            style={styles.button}
           >
-            <Text style={styles.rejectButtonText}>Reject</Text>
-          </TouchableOpacity>
+            Reject
+          </Button>
 
-          <TouchableOpacity
-            style={[styles.approveButton, isProcessing && styles.buttonDisabled]}
+          <Button
+            variant="primary"
+            size="lg"
             onPress={handleApprove}
             disabled={isProcessing}
+            loading={isProcessing}
+            style={styles.button}
           >
-            {isProcessing ? (
-              <ActivityIndicator size="small" color="#fff" />
-            ) : (
-              <Text style={styles.approveButtonText}>
-                {request.type === 'transaction' ? 'Confirm' : 'Sign'}
-              </Text>
-            )}
-          </TouchableOpacity>
+            {request.type === 'transaction' ? 'Confirm' : 'Sign'}
+          </Button>
         </View>
       </View>
     </BaseModal>
@@ -466,33 +465,7 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
       gap: Skin.space(12),
       paddingVertical: Skin.space(16),
     },
-    rejectButton: {
+    button: {
       flex: 1,
-      backgroundColor: theme.colors.surface2,
-      borderRadius: Skin.radius(12),
-      padding: Skin.space(16),
-      alignItems: 'center',
-    },
-    rejectButtonText: {
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.bold.fontFamily,
-      fontWeight: theme.fonts.bold.fontWeight,
-      color: theme.colors.textMain,
-    },
-    approveButton: {
-      flex: 1,
-      backgroundColor: theme.colors.primary,
-      borderRadius: Skin.radius(12),
-      padding: Skin.space(16),
-      alignItems: 'center',
-    },
-    approveButtonText: {
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.bold.fontFamily,
-      fontWeight: theme.fonts.bold.fontWeight,
-      color: '#fff',
-    },
-    buttonDisabled: {
-      opacity: 0.6,
     },
   });

--- a/components/MuteUserModal.tsx
+++ b/components/MuteUserModal.tsx
@@ -13,8 +13,8 @@
 import { truncateAddress } from '@/utils/formatAddress';
 import React, { useEffect, useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Image, TextInput } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { BaseModal } from '@/components/shared/BaseModal';
+import { Button } from '@/components/ui/Button';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import { useModMuteUser } from '@/hooks/chat/useModMuteUser';
@@ -143,20 +143,24 @@ export function MuteUserModal({
         </Text>
 
         <View style={styles.buttonRow}>
-          <TouchableOpacity
-            style={[styles.button, styles.cancelButton]}
+          <Button
+            variant="secondary"
+            size="lg"
             onPress={onClose}
             disabled={isSaving}
+            style={styles.button}
           >
-            <Text style={styles.cancelButtonText}>Cancel</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.button, styles.confirmButton, isSaving && styles.buttonDisabled]}
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            size="lg"
             onPress={handleConfirm}
             disabled={isSaving}
+            style={styles.button}
           >
-            <Text style={styles.confirmButtonText}>{isUnmuting ? 'Unmute' : 'Mute'}</Text>
-          </TouchableOpacity>
+            {isUnmuting ? 'Unmute' : 'Mute'}
+          </Button>
         </View>
       </View>
     </BaseModal>
@@ -264,29 +268,6 @@ const createStyles = (theme: AppTheme) =>
     },
     button: {
       flex: 1,
-      paddingVertical: Skin.space(14),
-      borderRadius: Skin.radius(8),
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cancelButton: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    cancelButtonText: {
-      color: theme.colors.textMain,
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
-    },
-    confirmButton: {
-      backgroundColor: theme.colors.primary,
-    },
-    confirmButtonText: {
-      color: '#fff',
-      fontSize: Skin.font(16),
-      fontFamily: theme.fonts.medium.fontFamily,
-    },
-    buttonDisabled: {
-      opacity: 0.5,
     },
   });
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -2672,7 +2672,7 @@ export default function ProfileModal({
           title="Reset App Data"
           body="This permanently deletes all your data, including your private keys. Back up your recovery phrase first — this cannot be undone."
           keyword="reset"
-          confirmLabel="Reset App Data"
+          confirmLabel="Reset"
           onConfirm={handleResetAppData}
           onCancel={() => setShowResetConfirm(false)}
         />

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -5,9 +5,10 @@
  */
 
 import React, { useState } from 'react';
-import { ActivityIndicator, Alert, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Alert, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
+import { Button } from '@/components/ui/Button';
 import type { AppTheme } from '@/theme';
 import { useTheme } from '@/theme';
 import { useAuth } from '@/context/AuthContext';
@@ -174,28 +175,25 @@ export function ReportModal({ visible, onClose, target, onSubmitted }: ReportMod
             />
 
             <View style={styles.actions}>
-              <TouchableOpacity
+              <Button
+                variant="secondary"
+                size="lg"
                 onPress={handleClose}
-                style={[styles.button, styles.secondary]}
                 disabled={submitting}
+                style={styles.button}
               >
-                <Text style={[styles.buttonLabel, { color: theme.colors.textMain }]}>Cancel</Text>
-              </TouchableOpacity>
-              <TouchableOpacity
+                Cancel
+              </Button>
+              <Button
+                variant="primary"
+                size="lg"
                 onPress={handleSubmit}
                 disabled={!reason || submitting}
-                style={[
-                  styles.button,
-                  styles.primary,
-                  { backgroundColor: theme.colors.primary, opacity: !reason || submitting ? 0.5 : 1 },
-                ]}
+                loading={submitting}
+                style={styles.button}
               >
-                {submitting ? (
-                  <ActivityIndicator color="#fff" />
-                ) : (
-                  <Text style={[styles.buttonLabel, { color: '#fff' }]}>Submit report</Text>
-                )}
-              </TouchableOpacity>
+                Submit report
+              </Button>
             </View>
           </Pressable>
         </KeyboardAvoidingView>
@@ -266,20 +264,7 @@ const createStyles = (theme: AppTheme) =>
       marginTop: Skin.space(4),
     },
     button: {
-      paddingVertical: Skin.space(12),
-      paddingHorizontal: Skin.space(20),
-      borderRadius: Skin.radius(10),
       minWidth: 120,
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    primary: {},
-    secondary: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    buttonLabel: {
-      fontSize: Skin.font(15),
-      fontWeight: '600',
     },
   });
 

--- a/components/TransactionWarningModal.tsx
+++ b/components/TransactionWarningModal.tsx
@@ -1,10 +1,10 @@
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
 import { BaseModal } from '@/components/shared';
+import { Button } from '@/components/ui/Button';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Skin from '@/theme/skins/geometry';
 
@@ -85,7 +85,7 @@ export default function TransactionWarningModal({
   };
 
   const warningConfig = getWarningConfig(warningType);
-  const styles = createStyles(theme, isDark, insets, warningConfig.severity);
+  const styles = createStyles(theme, isDark, insets);
 
   return (
     <BaseModal
@@ -155,20 +155,23 @@ export default function TransactionWarningModal({
 
       {/* Action Buttons */}
       <View style={styles.buttonContainer}>
-        <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
-          <Text style={styles.cancelButtonText}>Cancel</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.proceedButton} onPress={onProceed}>
-          <Text style={styles.proceedButtonText}>
-            {warningConfig.severity === 'high' ? 'Proceed Anyway' : 'Continue'}
-          </Text>
-        </TouchableOpacity>
+        <Button variant="secondary" size="lg" onPress={onClose} style={styles.button}>
+          Cancel
+        </Button>
+        <Button
+          variant={warningConfig.severity === 'high' ? 'danger' : 'primary'}
+          size="lg"
+          onPress={onProceed}
+          style={styles.button}
+        >
+          {warningConfig.severity === 'high' ? 'Proceed Anyway' : 'Continue'}
+        </Button>
       </View>
     </BaseModal>
   );
 }
 
-const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets, severity: 'low' | 'medium' | 'high') =>
+const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
   StyleSheet.create({
     warningHeader: {
       alignItems: 'center',
@@ -258,30 +261,7 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets, seve
       paddingBottom: insets.bottom + 16,
       gap: Skin.space(12),
     },
-    cancelButton: {
+    button: {
       flex: 1,
-      backgroundColor: theme.colors.bgButtonSubtle,
-      paddingVertical: Skin.space(16),
-      borderRadius: Skin.radius(12),
-      alignItems: 'center',
-    },
-    cancelButtonText: {
-      fontSize: Skin.font(16),
-      color: theme.colors.textMain,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-    },
-    proceedButton: {
-      flex: 1,
-      backgroundColor: severity === 'high' ? theme.colors.danger : theme.colors.primary,
-      paddingVertical: Skin.space(16),
-      borderRadius: Skin.radius(12),
-      alignItems: 'center',
-    },
-    proceedButtonText: {
-      fontSize: Skin.font(16),
-      color: '#ffffff',
-      fontFamily: theme.fonts.bold.fontFamily,
-      fontWeight: theme.fonts.bold.fontWeight,
     },
   });

--- a/components/shared/ConfirmDialog.tsx
+++ b/components/shared/ConfirmDialog.tsx
@@ -54,10 +54,10 @@ export function ConfirmDialog({
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.message}>{message}</Text>
       <View style={styles.actions}>
-        <Button variant="secondary" onPress={onCancel} style={styles.button}>
+        <Button variant="secondary" size="lg" onPress={onCancel} style={styles.button}>
           {cancelLabel}
         </Button>
-        <Button variant={variant} onPress={onConfirm} style={styles.button}>
+        <Button variant={variant} size="lg" onPress={onConfirm} style={styles.button}>
           {confirmLabel}
         </Button>
       </View>

--- a/components/shared/ConfirmDialog.tsx
+++ b/components/shared/ConfirmDialog.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useTheme } from '@/theme';
 import { createTheme } from '@/theme/themes';
 import * as Skin from '@/theme/skins/geometry';
+import { Button } from '@/components/ui/Button';
 import { CenterModal } from './CenterModal';
 
 type ThemeType = ReturnType<typeof createTheme>;
@@ -43,7 +43,6 @@ export function ConfirmDialog({
 }: ConfirmDialogProps) {
   const { theme } = useTheme();
   const styles = createStyles(theme);
-  const confirmColor = variant === 'danger' ? theme.colors.danger : theme.colors.primary;
 
   return (
     <CenterModal
@@ -55,22 +54,12 @@ export function ConfirmDialog({
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.message}>{message}</Text>
       <View style={styles.actions}>
-        <TouchableOpacity
-          style={[styles.button, styles.cancelButton]}
-          onPress={onCancel}
-          accessibilityRole="button"
-          accessibilityLabel={cancelLabel}
-        >
-          <Text style={styles.cancelLabel}>{cancelLabel}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={[styles.button, { backgroundColor: confirmColor }]}
-          onPress={onConfirm}
-          accessibilityRole="button"
-          accessibilityLabel={confirmLabel}
-        >
-          <Text style={styles.confirmLabel}>{confirmLabel}</Text>
-        </TouchableOpacity>
+        <Button variant="secondary" onPress={onCancel} style={styles.button}>
+          {cancelLabel}
+        </Button>
+        <Button variant={variant} onPress={onConfirm} style={styles.button}>
+          {confirmLabel}
+        </Button>
       </View>
     </CenterModal>
   );
@@ -98,25 +87,6 @@ const createStyles = (theme: ThemeType) =>
     },
     button: {
       flex: 1,
-      paddingVertical: Skin.space(12),
-      borderRadius: Skin.radius(12),
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cancelButton: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    cancelLabel: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
-    },
-    confirmLabel: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: '#fff',
     },
   });
 

--- a/components/shared/TypeToConfirmModal.tsx
+++ b/components/shared/TypeToConfirmModal.tsx
@@ -107,11 +107,12 @@ export function TypeToConfirmModal({
         />
 
         <View style={styles.actions}>
-          <Button variant="secondary" onPress={handleCancel} style={styles.button}>
+          <Button variant="secondary" size="lg" onPress={handleCancel} style={styles.button}>
             {cancelLabel}
           </Button>
           <Button
             variant="danger"
+            size="lg"
             onPress={onConfirm}
             disabled={!matches}
             style={styles.button}

--- a/components/shared/TypeToConfirmModal.tsx
+++ b/components/shared/TypeToConfirmModal.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import { KeyboardAvoidingView, Platform, StyleSheet, Text, TextInput, View } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useTheme } from '@/theme';
 import { createTheme } from '@/theme/themes';
 import * as Skin from '@/theme/skins/geometry';
+import { Button } from '@/components/ui/Button';
 import { CenterModal } from './CenterModal';
 
 type ThemeType = ReturnType<typeof createTheme>;
@@ -107,26 +107,17 @@ export function TypeToConfirmModal({
         />
 
         <View style={styles.actions}>
-          <TouchableOpacity
-            style={[styles.button, styles.cancelButton]}
-            onPress={handleCancel}
-            accessibilityRole="button"
-            accessibilityLabel={cancelLabel}
-          >
-            <Text style={styles.cancelLabel}>{cancelLabel}</Text>
-          </TouchableOpacity>
-          <TouchableOpacity
-            style={[styles.button, matches ? styles.confirmEnabled : styles.confirmDisabled]}
-            onPress={matches ? onConfirm : undefined}
+          <Button variant="secondary" onPress={handleCancel} style={styles.button}>
+            {cancelLabel}
+          </Button>
+          <Button
+            variant="danger"
+            onPress={onConfirm}
             disabled={!matches}
-            accessibilityRole="button"
-            accessibilityLabel={confirmLabel}
-            accessibilityState={{ disabled: !matches }}
+            style={styles.button}
           >
-            <Text style={[styles.confirmLabel, !matches && styles.confirmLabelDisabled]}>
-              {confirmLabel}
-            </Text>
-          </TouchableOpacity>
+            {confirmLabel}
+          </Button>
         </View>
       </KeyboardAvoidingView>
     </CenterModal>
@@ -199,34 +190,6 @@ const createStyles = (theme: ThemeType) =>
     },
     button: {
       flex: 1,
-      paddingVertical: Skin.space(12),
-      borderRadius: Skin.radius(12),
-      alignItems: 'center',
-      justifyContent: 'center',
-    },
-    cancelButton: {
-      backgroundColor: theme.colors.bgButtonSubtle,
-    },
-    cancelLabel: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: theme.colors.textMain,
-    },
-    confirmEnabled: {
-      backgroundColor: theme.colors.danger,
-    },
-    confirmDisabled: {
-      backgroundColor: theme.colors.surface4,
-    },
-    confirmLabel: {
-      fontSize: Skin.font(15),
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
-      color: '#fff',
-    },
-    confirmLabelDisabled: {
-      color: theme.colors.textMuted,
     },
   });
 

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -15,7 +15,7 @@ import { IconSymbol, type IconSymbolName } from './IconSymbol';
 import * as Skin from '@/theme/skins/geometry';
 import { useSurface } from '@/theme/skins/surfaces';
 
-type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'ghost';
+type ButtonVariant = 'primary' | 'secondary' | 'danger' | 'success' | 'ghost' | 'outline';
 type ButtonSize = 'sm' | 'md' | 'lg';
 
 interface ButtonProps {
@@ -37,6 +37,12 @@ interface ButtonProps {
   onPress: () => void;
   /** Full width button */
   fullWidth?: boolean;
+  /**
+   * Override the fill color for a one-off brand button (e.g. biometric purple,
+   * Apex gold). Applies to `primary`/`danger`/`success` fills; for `outline`
+   * it tints the border + label. Prefer a variant when the color is reusable.
+   */
+  color?: string;
   /** Custom style */
   style?: StyleProp<ViewStyle>;
   /** Test ID */
@@ -67,11 +73,12 @@ export function Button({
   iconPosition = 'left',
   onPress,
   fullWidth = false,
+  color,
   style,
   testID,
 }: ButtonProps) {
   const { theme } = useTheme();
-  const styles = createStyles(theme, variant, size, disabled, fullWidth);
+  const styles = createStyles(theme, variant, size, disabled, fullWidth, color);
 
   // Per-variant skin surface: `button.<variant>` inherits the generic `button`.
   const surface = useSurface(`button.${variant}`);
@@ -81,9 +88,17 @@ export function Button({
   const isDisabled = disabled || loading;
 
   const iconSize = size === 'sm' ? 14 : size === 'md' ? 16 : 18;
-  const iconColor = surface.text ?? (variant === 'ghost'
-    ? (disabled ? theme.colors.textMuted : theme.colors.primary)
-    : (variant === 'secondary' ? theme.colors.textMain : '#ffffff'));
+  // `ghost`/`outline` use a tinted label/icon (the override color, or accent);
+  // `secondary` uses textMain; filled variants (primary/danger/success) use white.
+  const tintedLabel = variant === 'ghost' || variant === 'outline';
+  const iconColor = surface.text ?? (
+    disabled
+      ? theme.colors.textMuted
+      : tintedLabel
+        ? (color ?? theme.colors.primary)
+        : variant === 'secondary'
+          ? theme.colors.textMain
+          : '#ffffff');
 
   const content = (
     <>
@@ -146,18 +161,22 @@ const createStyles = (
   variant: ButtonVariant,
   size: ButtonSize,
   disabled: boolean,
-  fullWidth: boolean
+  fullWidth: boolean,
+  color?: string
 ) => {
   const getBackgroundColor = () => {
     if (disabled) return theme.colors.surface3;
     switch (variant) {
       case 'primary':
-        return theme.colors.primary;
+        return color ?? theme.colors.primary;
       case 'secondary':
         return theme.colors.surface3;
       case 'danger':
-        return theme.colors.danger;
+        return color ?? theme.colors.danger;
+      case 'success':
+        return color ?? theme.colors.success;
       case 'ghost':
+      case 'outline':
         return 'transparent';
     }
   };
@@ -167,11 +186,13 @@ const createStyles = (
     switch (variant) {
       case 'primary':
       case 'danger':
+      case 'success':
         return '#ffffff';
       case 'secondary':
         return theme.colors.textMain;
       case 'ghost':
-        return theme.colors.primary;
+      case 'outline':
+        return color ?? theme.colors.primary;
     }
   };
 
@@ -205,6 +226,12 @@ const createStyles = (
       backgroundColor: getBackgroundColor(),
       borderRadius: size === 'sm' ? 6 : size === 'md' ? 8 : 12,
       ...getPadding(),
+      ...(variant === 'outline'
+        ? {
+            borderWidth: Skin.border(1),
+            borderColor: disabled ? theme.colors.surface5 : (color ?? theme.colors.primary),
+          }
+        : {}),
       ...(fullWidth ? { width: '100%' } : {}),
       opacity: disabled ? 0.6 : 1,
     } as ViewStyle,

--- a/components/ui/EmptyState.tsx
+++ b/components/ui/EmptyState.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View, ViewStyle } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useTheme, type AppTheme } from '@/theme';
 import { IconSymbol, type IconSymbolName } from './IconSymbol';
+import { Button } from './Button';
 import * as Skin from '@/theme/skins/geometry';
 
 interface EmptyStateProps {
@@ -62,13 +62,9 @@ export function EmptyState({
         <Text style={styles.message}>{message}</Text>
       )}
       {actionLabel && onAction && (
-        <TouchableOpacity
-          onPress={onAction}
-          style={styles.actionButton}
-          activeOpacity={0.7}
-        >
-          <Text style={styles.actionText}>{actionLabel}</Text>
-        </TouchableOpacity>
+        <Button variant="primary" onPress={onAction}>
+          {actionLabel}
+        </Button>
       )}
     </View>
   );
@@ -99,18 +95,6 @@ const createStyles = (theme: AppTheme) =>
       textAlign: 'center',
       lineHeight: Skin.font(20),
       marginBottom: Skin.space(20),
-    },
-    actionButton: {
-      paddingVertical: Skin.space(12),
-      paddingHorizontal: Skin.space(24),
-      backgroundColor: theme.colors.primary,
-      borderRadius: Skin.radius(8),
-    },
-    actionText: {
-      fontSize: Skin.font(14),
-      color: '#ffffff',
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
     },
   });
 

--- a/components/ui/ErrorState.tsx
+++ b/components/ui/ErrorState.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { StyleSheet, Text, View, ViewStyle } from 'react-native';
-import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { useTheme, type AppTheme } from '@/theme';
 import { IconSymbol } from './IconSymbol';
+import { Button } from './Button';
 import * as Skin from '@/theme/skins/geometry';
 
 interface ErrorStateProps {
@@ -50,18 +50,9 @@ export function ErrorState({
       </View>
       <Text style={styles.message}>{message}</Text>
       {onRetry && (
-        <TouchableOpacity
-          onPress={onRetry}
-          style={styles.retryButton}
-          activeOpacity={0.7}
-        >
-          <IconSymbol
-            name="arrow.clockwise"
-            size={14}
-            color={theme.colors.primary}
-          />
-          <Text style={styles.retryText}>{retryLabel}</Text>
-        </TouchableOpacity>
+        <Button variant="ghost" size="sm" icon="arrow.clockwise" onPress={onRetry}>
+          {retryLabel}
+        </Button>
       )}
     </View>
   );
@@ -84,21 +75,6 @@ const createStyles = (theme: AppTheme) =>
       textAlign: 'center',
       lineHeight: Skin.font(20),
       marginBottom: Skin.space(16),
-    },
-    retryButton: {
-      flexDirection: 'row',
-      alignItems: 'center',
-      paddingVertical: Skin.space(8),
-      paddingHorizontal: Skin.space(16),
-      backgroundColor: theme.colors.surface2,
-      borderRadius: Skin.radius(8),
-      gap: Skin.space(6),
-    },
-    retryText: {
-      fontSize: Skin.font(14),
-      color: theme.colors.primary,
-      fontFamily: theme.fonts.medium.fontFamily,
-      fontWeight: theme.fonts.medium.fontWeight,
     },
   });
 


### PR DESCRIPTION
Routes hand-rolled footer touchables through the canonical `<Button>` and standardizes all modal/dialog confirm footers, as the first sweep of a UI-consistency audit.

## What changed
- **`<Button>` gains additive props** (no existing call site changes): `variant="success"`, `variant="outline"` (transparent fill + tinted border), and a `color` override for one-off brand fills.
- **Shared confirm shells** (`ConfirmDialog`, `TypeToConfirmModal`) + **EmptyState/ErrorState** now use `<Button>`.
- **Six confirm/action modals** (Block, Kick, Mute, Report, TransactionWarning, MiniAppApproval) routed through `<Button>`.
- **Design standard:** all modal/dialog footer action buttons use `size="lg"` (>=44px touch target, consistent prominence). Manual `disabled`/`loading` styles collapse into Button's built-ins.
- Shortened the Reset App Data confirm label to "Reset" (was wrapping to two lines on small screens).

## Why
Canonical `<Button>` was used in only ~7 files while ~105 buttons were hand-rolled. This is the decoupled first step toward consistency (and a prerequisite for any future move of primitives into quorum-shared).

## Net
**+141 / -352 = -211 lines.**

## Verification
- `npx tsc --noEmit`: clean (no new errors vs master baseline).
- ESLint: no new warnings introduced.
- **In-app (Galaxy A40):** ConfirmDialog + TypeToConfirmModal (Reset App Data) + Report verified green. The remaining modals are structurally identical conversions sharing the same verified spinner/color code paths.

## Follow-up
Remaining button work (save/submit/retry sweep, ActionRow conversions, SegmentedPills consolidation) is tracked in `.agents/tasks/2026-06-28-ui-button-consistency-audit-and-sweep.md` (waves 3-5).