### PR TITLE
Chat UI fixes: spacing, emoji sizing, tab bar over emoji panel

### DIFF
--- a/components/Chat/ChatBottomChrome.tsx
+++ b/components/Chat/ChatBottomChrome.tsx
@@ -26,6 +26,10 @@ import { StyleSheet, View } from 'react-native';
 // padding + margin). Used to pad the list bottom and size the fade.
 const COMPOSER_RESTING_HEIGHT = 60;
 
+// Breathing room above the composer so the newest message doesn't sit flush
+// against the pill. Pads the list bottom only — deliberately NOT the fade height.
+const LAST_MESSAGE_GAP = 12;
+
 // Fade distance ABOVE the composer top. Kept at 0 so the gradient STARTS at the
 // composer top and never dims messages sitting above the composer (any lead here
 // visibly greys the last message line — reported + reverted). The fade covers
@@ -60,7 +64,7 @@ const BOTTOM_OPACITY_LIGHT = 0.30;
  * from the same constants.
  */
 export function useChatListBottomInset(tabBarHeight: number): number {
-  return COMPOSER_RESTING_HEIGHT + tabBarHeight;
+  return COMPOSER_RESTING_HEIGHT + tabBarHeight + LAST_MESSAGE_GAP;
 }
 
 interface ChatBottomChromeProps {

--- a/components/Chat/MentionableText.tsx
+++ b/components/Chat/MentionableText.tsx
@@ -77,6 +77,29 @@ interface TextPart {
 // Excludes digits 0-9 and other text characters that are technically in \p{Emoji}
 const EMOJI_ONLY_REGEX = /^[\p{Emoji_Presentation}\p{Extended_Pictographic}\u{FE0F}\s]+$/u;
 
+// Matches ONE emoji cluster: a base pictographic char plus any variation
+// selectors and ZWJ-joined follow-ups (so 👨‍👩‍👧 counts as one). Used to count
+// how many emojis an emoji-only message holds, for the size tiers below.
+const EMOJI_CLUSTER_REGEX =
+  /\p{Extended_Pictographic}(\u{FE0F}?(‍\p{Extended_Pictographic}\u{FE0F}?)*)/gu;
+
+// Emoji-only messages render bigger than inline emoji, in three tiers by count:
+//   1 emoji  → largest (a single reaction-style emoji reads big)
+//   2–3      → the current large size
+//   4+       → default inline size (a wall of emoji shouldn't dominate the row)
+// Multipliers are applied to the base body font size.
+function emojiOnlyScale(count: number): number {
+  if (count <= 1) return 3;
+  if (count <= 3) return 2;
+  return 1;
+}
+
+// Count emoji clusters in an emoji-only string (whitespace ignored).
+function countEmojiClusters(text: string): number {
+  const matches = text.replace(/\s+/g, '').match(EMOJI_CLUSTER_REGEX);
+  return matches ? matches.length : 0;
+}
+
 function MentionableTextBase({
   text: rawText,
   customEmojis,
@@ -423,8 +446,13 @@ function MentionableTextBase({
     // Check if text is only Unicode emojis
     const isEmojiOnly = text && EMOJI_ONLY_REGEX.test(text.trim());
     if (isEmojiOnly) {
+      const base = style?.fontSize || 16;
+      const size = base * emojiOnlyScale(countEmojiClusters(text));
+      // Pin lineHeight to the font size: a large emoji Text with no lineHeight
+      // gets an oversized line box on Android (extra emoji-font ascent/descent),
+      // which showed as a big empty gap below emoji-only messages.
       return renderWithToggle(
-        <Text style={[style, { fontSize: (style?.fontSize || 16) * 2 }]}>{text}</Text>
+        <Text style={[style, { fontSize: size, lineHeight: size }]}>{text}</Text>
       );
     }
     return renderWithToggle(<Text style={style}>{text}</Text>);
@@ -437,9 +465,31 @@ function MentionableTextBase({
       p.type === 'standard_emoji' ||
       (p.type === 'text' && p.content.trim() === '')
   );
-  const effectiveEmojiSize = isEmojiOnlyMessage ? largeEmojiSize : emojiSize;
+  // Count emojis (custom-image parts + Unicode clusters in standard parts) so an
+  // emoji-only message scales by the same 1 / 2–3 / 4+ tiers as the plain path.
+  const emojiOnlyCount = isEmojiOnlyMessage
+    ? parts.reduce(
+        (n, p) =>
+          n +
+          (p.type === 'emoji'
+            ? 1
+            : p.type === 'standard_emoji'
+            ? countEmojiClusters(p.standardEmoji ?? p.content)
+            : 0),
+        0
+      )
+    : 0;
+  const emojiScale = isEmojiOnlyMessage ? emojiOnlyScale(emojiOnlyCount) : 1;
+  const baseFont = style?.fontSize || 16;
+  const scaledFont = baseFont * emojiScale;
+  // Image emoji scale with the tier too; inline (with-text) keeps emojiSize.
+  const effectiveEmojiSize = isEmojiOnlyMessage
+    ? (largeEmojiSize / 2) * emojiScale
+    : emojiSize;
+  // lineHeight pinned to the font so the enlarged emoji row doesn't reserve the
+  // oversized emoji-font line box on Android (the empty-gap-below bug).
   const effectiveStyle = isEmojiOnlyMessage
-    ? { ...style, fontSize: (style?.fontSize || 16) * 2 }
+    ? { ...style, fontSize: scaledFont, lineHeight: scaledFont }
     : style;
 
   // Mention/channel styling — color-only (no highlighted background). The bg

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1483,11 +1483,16 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   messageHeader: {
     flexDirection: 'row',
     alignItems: 'baseline',
+    // Fixed line box so non-text indicators (warning/pin/edited/spinner) can't
+    // stretch the row taller than the username line and widen the header→text gap.
+    height: Skin.font(20),
   },
   messageUser: {
     color: theme.colors.textStrong,
     fontFamily: theme.fonts.medium.fontFamily,
     fontWeight: theme.fonts.medium.fontWeight,
+    fontSize: Skin.font(14),
+    lineHeight: Skin.font(20),
     marginRight: Skin.space(8),
     flexShrink: 1,
   },

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1489,8 +1489,8 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
   },
   messageUser: {
     color: theme.colors.textStrong,
-    fontFamily: theme.fonts.medium.fontFamily,
-    fontWeight: theme.fonts.medium.fontWeight,
+    fontFamily: theme.fonts.bold.fontFamily,
+    fontWeight: theme.fonts.bold.fontWeight,
     fontSize: Skin.font(14),
     lineHeight: Skin.font(20),
     marginRight: Skin.space(8),

--- a/components/ui/AppTabBar.tsx
+++ b/components/ui/AppTabBar.tsx
@@ -347,21 +347,27 @@ export function AppTabBar({ state, navigation }: BottomTabBarProps) {
     opacity: composerBottomBusySV.value === 1 ? 0 : 1,
   }));
 
+  // Safe-area fill keeps a scrim behind the device nav buttons. Unlike the bar,
+  // it must NOT fully vanish when a composer panel owns the bottom — it drops to
+  // a partial opacity so the panel shows faintly through while the buttons stay
+  // legible (a fully transparent strip made them near-invisible).
+  const safeAreaFillStyle = useAnimatedStyle(() => ({
+    opacity: composerBottomBusySV.value === 1 ? 0.75 : 1,
+  }));
+
   return (
     <>
-      {/* Safe-area fill: the bar floats `insets.bottom` above the screen edge so
-          its rows clear the home indicator / app-switcher. That strip below the
-          bar is otherwise transparent, letting scrolled content show through (iOS,
-          and any Android with a bottom inset). Paint it the same solid bar color so
-          the bottom edge reads as one continuous surface. Shares hideStyle so it
-          fades out in lockstep with the bar when a composer panel owns the bottom. */}
+      {/* Safe-area fill: scrim behind the device nav buttons / home indicator so
+          scrolled content (incl. the emoji panel) doesn't show through solid. Uses
+          safeAreaFillStyle, not hideStyle: it stays partly opaque when a composer
+          panel owns the bottom so the buttons remain legible. */}
       {insets.bottom > 0 && (
         <Reanimated.View
           pointerEvents="none"
           style={[
             styles.safeAreaFill,
             { height: insets.bottom, backgroundColor: isDark ? '#000000' : '#ffffff' },
-            hideStyle,
+            safeAreaFillStyle,
           ]}
         />
       )}

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -329,10 +329,19 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
   // and it never fights a legitimate hold (panel open or mid hand-off both keep
   // one of the two flags set). Mirror of the channels "bar visible above panel"
   // bug — same flag, opposite direction — so this hardens both.
+  // Emits: 1 = force-hold busy, 0 = force-release busy, -1 = leave alone.
   useAnimatedReaction(
     () => {
-      if (panelOpenSV.value === 1) return false; // panel open → legitimately busy
-      if (closingSV.value === 0) return true; // closed, no hand-off → must be idle
+      // Panel open → the bottom is legitimately busy. ENFORCE it (not just
+      // "don't release"): on the keyboard-first open path the dismiss's
+      // onEnd(height=0) worklet can run in the window before openPanel's
+      // JS-thread `panelOpenSV=1` write has propagated to the UI thread, so its
+      // `panelOpenSV !== 1` guard reads a stale 0 and clears the flag while the
+      // panel is open. Nothing re-set it, so the tab bar stayed visible over the
+      // panel until close (intermittent — depends on that write race). Re-holding
+      // here self-heals that within a frame. Mirror of the release direction.
+      if (panelOpenSV.value === 1) return 1;
+      if (closingSV.value === 0) return 0; // closed, no hand-off → must be idle
       // A hand-off is armed (closingSV===1). It's legitimate ONLY while the
       // summoned keyboard is rising. Once the keyboard is essentially fully up,
       // the hand-off is effectively complete even if onEnd hasn't fired — so the
@@ -340,11 +349,14 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
       // race that otherwise leaves both flags stuck and the tab bar hidden.
       const liveKb = Math.max(-keyboardHeight.value, 0);
       const kbTarget = lastKeyboardHeight.value;
-      return kbTarget > 0 && liveKb >= kbTarget * 0.9;
+      return kbTarget > 0 && liveKb >= kbTarget * 0.9 ? 0 : -1;
     },
-    (shouldRelease) => {
-      if (shouldRelease && composerBottomBusySV.value !== 0) {
-        composerBottomBusySV.value = 0;
+    (action) => {
+      if (action === 1) {
+        // Panel open but the flag got cleared by the open-path race → re-hold.
+        if (composerBottomBusySV.value !== 1) composerBottomBusySV.value = 1;
+      } else if (action === 0) {
+        if (composerBottomBusySV.value !== 0) composerBottomBusySV.value = 0;
         // Disarm the hand-off too so it can't re-trigger a stuck state.
         if (closingSV.value !== 0) closingSV.value = 0;
       }


### PR DESCRIPTION
A batch of small chat/UI fixes.

## Fixes

- **Space below last message**: the newest message sat flush against the composer. Added a small breathing-room gap to the chat list's bottom inset (applies to both spaces and DMs).

- **Uneven header-to-text spacing**: messages with indicators (unsigned warning, pin, "(edited)", sending spinner) showed a larger gap between the username and the first line than messages without them, because those non-text icons stretched the baseline-aligned header row. Pinned the header to a fixed line box so the gap is consistent.

- **Safe-area strip behind device nav buttons**: when the emoji panel was open, the strip behind the Android device buttons faded out completely (it shared the tab bar's hide animation), leaving the buttons nearly invisible. It now stays partly opaque so the buttons remain legible while the panel shows faintly through.

- **Tab bar visible over the emoji panel**: opening the emoji panel from an already-open keyboard sometimes left the bottom tab bar visible on top of the panel. Root cause was a UI-thread/JS-thread timing race where the keyboard-dismiss handler could clear the "composer owns the bottom" flag before the panel-open flag propagated. The self-correcting guard now re-asserts the flag while the panel is open, so it self-heals within a frame.

- **Emoji-only messages**: removed the large empty space below emoji-only messages (missing lineHeight on the enlarged text reserved an oversized emoji-font line box on Android). Also sized emoji-only messages by count: 1 emoji renders largest, 2-3 keep the current size, 4+ drop to the default inline size.

- **Bold display name**: message author display names now render bold.

All changes are JS/layout only (no native code).