### PR TITLE
Fix per-space profile edits: save, clear, and render correctly

### DIFF
--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -60,7 +60,8 @@ import { pickImage, compressAvatarImage } from '@/services/media/imageAttachment
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import { truncateAddress } from '@/utils/formatAddress';
-import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
+import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, queryKeys, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
+import { useQueryClient } from '@tanstack/react-query';
 import { resolveChannelIconColor } from '@/utils/channelIcon';
 import * as Clipboard from 'expo-clipboard';
 import React, { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -508,6 +509,7 @@ export default function SpaceSettingsModal({
   const styles = createStyles(theme, insets);
   const { user } = useAuth();
   const { enqueueOutbound } = useWebSocket();
+  const queryClient = useQueryClient();
 
   // Determine if user is space owner
   const isSpaceOwner = useMemo(() => {
@@ -678,6 +680,13 @@ export default function SpaceSettingsModal({
       };
       await adapter.saveSpaceMember(spaceId, merged as never);
 
+      // The member record is served to the channel UI via the
+      // useSpaceMembers React Query cache (2-min staleTime). Writing MMKV
+      // above doesn't refresh that cache, so without this the sender's own
+      // messages keep showing the old name/avatar until a remount. Invalidate
+      // so the open channel re-reads the updated member immediately.
+      queryClient.invalidateQueries({ queryKey: queryKeys.spaces.members(spaceId) });
+
       // Broadcast — only fields that actually changed since baseline
       // get included so we don't clobber stale fields with empty
       // values. maybeSendUpdateProfileMessage gates duplicate sends.
@@ -696,14 +705,18 @@ export default function SpaceSettingsModal({
         channelId,
         senderAddress: user.address,
       };
+      // Pass the RAW value (including '') when the field changed, so an
+      // explicit clear — cleared per-space name / removed avatar — reaches
+      // other members instead of being stripped to undefined ("no change").
+      // The service honors '' as a deliberate clear now (mirrors bio).
       if (spaceProfileDisplayName !== spaceProfileBaseline.displayName) {
-        params.displayName = spaceProfileDisplayName || undefined;
+        params.displayName = spaceProfileDisplayName;
       }
       if (spaceProfileBio !== spaceProfileBaseline.bio) {
         params.bio = spaceProfileBio;
       }
       if (spaceProfileImage !== spaceProfileBaseline.profileImage) {
-        params.userIcon = spaceProfileImage || undefined;
+        params.userIcon = spaceProfileImage;
       }
       // Auto-include Farcaster linkage whenever the user has one.
       // The broadcast gate (maybeSendUpdateProfileMessage) dedupes
@@ -742,6 +755,7 @@ export default function SpaceSettingsModal({
     spaceProfileImage,
     spaceProfileBaseline,
     enqueueOutbound,
+    queryClient,
   ]);
 
   // Tab state - default to 'account' for non-owners
@@ -1519,7 +1533,14 @@ export default function SpaceSettingsModal({
           {spaceProfileImage ? (
             <Image source={{ uri: spaceProfileImage }} style={{ width: 72, height: 72 }} />
           ) : (
-            <IconSymbol name="person.crop.circle" color={theme.colors.textMuted} size={36} />
+            // No image → show initials (matches the app-wide no-avatar
+            // fallback), using the per-space name if set, else the user's
+            // global name / address so the initials are still recognizable.
+            <DefaultAvatar
+              displayName={spaceProfileDisplayName || user?.displayName || user?.username}
+              address={user?.address}
+              size={72}
+            />
           )}
         </TouchableOpacity>
         <View style={{ flex: 1, marginLeft: Skin.space(16) }}>

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2155,7 +2155,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 // The sender omits displayName on bio/avatar-only edits, so
                 // '' on the wire is always an intentional clear.
                 ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
-                ...(profileContent.userIcon ? { profile_image: profileContent.userIcon } : {}),
+                // Presence check (not truthy), same as displayName/bio: '' is a
+                // deliberate avatar clear that must land, not be dropped as
+                // "no change". The sender omits userIcon on name/bio-only edits.
+                ...(profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
                 ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
                 ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
                   ? { farcasterFid: profileContent.farcasterFid }
@@ -3596,7 +3599,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // per-space-name clear, matching bio + desktop's receiver. See
               // the matching comment in the JS-path handler above.
               ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
-              ...(profileContent.userIcon ? { profile_image: profileContent.userIcon } : {}),
+              // Presence check (not truthy): '' is a deliberate avatar clear,
+              // matching displayName/bio + desktop's receiver.
+              ...(profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
               ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
               ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
                 ? { farcasterFid: profileContent.farcasterFid }

--- a/hooks/useMembersWithPublicProfileFallback.ts
+++ b/hooks/useMembersWithPublicProfileFallback.ts
@@ -114,7 +114,13 @@ export function useMembersWithPublicProfileFallback(
       const chatTs = local?.profileTimestamp;
       const chatIsNewer = chatTs != null && chatTs >= pub.timestamp;
       const pickField = (localVal: string | undefined, pubVal: string) => {
-        if (chatIsNewer) return localVal || pubVal || '';
+        // When the local (per-space) record is the newer source, its value
+        // WINS — including a deliberate empty '' (a cleared avatar / name),
+        // which must not fall back to the older public-profile value.
+        // `!== undefined` keeps the intended "explicit clear wins" without
+        // resurrecting the global value. Absent (undefined) still falls
+        // through to the public profile (partial-update / never-set case).
+        if (chatIsNewer) return localVal !== undefined ? localVal : pubVal || '';
         return pubVal || localVal || '';
       };
       merged[addr] = {

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -29,6 +29,7 @@ import {
   type RemoveMessage,
   type RemoveReactionMessage,
   type StickerMessage,
+  type UpdateProfileMessage,
   type SpaceCallStartMessage,
   type SpaceCallEndMessage,
   // New sync types
@@ -219,6 +220,18 @@ function canonicalizeContent(content: MessageContent): string {
   if (content.type === 'space-call-end') {
     const c = content as SpaceCallEndMessage;
     return content.type + c.callId;
+  }
+
+  // update-profile. MUST match shared canonicalize() byte-for-byte
+  // (quorum-shared 'update-profile' branch: type + displayName + userIcon, raw
+  // concatenation with NO ?? '' fallback) so a profile update signed on mobile
+  // verifies on desktop. When a field is omitted on the wire, JS concatenates
+  // the literal string "undefined" — shared does the same, so do NOT add a
+  // fallback here. bio/farcaster fields are intentionally excluded from the hash
+  // on both sides; matching shared is the requirement, not covering more fields.
+  if (content.type === 'update-profile') {
+    const updateProfileContent = content as UpdateProfileMessage;
+    return content.type + updateProfileContent.displayName + updateProfileContent.userIcon;
   }
 
   // Default: stringify the content
@@ -906,11 +919,18 @@ export async function sendUpdateProfileMessage(
 ): Promise<SendGenericMessageResult> {
   const { spaceId, channelId, senderAddress, displayName, userIcon, bio, farcasterFid, farcasterUsername } = params;
 
+  // displayName/userIcon use `!== undefined` (not a truthy check) so a caller
+  // that explicitly passes '' — a deliberate clear (removed avatar / cleared
+  // per-space name) — puts the empty value on the wire and clears it for other
+  // members. Callers that mean "no change" MUST pass undefined, never ''.
+  // (The on-connect rebroadcast in WebSocketContext passes `x || undefined`,
+  // so it stays omission-based and can't clobber a stored value with an
+  // incidental empty.) bio already worked this way.
   const content = {
     type: 'update-profile' as const,
     senderId: senderAddress,
-    ...(displayName ? { displayName } : {}),
-    ...(userIcon ? { userIcon } : {}),
+    ...(displayName !== undefined ? { displayName } : {}),
+    ...(userIcon !== undefined ? { userIcon } : {}),
     ...(bio !== undefined && { bio }),
     ...(farcasterFid !== undefined && farcasterFid > 0 ? { farcasterFid } : {}),
     ...(farcasterUsername ? { farcasterUsername } : {}),
@@ -946,8 +966,10 @@ function profileBroadcastKey(spaceId: string, senderAddress: string): string {
 // signatures), and field values matter. Stable JSON: keys sorted.
 function profileBroadcastSignature(p: SendUpdateProfileParams): string {
   const obj: Record<string, string> = {};
-  if (p.displayName) obj.displayName = p.displayName;
-  if (p.userIcon) obj.userIcon = p.userIcon;
+  // `!== undefined` (not truthy) so an explicit clear ('') produces a distinct
+  // signature and isn't deduped away — matches the wire builder above.
+  if (p.displayName !== undefined) obj.displayName = p.displayName;
+  if (p.userIcon !== undefined) obj.userIcon = p.userIcon;
   if (p.bio !== undefined) obj.bio = p.bio;
   if (p.farcasterFid !== undefined && p.farcasterFid > 0) {
     obj.farcasterFid = String(p.farcasterFid);


### PR DESCRIPTION
Per-space profile edits (display name and avatar) had several issues; this fixes them end to end and makes the empty-vs-cleared distinction consistent with desktop.

## Changes
- **Canonicalization:** add an `update-profile` branch to `canonicalizeContent` matching quorum-shared byte-for-byte (`type + displayName + userIcon`). Without it, mobile's profile updates failed desktop's signature/messageId check and were silently dropped.
- **Clears propagate:** a deliberately cleared display name or avatar now sends an explicit empty string instead of being stripped to `undefined` ("no change"), so clears reach other clients. Mirrors how `bio` already worked.
- **Own UI updates immediately:** invalidate the space-members query after a per-space profile save, so the sender's own channel reflects the change without a reload.
- **Initials fallback:** the space profile editor shows initials when there's no image, instead of a generic person icon.
- **No avatar resurrection:** honor an empty `userIcon` on receive, and stop the public-profile backfill from re-applying a cleared avatar (empty wins; only an absent value backfills).

## Model
Three states, discriminated by presence not truthiness: `undefined` = no change (backfill allowed), `''` = deliberate clear (wins, shows initials), value = the image.

## Testing
Mobile→desktop verified 2026-07-15: set avatar, clear avatar, and change display name all propagate correctly. No new type errors.

Paired with quorum-desktop PR (fix-userIcon-clear-propagation) which applies the same model on the receive/render side.