### PR TITLE
feat: per-space profile follows global unless overridden

### DIFF
--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -1553,7 +1553,7 @@ export default function SpaceSettingsModal({
             // not "Remove" — there is no per-space blank; clearing the override
             // reverts to the global avatar. (Follow-global design.)
             <TouchableOpacity onPress={() => setSpaceProfileImage('')} style={{ marginTop: Skin.space(4) }} aria-label="Use my main avatar in this space">
-              <Text style={{ color: theme.colors.primary, fontSize: Skin.font(13) }}>Use my main avatar</Text>
+              <Text style={{ color: theme.colors.danger, fontSize: Skin.font(13) }}>Use my main avatar</Text>
             </TouchableOpacity>
           ) : null}
         </View>

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -663,11 +663,10 @@ export default function SpaceSettingsModal({
       // Optimistically update the local SpaceMember so the UI
       // reflects the new values immediately. Receivers apply the
       // same fields on their end when our update-profile broadcast
-      // lands. Note: clearing fields (e.g. removing the avatar)
-      // works locally but the current update-profile wire shape
-      // skips empty fields, so other members keep seeing the old
-      // value until we add a clear-field signal. Tracked as a known
-      // limitation; flag if you hit it.
+      // lands. Clearing a field (e.g. reverting the avatar to follow
+      // global) sends an explicit '' below, which the service honors
+      // as a deliberate clear — receivers drop the override and fall
+      // back to the sender's global value via the render fallback.
       const adapter = getMMKVAdapter();
       const existing = await adapter.getSpaceMember(spaceId, user.address);
       const merged = {
@@ -1548,8 +1547,13 @@ export default function SpaceSettingsModal({
             </Text>
           </TouchableOpacity>
           {spaceProfileImage ? (
-            <TouchableOpacity onPress={() => setSpaceProfileImage('')} style={{ marginTop: Skin.space(4) }}>
-              <Text style={{ color: theme.colors.danger, fontSize: Skin.font(13) }}>Remove</Text>
+            // Revert this per-space OVERRIDE back to following the global
+            // avatar. Only shown when an override exists (spaceProfileImage is
+            // non-empty). Labeled by its true effect ("Use my main avatar"),
+            // not "Remove" — there is no per-space blank; clearing the override
+            // reverts to the global avatar. (Follow-global design.)
+            <TouchableOpacity onPress={() => setSpaceProfileImage('')} style={{ marginTop: Skin.space(4) }} aria-label="Use my main avatar in this space">
+              <Text style={{ color: theme.colors.primary, fontSize: Skin.font(13) }}>Use my main avatar</Text>
             </TouchableOpacity>
           ) : null}
         </View>

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -7,6 +7,7 @@ import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import { updateFarcasterProfile } from '@/services/farcaster/updateProfile';
 import { getAllSpaces } from '@/services/config/spaceStorage';
 import { maybeSendUpdateProfileMessage } from '@/services/space/spaceMessageService';
+import { publicProfileQueryKey, type PublicProfile } from '@/hooks/useUserPublicProfile';
 import { compressAvatarImage } from '@/services/media/imageAttachment';
 import { useTheme, type AppTheme } from '@/theme';
 import * as ImagePicker from 'expo-image-picker';
@@ -125,6 +126,25 @@ export default function UnifiedProfileEditModal({
       bio: b || undefined,
       profileImage: avatar ?? undefined,
     });
+
+    // Refresh our own public-profile cache. Non-overridden spaces render our
+    // name/avatar via this cache (1h staleTime), so without this a global change
+    // wouldn't reach already-rendered messages until the cache expired. Set
+    // optimistically for an instant update; only refetch when public (a private
+    // profile 404s to null, which would blank the optimistic value).
+    if (user?.address) {
+      const key = publicProfileQueryKey(user.address);
+      queryClient.setQueryData<PublicProfile | null>(key, (prev) => ({
+        display_name: name,
+        profile_image: avatar ?? '',
+        bio: user.isProfilePublic ? b : (prev?.bio ?? ''),
+        timestamp: Date.now(),
+        signature: prev?.signature ?? '',
+      }));
+      if (user.isProfilePublic) {
+        void queryClient.invalidateQueries({ queryKey: key });
+      }
+    }
 
     // Broadcast to all spaces
     const spaces = getAllSpaces();

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -15,9 +15,11 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { ActivityIndicator, Alert, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as Skin from '@/theme/skins/geometry';
+import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
 import {
   validateDisplayName,
   validateUserBio,
+  queryKeys,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
@@ -166,24 +168,47 @@ export default function UnifiedProfileEditModal({
       }
     }
 
-    // Broadcast to all spaces
+    // Broadcast the new GLOBAL identity to all spaces — via the global* slots,
+    // NOT the per-space override fields. This is the two-slot fix: a global
+    // rename reaches spacemates live without being stored as a per-space
+    // override (which would freeze the space and defeat follow-global). We send
+    // the actual values (empty string = deliberate global clear); bio stays
+    // gated on the public toggle to preserve prior bio-privacy behavior.
+    // Also write our OWN roster global slots locally so this device (and
+    // non-public users) render the new global value immediately.
     const spaces = getAllSpaces();
     if (spaces.length > 0) {
+      const adapter = getMMKVAdapter();
+      const selfAddress = user.address;
+      const globalBioValue = user.isProfilePublic ? b : undefined;
+      // Local self-apply of global slots (best-effort, per space).
+      for (const space of spaces) {
+        try {
+          const existing = await adapter.getSpaceMember(space.spaceId, selfAddress);
+          await adapter.saveSpaceMember(space.spaceId, {
+            ...(existing ?? { address: selfAddress, inbox_address: '' }),
+            global_display_name: name,
+            global_profile_image: avatar ?? '',
+            ...(globalBioValue !== undefined ? { global_bio: globalBioValue } : {}),
+            globalProfileTimestamp: Date.now(),
+          } as never);
+          queryClient.invalidateQueries({ queryKey: queryKeys.spaces.members(space.spaceId) });
+        } catch {
+          // Non-fatal — the broadcast below still informs other members.
+        }
+      }
+
       enqueueOutbound(async () => {
         const envelopes: string[] = [];
         for (const space of spaces) {
           try {
-            // Only include fields that have a real value — empty
-            // strings would clobber recipients' stored values for
-            // those fields under the receiver's "treat present as
-            // assigned" rule.
             const res = await maybeSendUpdateProfileMessage({
               spaceId: space.spaceId,
               channelId: space.defaultChannelId,
-              senderAddress: user.address,
-              displayName: name || undefined,
-              userIcon: avatar || undefined,
-              bio: user.isProfilePublic ? b : undefined,
+              senderAddress: selfAddress,
+              globalDisplayName: name,
+              globalUserIcon: avatar ?? '',
+              globalBio: globalBioValue,
             });
             if (res) {
               envelopes.push(res.wsEnvelope);

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -20,6 +20,7 @@ import {
   validateDisplayName,
   validateUserBio,
   queryKeys,
+  type SpaceMember,
 } from '@quilibrium/quorum-shared';
 import {
   translateValidationResult,
@@ -196,7 +197,12 @@ export default function UnifiedProfileEditModal({
             global_profile_image: avatar ?? '',
             global_bio: globalBioValue,
             globalProfileTimestamp: Date.now(),
-          } as never);
+          } as SpaceMember & {
+            global_display_name?: string;
+            global_profile_image?: string;
+            global_bio?: string;
+            globalProfileTimestamp?: number;
+          });
           queryClient.invalidateQueries({ queryKey: queryKeys.spaces.members(space.spaceId) });
         } catch {
           // Non-fatal — the broadcast below still informs other members.

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -127,11 +127,31 @@ export default function UnifiedProfileEditModal({
       profileImage: avatar ?? undefined,
     });
 
+    // Publish the new profile to the public-profile server when public.
+    // Without this, mobile edits never reach the server, so other devices'
+    // published value (and our own space messages, which render via the
+    // public-profile fallback) keep showing the stale name/avatar. Best-effort:
+    // the local save is the source of truth; a failed publish only warns.
+    if (user?.address && user.isProfilePublic) {
+      try {
+        const { publishPublicProfile } = await import('@/services/profile/publicProfile');
+        await publishPublicProfile({
+          address: user.address,
+          displayName: name,
+          profileImage: avatar ?? '',
+          bio: b,
+          primaryUsername: user.primaryUsername,
+        });
+      } catch (e) {
+        Alert.alert('Profile not published', 'Your profile was saved on this device but could not be published publicly. Other devices may show an old name until you retry.');
+      }
+    }
+
     // Refresh our own public-profile cache. Non-overridden spaces render our
     // name/avatar via this cache (1h staleTime), so without this a global change
     // wouldn't reach already-rendered messages until the cache expired. Set
-    // optimistically for an instant update; only refetch when public (a private
-    // profile 404s to null, which would blank the optimistic value).
+    // optimistically for an instant update; refetch (public only) reads the
+    // value we just published above, not another device's stale one.
     if (user?.address) {
       const key = publicProfileQueryKey(user.address);
       queryClient.setQueryData<PublicProfile | null>(key, (prev) => ({

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -180,7 +180,12 @@ export default function UnifiedProfileEditModal({
     if (spaces.length > 0) {
       const adapter = getMMKVAdapter();
       const selfAddress = user.address;
-      const globalBioValue = user.isProfilePublic ? b : undefined;
+      // Global bio propagates to SPACEMATES like the name/avatar — NOT gated on
+      // the public toggle. The public toggle only controls the stranger-facing
+      // public-profile server (channel B), not what your spacemates see. Empty
+      // string = a deliberately empty global bio. (Per-space bio override still
+      // wins where set.) See identity-resolution doc.
+      const globalBioValue = b;
       // Local self-apply of global slots (best-effort, per space).
       for (const space of spaces) {
         try {
@@ -189,7 +194,7 @@ export default function UnifiedProfileEditModal({
             ...(existing ?? { address: selfAddress, inbox_address: '' }),
             global_display_name: name,
             global_profile_image: avatar ?? '',
-            ...(globalBioValue !== undefined ? { global_bio: globalBioValue } : {}),
+            global_bio: globalBioValue,
             globalProfileTimestamp: Date.now(),
           } as never);
           queryClient.invalidateQueries({ queryKey: queryKeys.spaces.members(space.spaceId) });

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -4843,6 +4843,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // store them apart. (Two-slot design — identity-resolution doc.)
               globalDisplayName: displayName || undefined,
               globalUserIcon: userIcon || undefined,
+              // Global bio propagates to spacemates ungated (not gated on the
+              // public toggle) — matches the global-save path and desktop.
+              globalBio: user.bio || undefined,
               // Include Farcaster linkage if linked so peers can
               // surface it in UserProfileModal. Gate dedupes on
               // signature so this is a no-op once recorded.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -4775,14 +4775,28 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // running this on every connect is cheap and safe.
         runProfileBroadcastMigrations();
         const spaces = getAllSpaces();
+        const adapter = getMMKVAdapter();
         for (const space of spaces) {
           try {
+            // Per-space profile follows the global value unless the user
+            // set a deliberate OVERRIDE in this space. The stored member
+            // row carries an override iff its field is a non-empty value;
+            // empty/absent = follow global. We must NOT stamp the global
+            // value as a per-space field (that froze the space to a stale
+            // global and broke "clear the override" — the bug this whole
+            // effort removes). So: send the per-space override if one
+            // exists, else OMIT the field so receivers fall back to the
+            // sender's global (public-profile) value.
+            // (See 2026-07-15-per-space-profile-empty-follows-global design.)
+            const member = await adapter.getSpaceMember(space.spaceId, user.address);
+            const nameOverride = member?.display_name || undefined;
+            const iconOverride = member?.profile_image || undefined;
             const res = await maybeSendUpdateProfileMessage({
               spaceId: space.spaceId,
               channelId: space.defaultChannelId,
               senderAddress: user.address,
-              displayName: displayName || undefined,
-              userIcon: userIcon || undefined,
+              displayName: nameOverride,
+              userIcon: iconOverride,
               // Include Farcaster linkage if linked so peers can
               // surface it in UserProfileModal. Gate dedupes on
               // signature so this is a no-op once recorded.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2117,13 +2117,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 displayName?: string;
                 userIcon?: string;
                 bio?: string;
+                globalDisplayName?: string;
+                globalUserIcon?: string;
+                globalBio?: string;
                 farcasterFid?: number;
                 farcasterUsername?: string;
               };
 
               const adapter = getMMKVAdapter();
               const existingMember = await adapter.getSpaceMember(spaceId, profileContent.senderId) as
-                | (SpaceMember & { profileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string })
+                | (SpaceMember & { profileTimestamp?: number; globalProfileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string })
                 | undefined;
 
               // Stamp the merge with the wire message's createdDate so the
@@ -2131,9 +2134,29 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // both exist for the same user.
               const ts = spaceMessage.createdDate || Date.now();
 
-              // Skip stale updates — older than the timestamp we already
-              // applied for this member.
-              if (existingMember?.profileTimestamp && existingMember.profileTimestamp >= ts) {
+              // Two-slot staleness: OVERRIDE fields (display_name/profile_image/
+              // bio) and GLOBAL fields (global_*) each have their own timestamp
+              // guard, so a global-only rename message isn't dropped by a newer
+              // override message (or vice versa). See identity-resolution doc.
+              const hasOverrideFields =
+                profileContent.displayName !== undefined ||
+                profileContent.userIcon !== undefined ||
+                profileContent.bio !== undefined;
+              const hasGlobalFields =
+                profileContent.globalDisplayName !== undefined ||
+                profileContent.globalUserIcon !== undefined ||
+                profileContent.globalBio !== undefined;
+              const applyOverride =
+                hasOverrideFields &&
+                !(existingMember?.profileTimestamp && existingMember.profileTimestamp >= ts);
+              const applyGlobal =
+                hasGlobalFields &&
+                !(existingMember?.globalProfileTimestamp && existingMember.globalProfileTimestamp >= ts);
+
+              // Nothing to apply (both slots stale or absent, ignoring Farcaster
+              // which follows the override guard) — drop the inbox message and
+              // return, matching the prior single-guard behavior.
+              if (!applyOverride && !applyGlobal && !hasGlobalFields) {
                 if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
                   deleteSpaceInboxMessages(
                     spaceInboxKey.address,
@@ -2149,23 +2172,24 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   address: profileContent.senderId,
                   inbox_address: '',
                 }),
-                // Presence check (not truthy): an empty displayName is a
-                // deliberate per-space-name clear ("use my global/QNS name
-                // here"), matching bio's semantics and desktop's receiver.
-                // The sender omits displayName on bio/avatar-only edits, so
-                // '' on the wire is always an intentional clear.
-                ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
-                // Presence check (not truthy), same as displayName/bio: '' is a
-                // deliberate avatar clear that must land, not be dropped as
-                // "no change". The sender omits userIcon on name/bio-only edits.
-                ...(profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
-                ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
-                ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
+                // OVERRIDE slot — applied only when newer. Presence check (not
+                // truthy): an empty displayName is a deliberate per-space clear
+                // ("follow my global name here"). '' on the wire is intentional.
+                ...(applyOverride && profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
+                ...(applyOverride && profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
+                ...(applyOverride && profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
+                ...(applyOverride ? { profileTimestamp: ts } : {}),
+                // GLOBAL slot — the sender's current global identity, stored
+                // separately so it never masquerades as a per-space override.
+                ...(applyGlobal && profileContent.globalDisplayName !== undefined ? { global_display_name: profileContent.globalDisplayName } : {}),
+                ...(applyGlobal && profileContent.globalUserIcon !== undefined ? { global_profile_image: profileContent.globalUserIcon } : {}),
+                ...(applyGlobal && profileContent.globalBio !== undefined ? { global_bio: profileContent.globalBio } : {}),
+                ...(applyGlobal ? { globalProfileTimestamp: ts } : {}),
+                ...(applyOverride && profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
                   ? { farcasterFid: profileContent.farcasterFid }
                   : {}),
-                ...(profileContent.farcasterUsername ? { farcasterUsername: profileContent.farcasterUsername } : {}),
-                profileTimestamp: ts,
-              } as SpaceMember & { profileTimestamp: number; farcasterFid?: number; farcasterUsername?: string };
+                ...(applyOverride && profileContent.farcasterUsername ? { farcasterUsername: profileContent.farcasterUsername } : {}),
+              } as SpaceMember & { profileTimestamp: number; globalProfileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string };
 
               await adapter.saveSpaceMember(spaceId, merged);
 
@@ -3572,43 +3596,59 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               displayName?: string;
               userIcon?: string;
               bio?: string;
+              globalDisplayName?: string;
+              globalUserIcon?: string;
+              globalBio?: string;
               farcasterFid?: number;
               farcasterUsername?: string;
             };
             const adapter = getMMKVAdapter();
             const existingMember = await adapter.getSpaceMember(spaceId, profileContent.senderId) as
-              | (SpaceMember & { profileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string })
+              | (SpaceMember & { profileTimestamp?: number; globalProfileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string })
               | undefined;
             const ts = spaceMessage.createdDate || Date.now();
 
-            // Skip stale updates.
-            if (existingMember?.profileTimestamp && existingMember.profileTimestamp >= ts) {
+            // Two-slot staleness (mirror of the JS-path handler): override and
+            // global field groups each guard on their own timestamp.
+            const hasOverrideFields =
+              profileContent.displayName !== undefined ||
+              profileContent.userIcon !== undefined ||
+              profileContent.bio !== undefined;
+            const hasGlobalFields =
+              profileContent.globalDisplayName !== undefined ||
+              profileContent.globalUserIcon !== undefined ||
+              profileContent.globalBio !== undefined;
+            const applyOverride =
+              hasOverrideFields &&
+              !(existingMember?.profileTimestamp && existingMember.profileTimestamp >= ts);
+            const applyGlobal =
+              hasGlobalFields &&
+              !(existingMember?.globalProfileTimestamp && existingMember.globalProfileTimestamp >= ts);
+            if (!applyOverride && !applyGlobal) {
               continue;
             }
 
-            // Spread-only-if-truthy: an empty string in the wire content
-            // means "no change", not "clear it". Same rule as the legacy
-            // handler; without it a partial broadcast (e.g. avatar-only)
-            // would clobber everyone's stored display name.
             const merged = {
               ...(existingMember ?? {
                 address: profileContent.senderId,
                 inbox_address: '',
               }),
-              // Presence check (not truthy): empty displayName = deliberate
-              // per-space-name clear, matching bio + desktop's receiver. See
-              // the matching comment in the JS-path handler above.
-              ...(profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
-              // Presence check (not truthy): '' is a deliberate avatar clear,
-              // matching displayName/bio + desktop's receiver.
-              ...(profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
-              ...(profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
-              ...(profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
+              // OVERRIDE slot (applied only when newer). Presence check: '' is a
+              // deliberate per-space clear. See the JS-path handler above.
+              ...(applyOverride && profileContent.displayName !== undefined ? { display_name: profileContent.displayName } : {}),
+              ...(applyOverride && profileContent.userIcon !== undefined ? { profile_image: profileContent.userIcon } : {}),
+              ...(applyOverride && profileContent.bio !== undefined ? { bio: profileContent.bio } : {}),
+              ...(applyOverride ? { profileTimestamp: ts } : {}),
+              // GLOBAL slot — stored separately from the override fields.
+              ...(applyGlobal && profileContent.globalDisplayName !== undefined ? { global_display_name: profileContent.globalDisplayName } : {}),
+              ...(applyGlobal && profileContent.globalUserIcon !== undefined ? { global_profile_image: profileContent.globalUserIcon } : {}),
+              ...(applyGlobal && profileContent.globalBio !== undefined ? { global_bio: profileContent.globalBio } : {}),
+              ...(applyGlobal ? { globalProfileTimestamp: ts } : {}),
+              ...(applyOverride && profileContent.farcasterFid !== undefined && profileContent.farcasterFid > 0
                 ? { farcasterFid: profileContent.farcasterFid }
                 : {}),
-              ...(profileContent.farcasterUsername ? { farcasterUsername: profileContent.farcasterUsername } : {}),
-              profileTimestamp: ts,
-            } as SpaceMember & { profileTimestamp: number; farcasterFid?: number; farcasterUsername?: string };
+              ...(applyOverride && profileContent.farcasterUsername ? { farcasterUsername: profileContent.farcasterUsername } : {}),
+            } as SpaceMember & { profileTimestamp: number; globalProfileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string };
 
             await adapter.saveSpaceMember(spaceId, merged);
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -4837,6 +4837,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               senderAddress: user.address,
               displayName: nameOverride,
               userIcon: iconOverride,
+              // Carry the current GLOBAL identity in the global* slots so any
+              // member who missed the global-save broadcast still learns it on
+              // our reconnect. Separate from the override fields above; receivers
+              // store them apart. (Two-slot design — identity-resolution doc.)
+              globalDisplayName: displayName || undefined,
+              globalUserIcon: userIcon || undefined,
               // Include Farcaster linkage if linked so peers can
               // surface it in UserProfileModal. Gate dedupes on
               // signature so this is a no-op once recorded.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2153,10 +2153,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 hasGlobalFields &&
                 !(existingMember?.globalProfileTimestamp && existingMember.globalProfileTimestamp >= ts);
 
-              // Nothing to apply (both slots stale or absent, ignoring Farcaster
-              // which follows the override guard) — drop the inbox message and
-              // return, matching the prior single-guard behavior.
-              if (!applyOverride && !applyGlobal && !hasGlobalFields) {
+              // Nothing to apply — neither slot is fresh (both stale or absent).
+              // Drop the inbox message and return. A stale global-ONLY message
+              // hits this too (applyGlobal false, applyOverride false), so it's
+              // cleaned up instead of falling through to a no-op write. Matches
+              // the native-batch path's `!applyOverride && !applyGlobal` guard.
+              if (!applyOverride && !applyGlobal) {
                 if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
                   deleteSpaceInboxMessages(
                     spaceInboxKey.address,

--- a/hooks/useMembersWithPublicProfileFallback.ts
+++ b/hooks/useMembersWithPublicProfileFallback.ts
@@ -34,10 +34,15 @@ export function useMembersWithPublicProfileFallback(
   members: MemberMap,
   visibleAddresses: string[],
 ): MemberMap {
-  // Determine which addresses need a public-profile query — addresses
-  // where we have no local record, or the record exists but has no
-  // display_name AND no profile_image. Fully-populated members aren't
-  // queried.
+  // Determine which addresses need a public-profile query. Under the two-state
+  // "follow global" model, an empty per-space field follows the member's global
+  // value, so we need the public profile whenever a rendered per-space field
+  // (name OR avatar) is missing — not only when BOTH are missing. A member who
+  // overrode just their name still needs the fetch to fill their global avatar.
+  // (Bio is NOT gated on: it's only shown in the profile modal, and gating on
+  // it would fetch for nearly everyone — a fetch storm the memoized cache and
+  // this bounded set are meant to avoid. The merge below still fills bio from
+  // the public profile whenever a fetch happens for another reason.)
   const addressesToFetch = useMemo(() => {
     const out: string[] = [];
     const seen = new Set<string>();
@@ -45,7 +50,7 @@ export function useMembersWithPublicProfileFallback(
       if (!addr || seen.has(addr)) continue;
       seen.add(addr);
       const m = members[addr];
-      if (!m || (!m.display_name && !m.profile_image)) {
+      if (!m || !m.display_name || !m.profile_image) {
         out.push(addr);
       }
     }
@@ -114,13 +119,13 @@ export function useMembersWithPublicProfileFallback(
       const chatTs = local?.profileTimestamp;
       const chatIsNewer = chatTs != null && chatTs >= pub.timestamp;
       const pickField = (localVal: string | undefined, pubVal: string) => {
-        // When the local (per-space) record is the newer source, its value
-        // WINS — including a deliberate empty '' (a cleared avatar / name),
-        // which must not fall back to the older public-profile value.
-        // `!== undefined` keeps the intended "explicit clear wins" without
-        // resurrecting the global value. Absent (undefined) still falls
-        // through to the public profile (partial-update / never-set case).
-        if (chatIsNewer) return localVal !== undefined ? localVal : pubVal || '';
+        // Per-space profile is two-state: a per-space OVERRIDE (non-empty
+        // value) wins; otherwise the field follows the member's GLOBAL value
+        // from their public profile. An empty per-space field = "follow global"
+        // (there is no per-space "blank" — that only exists globally), so empty
+        // falls through to the public value in BOTH freshness branches. See
+        // per-space-profile-follow-global design.
+        if (chatIsNewer) return localVal || pubVal || '';
         return pubVal || localVal || '';
       };
       merged[addr] = {

--- a/hooks/useMembersWithPublicProfileFallback.ts
+++ b/hooks/useMembersWithPublicProfileFallback.ts
@@ -28,29 +28,47 @@ import {
 } from '@/hooks/useUserPublicProfile';
 import type { MemberMap } from '@/components/Chat/types';
 
-type MemberWithTs = MemberMap[string] & { profileTimestamp?: number };
+type MemberWithTs = MemberMap[string] & {
+  profileTimestamp?: number;
+  global_display_name?: string;
+  global_profile_image?: string;
+  global_bio?: string;
+};
+
+// Effective per-field value BEFORE the public-profile fetch: a non-empty
+// per-space OVERRIDE wins; otherwise the roster GLOBAL slot (the sender's
+// global identity, pushed via the two-slot update-profile). Empty string
+// means "not set at this tier" — fall through. See identity-resolution doc.
+function effectiveLocal(
+  override: string | undefined,
+  global: string | undefined,
+): string | undefined {
+  return override || global || undefined;
+}
 
 export function useMembersWithPublicProfileFallback(
   members: MemberMap,
   visibleAddresses: string[],
 ): MemberMap {
-  // Determine which addresses need a public-profile query. Under the two-state
-  // "follow global" model, an empty per-space field follows the member's global
-  // value, so we need the public profile whenever a rendered per-space field
-  // (name OR avatar) is missing — not only when BOTH are missing. A member who
-  // overrode just their name still needs the fetch to fill their global avatar.
-  // (Bio is NOT gated on: it's only shown in the profile modal, and gating on
-  // it would fetch for nearly everyone — a fetch storm the memoized cache and
-  // this bounded set are meant to avoid. The merge below still fills bio from
-  // the public profile whenever a fetch happens for another reason.)
+  // Determine which addresses need a public-profile query. A member's name/
+  // avatar is resolved by: override → roster global slot → public profile.
+  // So we only need the public-profile fetch when NEITHER the override NOR the
+  // roster global slot supplies the field (name or avatar). This narrows the
+  // fetch set now that a global rename is pushed into the roster global slot —
+  // most members resolve without any fetch. (Bio is NOT gated on, to avoid a
+  // fetch storm; the merge still fills bio from public profile when a fetch
+  // happens for another reason.) The public profile is still fetched for the
+  // QNS `.q` name it uniquely carries when nothing else resolves.
   const addressesToFetch = useMemo(() => {
     const out: string[] = [];
     const seen = new Set<string>();
     for (const addr of visibleAddresses) {
       if (!addr || seen.has(addr)) continue;
       seen.add(addr);
-      const m = members[addr];
-      if (!m || !m.display_name || !m.profile_image) {
+      const m = members[addr] as MemberWithTs | undefined;
+      const effName = effectiveLocal(m?.display_name, m?.global_display_name);
+      const effIcon = effectiveLocal(m?.profile_image, m?.global_profile_image);
+      if (!m || !effName || !effIcon) {
         out.push(addr);
       }
     }
@@ -85,6 +103,7 @@ export function useMembersWithPublicProfileFallback(
   const cacheRef = useRef<{
     members: MemberMap;
     addressesToFetch: string[];
+    visibleAddresses: string[];
     dataRefs: (PublicProfile | null)[];
     result: MemberMap;
   } | null>(null);
@@ -94,50 +113,73 @@ export function useMembersWithPublicProfileFallback(
     cached !== null &&
     cached.members === members &&
     cached.addressesToFetch === addressesToFetch &&
+    cached.visibleAddresses === visibleAddresses &&
     cached.dataRefs.length === dataRefs.length &&
     cached.dataRefs.every((d, i) => d === dataRefs[i]);
   if (sameInputs) return cached!.result;
 
   let result: MemberMap;
-  if (addressesToFetch.length === 0) {
-    result = members;
-  } else {
+  {
+    // Build the effective map. For every VISIBLE member, resolve each field by
+    // precedence: per-space OVERRIDE → roster GLOBAL slot → public profile.
+    // The override always wins when non-empty. Between the roster global slot
+    // and the public profile, prefer whichever is newer by timestamp (both
+    // carry the sender's global identity; the roster slot is the live push, the
+    // public profile is the stranger-fallback). This runs even when nothing was
+    // fetched, so a global rename pushed into the roster slot renders without a
+    // public profile (works for non-public users). See identity-resolution doc.
+    const fetchIndex = new Map<string, number>();
+    addressesToFetch.forEach((addr, i) => fetchIndex.set(addr, i));
+
+    let changed = false;
     const merged: MemberMap = { ...members };
-    addressesToFetch.forEach((addr, i) => {
-      const pub = dataRefs[i];
-      if (!pub) return;
+    for (const addr of new Set(visibleAddresses)) {
+      if (!addr) continue;
       const local = members[addr] as MemberWithTs | undefined;
-      // Per-field fallback. Whichever source is "newer" by timestamp
-      // is preferred, but only if it has a non-empty value for that
-      // field — otherwise we fall through to the other source.
-      // This matters when a user broadcasts a partial update (e.g.
-      // avatar-only with no displayName): their profileTimestamp gets
-      // stamped recently while display_name stays empty. Without the
-      // per-field fallback, the all-or-nothing "useChat" branch would
-      // pin them to the empty local record and ignore the public
-      // profile that has the real name.
-      const chatTs = local?.profileTimestamp;
-      const chatIsNewer = chatTs != null && chatTs >= pub.timestamp;
-      const pickField = (localVal: string | undefined, pubVal: string) => {
-        // Per-space profile is two-state: a per-space OVERRIDE (non-empty
-        // value) wins; otherwise the field follows the member's GLOBAL value
-        // from their public profile. An empty per-space field = "follow global"
-        // (there is no per-space "blank" — that only exists globally), so empty
-        // falls through to the public value in BOTH freshness branches. See
-        // per-space-profile-follow-global design.
-        if (chatIsNewer) return localVal || pubVal || '';
-        return pubVal || localVal || '';
+      const fi = fetchIndex.get(addr);
+      const pub = fi != null ? dataRefs[fi] : null;
+
+      // Resolve one field: override wins; else newer-of(global slot, public).
+      const globalTs = (local as { globalProfileTimestamp?: number } | undefined)?.globalProfileTimestamp ?? 0;
+      const pubTs = pub?.timestamp ?? -1;
+      const globalNewer = globalTs >= pubTs;
+      const pick = (
+        override: string | undefined,
+        globalSlot: string | undefined,
+        pubVal: string | undefined,
+      ): string => {
+        if (override) return override;
+        const g = globalSlot || undefined;
+        const p = pubVal || undefined;
+        if (globalNewer) return g || p || '';
+        return p || g || '';
       };
-      merged[addr] = {
-        ...(local ?? { address: addr }),
-        display_name: pickField(local?.display_name, pub.display_name),
-        profile_image: pickField(local?.profile_image, pub.profile_image),
-        bio: pickField(local?.bio, pub.bio),
-      } as MemberMap[string];
-    });
-    result = merged;
+
+      const nextName = pick(local?.display_name, local?.global_display_name, pub?.display_name);
+      const nextIcon = pick(local?.profile_image, local?.global_profile_image, pub?.profile_image);
+      const nextBio = pick(local?.bio, local?.global_bio, pub?.bio);
+
+      // Only rewrite when a rendered field actually changes, so members that
+      // already resolve (override present) keep their identity and don't churn
+      // downstream memos.
+      if (
+        !local ||
+        nextName !== (local.display_name ?? '') ||
+        nextIcon !== (local.profile_image ?? '') ||
+        nextBio !== (local.bio ?? '')
+      ) {
+        merged[addr] = {
+          ...(local ?? { address: addr }),
+          display_name: nextName,
+          profile_image: nextIcon,
+          bio: nextBio,
+        } as MemberMap[string];
+        changed = true;
+      }
+    }
+    result = changed ? merged : members;
   }
 
-  cacheRef.current = { members, addressesToFetch, dataRefs, result };
+  cacheRef.current = { members, addressesToFetch, visibleAddresses, dataRefs, result };
   return result;
 }

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -902,6 +902,16 @@ export interface SendUpdateProfileParams {
   displayName?: string;
   userIcon?: string;
   bio?: string;
+  // Global-identity slots (two-slot design — see
+  // identity-resolution-and-profile-sync doc). These carry the sender's
+  // CURRENT GLOBAL name/avatar/bio, stored by receivers separately from the
+  // per-space override fields above. A global rename sends ONLY these (never
+  // the override fields), so it reaches spacemates live WITHOUT being mistaken
+  // for a deliberate per-space override. Empty string is a deliberate global
+  // clear; undefined = no change.
+  globalDisplayName?: string;
+  globalUserIcon?: string;
+  globalBio?: string;
   // Farcaster linkage — included automatically when the user has a
   // linked Farcaster account. Lets other members see "@username · FID"
   // on the user's profile card and tap through to the Farcaster feed
@@ -917,7 +927,12 @@ export interface SendUpdateProfileParams {
 export async function sendUpdateProfileMessage(
   params: SendUpdateProfileParams
 ): Promise<SendGenericMessageResult> {
-  const { spaceId, channelId, senderAddress, displayName, userIcon, bio, farcasterFid, farcasterUsername } = params;
+  const {
+    spaceId, channelId, senderAddress,
+    displayName, userIcon, bio,
+    globalDisplayName, globalUserIcon, globalBio,
+    farcasterFid, farcasterUsername,
+  } = params;
 
   // displayName/userIcon use `!== undefined` (not a truthy check) so a caller
   // that explicitly passes '' — a deliberate clear (removed avatar / cleared
@@ -925,18 +940,25 @@ export async function sendUpdateProfileMessage(
   // members. Callers that mean "no change" MUST pass undefined, never ''.
   // (The on-connect rebroadcast in WebSocketContext passes `x || undefined`,
   // so it stays omission-based and can't clobber a stored value with an
-  // incidental empty.) bio already worked this way.
+  // incidental empty.) bio already worked this way. The global* slots use the
+  // same `!== undefined` presence rule.
   const content = {
     type: 'update-profile' as const,
     senderId: senderAddress,
     ...(displayName !== undefined ? { displayName } : {}),
     ...(userIcon !== undefined ? { userIcon } : {}),
     ...(bio !== undefined && { bio }),
+    ...(globalDisplayName !== undefined ? { globalDisplayName } : {}),
+    ...(globalUserIcon !== undefined ? { globalUserIcon } : {}),
+    ...(globalBio !== undefined ? { globalBio } : {}),
     ...(farcasterFid !== undefined && farcasterFid > 0 ? { farcasterFid } : {}),
     ...(farcasterUsername ? { farcasterUsername } : {}),
   };
 
-  return sendGenericMessage({ spaceId, channelId, senderAddress, content });
+  // Cast: global* slots are additive and not yet in shared's UpdateProfileMessage
+  // (additive shared PR pending, non-blocking). Wire-compatible: receivers read
+  // them untyped. Matches the untyped-additive-field pattern used elsewhere.
+  return sendGenericMessage({ spaceId, channelId, senderAddress, content: content as MessageContent });
 }
 
 // MMKV-backed gate that records the last profile-update payload broadcast
@@ -971,6 +993,9 @@ function profileBroadcastSignature(p: SendUpdateProfileParams): string {
   if (p.displayName !== undefined) obj.displayName = p.displayName;
   if (p.userIcon !== undefined) obj.userIcon = p.userIcon;
   if (p.bio !== undefined) obj.bio = p.bio;
+  if (p.globalDisplayName !== undefined) obj.globalDisplayName = p.globalDisplayName;
+  if (p.globalUserIcon !== undefined) obj.globalUserIcon = p.globalUserIcon;
+  if (p.globalBio !== undefined) obj.globalBio = p.globalBio;
   if (p.farcasterFid !== undefined && p.farcasterFid > 0) {
     obj.farcasterFid = String(p.farcasterFid);
   }

--- a/services/space/spaceService.ts
+++ b/services/space/spaceService.ts
@@ -290,11 +290,11 @@ export async function createSpace(params: CreateSpaceParams): Promise<CreateSpac
   const adapter = getMMKVAdapter();
   await adapter.saveSpace(space);
 
-  // 8.1 Save creator as a member of the space
+  // 8.1 Save creator as a member. Follow-global: don't stamp the creator's
+  // global name/avatar into their per-space row (empty = follow global). Peers
+  // learn identity from the join envelope; this row only records membership.
   await adapter.saveSpaceMember(spaceAddress, {
     address: params.userAddress,
-    display_name: params.userDisplayName,
-    profile_image: params.userIcon,
     inbox_address: inboxAddress,
   });
 


### PR DESCRIPTION
Makes a member's per-space display name, avatar, and bio **follow their global profile unless they set a deliberate per-space override**, and makes a global profile change reach spacemates reliably.

## Why
Previously the app copied a user's global name/avatar into every space's member row (at join, space creation, on reconnect, and on every global save). That froze each space to a stale copy: changing your global name didn't reach spaces, "clear my per-space name" was impossible, and two of your own devices could overwrite each other's rows. This PR removes that stamping and replaces it with an explicit two-channel model.

## What changed
- **Follow-global rendering**: an empty per-space name/avatar/bio now renders the member's global value; a non-empty value is a real per-space override.
- **Global identity is broadcast on its own labeled fields** (separate from the per-space override fields), so a global rename propagates to everyone in a space live, works for users who haven't made their profile public, and can never be mistaken for a deliberate per-space override. Receivers store the two independently with separate freshness timestamps so neither can clobber the other.
- **Editor**: the per-space avatar revert control ("Use my main avatar") only appears when an override exists, in a danger color; the field shows the global value as a placeholder when following global.
- **Space creation** no longer stamps the creator's global identity into their own member row.
- **Global bio** now reaches spacemates like the name/avatar (it was previously withheld from non-public users).
- Refreshes the editing user's own public-profile cache on save so their name updates immediately.

## Verification
Space propagation confirmed working desktop↔desktop and mobile→desktop. Reviewed for message-delivery safety (the normal message transport is untouched) and last-write-wins correctness. Pairs with the matching quorum-desktop PR; the wire change is additive and interoperates with older clients.
