### PR TITLE
fix(dates): unify Quorum timestamp formatting via shared formatters

### DIFF
--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -11,6 +11,7 @@ import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { FarcasterLogoIcon } from '@/components/ui/FarcasterLogoIcon';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
 import { coerceMessagePreview, previewKindIcon } from '@/utils/messagePreview';
+import { formatRowTime } from '@/utils/dateFormat';
 import { useAuth } from '@/context/AuthContext';
 import type { Conversation } from '@/hooks/chat';
 import { useDMMute } from '@/hooks/chat/useDMMute';
@@ -59,17 +60,10 @@ interface InboxItem {
   placeholder?: boolean;
 }
 
+// Conversation-row time via the shared formatter: today → locale time,
+// 1–6 days → "Nd", older → "Jun 28" / "Jun 28, 2025".
 function formatRelativeTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const timeStr = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-  if (date.toDateString() === now.toDateString()) return timeStr;
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
-  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-  if (diffDays < 7) return date.toLocaleDateString([], { weekday: 'short' });
-  return date.toLocaleDateString();
+  return formatRowTime(timestamp);
 }
 
 interface InboxRowProps {

--- a/app/(tabs)/spaces/index.tsx
+++ b/app/(tabs)/spaces/index.tsx
@@ -7,6 +7,7 @@ import { isValidAvatarUri } from '@/utils/validation';
 import { useChannelMentionUnread } from '@/services/notifications/mentionReplyLog';
 import { useSpaceActivity } from '@/hooks/chat/useSpaceActivity';
 import { useMutedSpaceIds } from '@/hooks/chat/useChannelMute';
+import { formatRowTime } from '@/utils/dateFormat';
 import { textStyles, useTheme, type AppTheme } from '@/theme';
 import { haptics } from '@/utils/haptics';
 import type { Space } from '@quilibrium/quorum-shared';
@@ -34,17 +35,10 @@ interface SpaceItem {
   isMuted: boolean;
 }
 
+// Conversation-row time via the shared formatter: today → locale time,
+// 1–6 days → "Nd", older → "Jun 28" / "Jun 28, 2025".
 function formatRelativeTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const timeStr = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-  if (date.toDateString() === now.toDateString()) return timeStr;
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) return 'Yesterday';
-  const diffDays = Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
-  if (diffDays < 7) return date.toLocaleDateString([], { weekday: 'short' });
-  return date.toLocaleDateString();
+  return formatRowTime(timestamp);
 }
 
 const SpaceRow = React.memo(function SpaceRow({

--- a/components/Chat/DirectMessagesList.tsx
+++ b/components/Chat/DirectMessagesList.tsx
@@ -10,6 +10,7 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import type { Conversation } from '@/hooks/chat';
 import { coerceMessagePreview, previewKindIcon } from '@/utils/messagePreview';
 import { truncateAddress } from '@/utils/formatAddress';
+import { formatRowTime } from '@/utils/dateFormat';
 import React, { useCallback, useMemo } from 'react';
 import { ActivityIndicator, Alert, Image, RefreshControl, StyleSheet, Text, View } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
@@ -46,26 +47,10 @@ function isValidAvatarUri(icon: string | undefined): boolean {
   return icon.startsWith('data:');
 }
 
-// Format timestamp for conversation list (Discord-style)
+// DM-list-row time via the shared conversation formatter: today → locale time,
+// 1–6 days → "Nd", older → "Jun 28" / "Jun 28, 2025".
 function formatRelativeTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const timeStr = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-
-  // Check if same day - show time only
-  if (date.toDateString() === now.toDateString()) {
-    return timeStr;
-  }
-
-  // Check if yesterday
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) {
-    return `Yesterday at ${timeStr}`;
-  }
-
-  // Older - show date and time
-  return `${date.toLocaleDateString()} ${timeStr}`;
+  return formatRowTime(timestamp);
 }
 
 // Truncate sender name for preview

--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -8,6 +8,7 @@
 import { ImageSourcePropType } from 'react-native';
 import type { Message as SharedMessage, Space, Channel, SpaceMember, MessageSendStatus } from '@quilibrium/quorum-shared';
 import type { DirectCastMessage } from '@/services/farcasterClient';
+import { formatMessageTime } from '@/utils/dateFormat';
 
 // Message type categories for rendering
 export type MessageRenderType =
@@ -175,30 +176,16 @@ export interface DisplayGroup {
 export type MemberMap = Record<string, SpaceMember>;
 
 /**
- * Format timestamp to display string (Discord-style)
- * - Today: "12:34 PM"
- * - Yesterday: "Yesterday at 12:34 PM"
- * - Older: "01/15/2025 12:34 PM"
+ * Per-message time inside a chat. Delegates to the shared message-date formatter
+ * (locale-driven clock; older messages bucket to weekday / "N days ago" instead
+ * of the ambiguous locale-numeric date the old impl produced).
+ * - Today: locale time (e.g. "16:40" or "4:40 PM")
+ * - Yesterday: "Yesterday at 16:40"
+ * - Last week: weekday ("Monday")
+ * - Older: "3 days ago"
  */
 export function formatTime(timestamp: number): string {
-  const date = new Date(timestamp);
-  const now = new Date();
-  const timeStr = date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
-
-  // Check if same day - show time only
-  if (date.toDateString() === now.toDateString()) {
-    return timeStr;
-  }
-
-  // Check if yesterday
-  const yesterday = new Date(now);
-  yesterday.setDate(yesterday.getDate() - 1);
-  if (date.toDateString() === yesterday.toDateString()) {
-    return `Yesterday at ${timeStr}`;
-  }
-
-  // Older - show date and time
-  return `${date.toLocaleDateString()} ${timeStr}`;
+  return formatMessageTime(timestamp);
 }
 
 // Image URL pattern - matches common image hosting URLs

--- a/utils/dateFormat.ts
+++ b/utils/dateFormat.ts
@@ -1,0 +1,40 @@
+/**
+ * Mobile bindings for the shared date formatters (quorum-shared `dateFormatting`).
+ *
+ * Shared owns the calendar logic + locale-driven clock; mobile owns the wording.
+ * The app is currently English-only (no i18n framework), so we bind English
+ * labels here once and expose two ready-to-use string formatters that every
+ * Quorum surface calls. When i18n lands, swap these labels for translated
+ * strings (or consume the shared `describe*` parts directly).
+ *
+ * Fixes the ambiguous locale-numeric date (`28/6/2026`) that the old per-file
+ * `toLocaleDateString()` formatters produced; older messages now bucket to
+ * weekday / "N days ago", and the time-of-day follows the device's locale clock.
+ *
+ * NOTE: the Farcaster feed (`components/SocialFeed/utils.ts`) keeps its own
+ * sub-hour format (`5s/3m/2h`) on purpose — feed recency is a different UX job.
+ */
+import { formatMessageDate, formatConversationTime } from '@quilibrium/quorum-shared';
+
+const MESSAGE_LABELS = {
+  today: 'Today',
+  yesterday: 'Yesterday',
+  yesterdayAt: (time: string) => `Yesterday at ${time}`,
+};
+
+/**
+ * Per-message time inside a chat.
+ * Today → locale time; Yesterday → "Yesterday at HH:MM"; last week → weekday;
+ * older → "N days ago".
+ */
+export function formatMessageTime(timestamp: number): string {
+  return formatMessageDate(timestamp, { labels: MESSAGE_LABELS });
+}
+
+/**
+ * Conversation / list / row time.
+ * Today → locale time; 1–6 days → "Nd"; older → "Jun 28" / "Jun 28, 2025".
+ */
+export function formatRowTime(timestamp: number): string {
+  return formatConversationTime(timestamp);
+}


### PR DESCRIPTION
## What

Routes the per-message and conversation-list timestamps through quorum-shared's `formatMessageDate` / `formatConversationTime` (published in `2.1.0-34`) instead of four drifting local formatters.

## Why

Message timestamps showed an ambiguous locale-numeric date on non-US devices — e.g. `28/6/2026 16:40` on an Italian phone — because the old `formatTime` fell back to `toLocaleDateString()` for older messages. The shared formatter buckets older messages to weekday / "N days ago" and uses a locale-driven clock for the time-of-day.

## Scope

Unified (the "when was this said" surfaces): chat messages, DM inbox list, spaces list, DM list.

**Left as-is on purpose** — the two recency-signal surfaces that show sub-hour relative times (`5m ago`): the Farcaster feed and the notifications tab. A feed/notification list wants "how fresh is this?"; a conversation wants "when?". Forcing one format onto the other makes it worse.

New `utils/dateFormat.ts` binds the app's (currently English) labels once and exposes `formatMessageTime` (chat) + `formatRowTime` (list/row).

## Verification

- 0 new TypeScript / lint errors.
- Thin delegation to the shared formatters (already unit-tested in quorum-shared); no new date logic added on mobile.