### PR TITLE
refactor: source mobile image limits from shared IMAGE_CONFIGS

### DIFF
--- a/app/(onboarding)/profile-setup.tsx
+++ b/app/(onboarding)/profile-setup.tsx
@@ -11,6 +11,7 @@ import React, { useState, useEffect } from 'react';
 import { View, Text, TextInput, StyleSheet, Image, ScrollView, KeyboardAvoidingView, Platform } from 'react-native';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import * as ImagePicker from 'expo-image-picker';
+import { compressAvatarImage } from '@/services/media/imageAttachment';
 import { useTheme, type AppTheme } from '@/theme';
 import { useOnboarding } from '@/context';
 import { OnboardingLayout, StepNavigation } from '@/components/onboarding';
@@ -70,7 +71,7 @@ export default function ProfileSetupScreen() {
     });
 
     if (!result.canceled && result.assets[0]) {
-      setProfileImage(result.assets[0].uri);
+      await setCompressedAvatar(result.assets[0]);
     }
   };
 
@@ -88,8 +89,17 @@ export default function ProfileSetupScreen() {
     });
 
     if (!result.canceled && result.assets[0]) {
-      setProfileImage(result.assets[0].uri);
+      await setCompressedAvatar(result.assets[0]);
     }
+  };
+
+  // Compress the picked avatar (512px, ~150KB) before storing. Without this
+  // the raw multi-MP picker URI becomes user.profileImage and can broadcast as
+  // a full-size userIcon — an OOM/bandwidth risk. Falls back to the raw URI if
+  // compression fails, so the user still gets an avatar.
+  const setCompressedAvatar = async (asset: ImagePicker.ImagePickerAsset) => {
+    const compressed = await compressAvatarImage(asset.uri, asset.width, asset.height);
+    setProfileImage(compressed?.dataUri ?? asset.uri);
   };
 
   const handleContinue = () => {

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -988,6 +988,7 @@ export default function ProfileModal({
       aspect: [1, 1],
       quality: 0.8,
       base64: false,
+      exif: false,
     });
 
     if (!result.canceled && result.assets[0]) {

--- a/components/SpaceSettingsModal.tsx
+++ b/components/SpaceSettingsModal.tsx
@@ -60,7 +60,7 @@ import { pickImage, compressAvatarImage } from '@/services/media/imageAttachment
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import { truncateAddress } from '@/utils/formatAddress';
-import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, queryKeys, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
+import { hexToBytes, findRoleConflict, getUniqueRoleDefaults, queryKeys, IMAGE_CONFIGS, type Emoji, type Permission, type Role, type Space, type Sticker } from '@quilibrium/quorum-shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { resolveChannelIconColor } from '@/utils/channelIcon';
 import * as Clipboard from 'expo-clipboard';
@@ -623,6 +623,7 @@ export default function SpaceSettingsModal({
       aspect: [1, 1],
       quality: 0.8,
       base64: false,
+      exif: false,
     });
     if (!result.canceled && result.assets[0]) {
       const asset = result.assets[0];
@@ -950,14 +951,16 @@ export default function SpaceSettingsModal({
   }, [hasGeneralChanges]);
 
   const handlePickIcon = useCallback(async () => {
-    const result = await pickImage('library');
+    // Space icon → 256px (shared spaceIcon config), not the 1200px chat path.
+    const result = await pickImage('library', { maxDimension: IMAGE_CONFIGS.spaceIcon.maxWidth });
     if (result.success && result.attachment) {
       setIconUrl(result.attachment.imageUrl);
     }
   }, []);
 
   const handlePickBanner = useCallback(async () => {
-    const result = await pickImage('library');
+    // Space banner → 1600px longest-axis bounding box (shared spaceBanner config).
+    const result = await pickImage('library', { maxDimension: IMAGE_CONFIGS.spaceBanner.maxWidth });
     if (result.success && result.attachment) {
       setBannerUrl(result.attachment.imageUrl);
     }

--- a/components/UnifiedProfileEditModal.tsx
+++ b/components/UnifiedProfileEditModal.tsx
@@ -108,6 +108,7 @@ export default function UnifiedProfileEditModal({
       // bloating the public-profile JSON to 60MB+, OOM'ing okhttp
       // on the fetching side.
       base64: false,
+      exif: false,
     });
     if (result.canceled || !result.assets[0]) return;
     const asset = result.assets[0];

--- a/components/skins/SkinEditor.tsx
+++ b/components/skins/SkinEditor.tsx
@@ -157,6 +157,7 @@ export function SkinEditor({ onClose }: { onClose: () => void }) {
     const res = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 1,
+      exif: false,
     });
     if (res.canceled || !res.assets?.[0]) return null;
     const a = res.assets[0];

--- a/services/media/customAssets.ts
+++ b/services/media/customAssets.ts
@@ -8,22 +8,26 @@
  * - Stickers: 512px on longest axis
  */
 
+import { FILE_SIZE_LIMITS, IMAGE_CONFIGS } from '@quilibrium/quorum-shared';
 import * as ImagePicker from 'expo-image-picker';
 import * as ImageManipulator from 'expo-image-manipulator';
 
-// Configuration matching desktop behavior
+// Numeric limits sourced from the shared IMAGE_CONFIGS single source of truth
+// (kills cross-platform drift). Mobile keeps its aspect-preserving longest-axis
+// resize (it does NOT adopt shared's square cropToFit for emoji/sticker) — only
+// the max-bound number comes from shared.
 const EMOJI_CONFIG = {
-  maxInputSizeMB: 5,
-  quality: 0.8,
-  maxGifSizeKB: 100,
-  maxSize: 128, // Max 128px on longest axis
+  maxInputSizeMB: FILE_SIZE_LIMITS.MAX_EMOJI_INPUT_SIZE / (1024 * 1024), // 5MB
+  quality: IMAGE_CONFIGS.emoji.quality, // 0.8
+  maxGifSizeKB: FILE_SIZE_LIMITS.MAX_EMOJI_GIF_SIZE / 1024, // 100KB
+  maxSize: IMAGE_CONFIGS.emoji.maxWidth, // 128px on longest axis
 };
 
 const STICKER_CONFIG = {
-  maxInputSizeMB: 25,
-  quality: 0.8,
-  maxGifSizeKB: 750,
-  maxSize: 512, // Max 512px on longest axis
+  maxInputSizeMB: FILE_SIZE_LIMITS.MAX_INPUT_SIZE / (1024 * 1024), // 25MB
+  quality: IMAGE_CONFIGS.sticker.quality, // 0.8
+  maxGifSizeKB: FILE_SIZE_LIMITS.MAX_STICKER_GIF_SIZE / 1024, // 750KB
+  maxSize: IMAGE_CONFIGS.sticker.maxWidth, // 512px on longest axis
 };
 
 export interface ProcessedAsset {

--- a/services/media/imageAttachment.ts
+++ b/services/media/imageAttachment.ts
@@ -17,20 +17,25 @@
 // stable callable API (downloadAsync / readAsStringAsync /
 // deleteAsync) without the warning. saveToLibrary.ts already uses
 // /legacy — keep this consistent.
+import { FILE_SIZE_LIMITS, IMAGE_CONFIGS } from '@quilibrium/quorum-shared';
 import * as FileSystem from 'expo-file-system/legacy';
 import * as ImageManipulator from 'expo-image-manipulator';
 import * as ImagePicker from 'expo-image-picker';
 
-// Configuration matching desktop behavior
+// Numeric limits are sourced from the shared IMAGE_CONFIGS single source of
+// truth (kills cross-platform drift). Mobile-only fields with no shared
+// equivalent (the 1MB byte target, the thumbnail sizing) stay local.
+const messageConfig = IMAGE_CONFIGS.messageAttachment;
 const IMAGE_CONFIG = {
-  maxWidth: 1200,
-  maxHeight: 1200,
-  quality: 0.8,
-  thumbnailMaxSize: 300,
-  thumbnailThreshold: 300, // Generate thumbnail if image > 300px
-  maxFileSizeMB: 25,
-  maxGifSizeMB: 2,
-  targetFileSizeBytes: 1024 * 1024, // 1MB target for E2EE chats
+  maxWidth: messageConfig.maxWidth, // 1200
+  maxHeight: messageConfig.maxHeight, // 1200
+  quality: messageConfig.quality, // 0.8
+  thumbnailMaxSize: messageConfig.thumbnailConfig?.maxWidth ?? 300,
+  thumbnailThreshold: messageConfig.thumbnailConfig?.threshold ?? 300,
+  // Input-size ceiling before compression (shared MAX_INPUT_SIZE = 25MB).
+  maxInputSizeBytes: FILE_SIZE_LIMITS.MAX_INPUT_SIZE,
+  maxGifSizeBytes: messageConfig.gifSizeLimit ?? FILE_SIZE_LIMITS.MAX_GIF_SIZE, // 2MB
+  targetFileSizeBytes: 1024 * 1024, // 1MB target for E2EE chats (mobile-local, no shared equivalent)
 };
 
 export interface ProcessedAttachment {
@@ -55,6 +60,17 @@ export interface ProcessedAttachment {
   localUri: string;
 }
 
+/**
+ * Per-surface overrides for pickImage. Absent = the default message-attachment
+ * path (1200px, 1MB byte target). When `maxDimension` is set (e.g. space icon
+ * 256, banner 1600×900), the picked image is resized so its longest axis fits
+ * that bound before base64 encoding — used by non-chat surfaces so they don't
+ * ride the oversized attachment path.
+ */
+export interface PickImageOptions {
+  maxDimension?: number;
+}
+
 export interface AttachmentPickerResult {
   success: boolean;
   attachment?: ProcessedAttachment;
@@ -66,7 +82,8 @@ export interface AttachmentPickerResult {
  * Request permissions and pick an image from library or camera
  */
 export async function pickImage(
-  source: 'library' | 'camera' = 'library'
+  source: 'library' | 'camera' = 'library',
+  options?: PickImageOptions,
 ): Promise<AttachmentPickerResult> {
   try {
     // Request permissions
@@ -102,7 +119,7 @@ export async function pickImage(
     }
 
     const asset = result.assets[0];
-    return processImageAsset(asset);
+    return processImageAsset(asset, options);
   } catch (error) {
     return {
       success: false,
@@ -215,7 +232,8 @@ async function compressImageToTargetSize(
  * Process an image asset into a ProcessedAttachment
  */
 async function processImageAsset(
-  asset: ImagePicker.ImagePickerAsset
+  asset: ImagePicker.ImagePickerAsset,
+  options?: PickImageOptions,
 ): Promise<AttachmentPickerResult> {
   try {
     const { uri, width, height, mimeType, fileSize } = asset;
@@ -226,10 +244,11 @@ async function processImageAsset(
     // For GIFs, we don't compress (would lose animation)
     if (isGif) {
       const fileSizeMB = currentFileSize / (1024 * 1024);
-      if (fileSizeMB > IMAGE_CONFIG.maxGifSizeMB) {
+      if (currentFileSize > IMAGE_CONFIG.maxGifSizeBytes) {
+        const maxGifMB = Math.round(IMAGE_CONFIG.maxGifSizeBytes / (1024 * 1024));
         return {
           success: false,
-          error: `GIF too large (max ${IMAGE_CONFIG.maxGifSizeMB}MB)`,
+          error: `GIF too large (max ${maxGifMB}MB)`,
         };
       }
 
@@ -255,6 +274,17 @@ async function processImageAsset(
       };
     }
 
+    // Reject oversized inputs before any decode/compress work (shared 25MB
+    // ceiling). Previously this limit existed as a dead config field and was
+    // never enforced.
+    if (currentFileSize > IMAGE_CONFIG.maxInputSizeBytes) {
+      const maxMB = Math.round(IMAGE_CONFIG.maxInputSizeBytes / (1024 * 1024));
+      return {
+        success: false,
+        error: `Image too large (max ${maxMB}MB)`,
+      };
+    }
+
     // For non-GIF images, compress to target size (1MB)
     let finalUri = uri;
     let finalBase64 = asset.base64;
@@ -262,12 +292,47 @@ async function processImageAsset(
     let finalHeight = height;
     let finalMime = mime;
 
-    // Check if compression is needed
-    if (currentFileSize > IMAGE_CONFIG.targetFileSizeBytes) {
+    // Surface override (e.g. space icon 256, banner 1600×900): resize down to
+    // the requested longest-axis bound before anything else, so non-chat
+    // surfaces don't ride the 1200px attachment path. Runs even when the file
+    // is small enough to skip the byte-target sweep below.
+    const maxDim = options?.maxDimension;
+    if (maxDim && Math.max(finalWidth, finalHeight) > maxDim) {
+      const scale = maxDim / Math.max(finalWidth, finalHeight);
+      const targetW = Math.round(finalWidth * scale);
+      const targetH = Math.round(finalHeight * scale);
+      try {
+        const resized = await ImageManipulator.manipulateAsync(
+          finalUri,
+          [{ resize: { width: targetW, height: targetH } }],
+          { compress: IMAGE_CONFIG.quality, format: ImageManipulator.SaveFormat.JPEG, base64: true },
+        );
+        if (resized.base64) {
+          finalUri = resized.uri;
+          finalBase64 = resized.base64;
+          finalWidth = resized.width;
+          finalHeight = resized.height;
+          finalMime = 'image/jpeg';
+        }
+      } catch {
+        // Resize failed — fall through with the original; the byte-target
+        // sweep below still bounds the payload.
+      }
+    }
+
+    // Check if compression is needed. Use the (possibly resized) file size —
+    // recompute from base64 when the override already produced a smaller image.
+    const sizeForCompressionCheck =
+      finalBase64 && finalUri !== uri
+        ? Math.ceil(finalBase64.length * 0.75)
+        : currentFileSize;
+    if (sizeForCompressionCheck > IMAGE_CONFIG.targetFileSizeBytes) {
+      // Compress the current (possibly override-resized) image. On the default
+      // chat path finalUri/finalWidth/finalHeight still equal the originals.
       const compressed = await compressImageToTargetSize(
-        uri,
-        width,
-        height,
+        finalUri,
+        finalWidth,
+        finalHeight,
         IMAGE_CONFIG.targetFileSizeBytes
       );
 
@@ -465,7 +530,11 @@ export async function compressAvatarImage(
   height: number,
   opts?: { maxDimension?: number; maxBytes?: number },
 ): Promise<{ dataUri: string; width: number; height: number } | null> {
-  const MAX_DIM = opts?.maxDimension ?? 512;
+  // Dimension sourced from shared IMAGE_CONFIGS.avatar (512) so it can't drift
+  // from desktop. The 150KB byte cap is mobile-only OOM protection (shared has
+  // no byte target) — it prevents an uncompressed camera photo from OOMing RN's
+  // okhttp layer, so it stays local and load-bearing.
+  const MAX_DIM = opts?.maxDimension ?? IMAGE_CONFIGS.avatar.maxWidth;
   const MAX_BYTES = opts?.maxBytes ?? 150 * 1024;
 
   // Resize first so dimensions never exceed MAX_DIM. We respect


### PR DESCRIPTION
Adopts the shared `IMAGE_CONFIGS` single source of truth for per-surface image dimensions/limits, so mobile can no longer drift from desktop (avatar was 512 vs 123, emoji 128 vs 36). Config-only adoption by design: mobile keeps all its own image functions, compression engine, byte-target sweep and return shapes unchanged, it only reads the numbers from shared.

### Changes
- **imageAttachment**: message-attachment + avatar limits now sourced from shared. Adds an optional per-surface `maxDimension` override to `pickImage` so space icon (256) and banner (1600×900) no longer ride the 1200px attachment path. The default chat-send path is byte-for-byte unchanged.
- **customAssets**: emoji (128) / sticker (512) limits sourced from shared; aspect-preserving resize kept (no square crop), PNG format unchanged.
- **Bug fix**: wire the previously-dead `maxFileSizeMB` config into a real 25MB input-size guard for non-GIF images.
- **Bug fix**: compress the onboarding avatar (512 / ~150KB) instead of storing the raw multi-MP picker URI that could broadcast as a full-size userIcon (OOM/bandwidth risk). Reuses the same `compressAvatarImage` as the profile avatar.
- Add `exif:false` to the profile, space-avatar and skin pickers (privacy).

### Verification
- Typecheck + lint clean (zero new errors vs base).
- Device-tested: chat image send (space/DM/Farcaster), space icon + banner, profile avatar. All good.
- Two pre-existing, unrelated defects surfaced during testing and confirmed NOT caused by this change (diff touches no format handling): static-GIF render, and transparent-emoji black background on import.

Canonical dims from shared `2.1.0-34`: avatar 512, space icon 256, banner 1600×900, emoji 128, sticker 512, message attachment 1200.