### PR TITLE
fix: sync message edits across devices in DMs

### DIFF
--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -53,13 +53,14 @@ export const PERSISTABLE_TYPES: ReadonlySet<string> = new Set([
  * the guard lets them fall through unchanged (today's behavior: saved-but-hidden,
  * not deleted from the server), so no data is lost.
  *
- * - `edit-message`: desktop sends DM edits over the wire, but mobile has no DM
- *   edit-message handler yet (only the SPACE paths handle it). See the DM-edit
- *   sync task; when the real handler lands, remove `edit-message` from here.
+ * Currently EMPTY: `edit-message` was here while mobile had no DM edit handler;
+ * the real DM edit send + receive now exists (WebSocketContext DM paths), so it
+ * was removed and the guard treats a malformed edit as a normal drop. Keep this
+ * set as the documented escape hatch: a future half-built DM control feature can
+ * be added here to fall through instead of being dropped, then removed once its
+ * real handler lands.
  */
-export const DM_GUARD_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([
-  'edit-message',
-]);
+export const DM_GUARD_PASSTHROUGH_TYPES: ReadonlySet<string> = new Set([]);
 
 // Invariant: every persistable type must have a real render branch in
 // getMessageRenderType (i.e. not fall through to 'unsupported'), or the receive

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -15,6 +15,7 @@ import {
   createRNWebSocketClient,
   int64ToBytes,
   logger,
+  MAX_MESSAGE_LENGTH,
   queryKeys,
 } from '@quilibrium/quorum-shared';
 import { useQueryClient } from '@tanstack/react-query';
@@ -39,6 +40,7 @@ import { applyReceivedEdit } from '@/utils/editHistory';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type {
   Channel,
+  EditMessage,
   EncryptedWebSocketMessage,
   KickMessage,
   Message,
@@ -2791,6 +2793,90 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           return;
         }
 
+        // edit-message on the fallback path (defensive — the batch path folds
+        // these; without this an edit control message reaching here is a ghost
+        // post). Mirrors the DM remove-message auth + the space edit-apply.
+        if (decryptedMessage.content?.type === 'edit-message') {
+          const editContent = decryptedMessage.content as EditMessage;
+          const targetMsg = await storage.getMessage({
+            spaceId: senderAddress,
+            channelId: senderAddress,
+            messageId: editContent.originalMessageId,
+          });
+
+          // Auth: editor must be the target's author, judged by the
+          // session-authenticated sender, not the spoofable payload senderId —
+          // same rule as the DM remove-message branch and desktop's DM edit
+          // (MessageService.ts: senderId === owner && target.author === owner).
+          const authorized = editContent.senderId === authenticatedDmSender &&
+            (!!targetMsg && targetMsg.content?.senderId === authenticatedDmSender);
+
+          if (authorized && targetMsg && targetMsg.content.type === 'post') {
+            // Full desktop DM parity on receive: re-check the 15-min window
+            // against the target's own createdDate, and reject oversized edits.
+            const withinWindow = Date.now() - targetMsg.createdDate <= 15 * 60 * 1000;
+            const editedText = Array.isArray(editContent.editedText)
+              ? editContent.editedText.join('')
+              : editContent.editedText;
+            const withinLength = !editedText || editedText.length <= MAX_MESSAGE_LENGTH;
+
+            if (withinWindow && withinLength) {
+              const conversation = await storage.getConversation(conversationId);
+              const saveEditHistory = conversation?.saveEditHistory ?? false;
+              const applied = applyReceivedEdit(targetMsg, {
+                newText: editContent.editedText,
+                editedAt: editContent.editedAt,
+                editNonce: editContent.editNonce,
+                saveEditHistory,
+              });
+              // Replayed edit already applied → no-op (don't clobber history).
+              if (applied.changed) {
+                const key = queryKeys.messages.infinite(senderAddress, senderAddress);
+                queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
+                  if (!old) return old;
+                  return { ...old, pages: old.pages.map((page) => ({
+                    ...page,
+                    messages: page.messages.map((m) => {
+                      if (m.messageId === editContent.originalMessageId && m.content.type === 'post') {
+                        return {
+                          ...m,
+                          modifiedDate: applied.modifiedDate,
+                          lastModifiedHash: applied.lastModifiedHash,
+                          content: { ...m.content, text: editContent.editedText },
+                          edits: applied.edits,
+                        };
+                      }
+                      return m;
+                    }),
+                  })) };
+                });
+                const updated: Message = {
+                  ...targetMsg,
+                  modifiedDate: applied.modifiedDate,
+                  lastModifiedHash: applied.lastModifiedHash,
+                  content: { ...targetMsg.content, text: editContent.editedText },
+                  edits: applied.edits,
+                };
+                await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
+                scheduleConversationRefresh(conversationId);
+              }
+            } else {
+              logger.debug(
+                `[DM-fallback] dropped edit-message for ${editContent.originalMessageId?.slice(0, 12)} (window=${withinWindow} length=${withinLength})`
+              );
+            }
+          } else if (!authorized) {
+            logger.debug(
+              `[DM-fallback] dropped unauthorized edit-message from ${editContent.senderId?.slice(0, 12)} for ${editContent.originalMessageId?.slice(0, 12)}`
+            );
+          }
+          // Best-effort: clear the control message from the inbox.
+          getDeviceKeyset().then(dk => {
+            if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+          });
+          return;
+        }
+
         // delete-conversation, fallback path (defensive — mirrors the batch
         // branch): reset the session only, before the save.
         if (decryptedMessage.content?.type === 'delete-conversation') {
@@ -4124,6 +4210,105 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             } else {
               getDeviceKeyset().then(dk => {
                 if (dk) deleteInboxMessages(originalRemoveMsg.inboxAddress, [originalRemoveMsg.timestamp], dk).catch(() => {});
+              });
+            }
+          }
+          continue;
+        }
+
+        // edit-message: edit-for-everyone control message. Fold it (don't
+        // persist as a ghost post); apply the edit to the target, authorizing
+        // per the check below. Mirrors the space batch edit handler + the DM
+        // remove-message auth.
+        if (dmContentType === 'edit-message') {
+          const editContent = decryptedMessage.content as EditMessage;
+          const targetMsg = await storage.getMessage({
+            spaceId: resolvedSenderAddress,
+            channelId: resolvedSenderAddress,
+            messageId: editContent.originalMessageId,
+          });
+
+          // Auth: editor must be the target's author. "Editor" is the
+          // session-authenticated sender (pre-self-sync `senderAddress`), NOT
+          // the spoofable payload `senderId` — same rule as remove-message and
+          // desktop's DM edit. Pre-self-sync keeps our own echo authorized.
+          const authenticatedSender = senderAddress;
+          const authorized = editContent.senderId === authenticatedSender &&
+            (!!targetMsg && targetMsg.content?.senderId === authenticatedSender);
+
+          if (authorized && targetMsg && targetMsg.content.type === 'post') {
+            // Full desktop DM parity on receive: 15-min window re-check against
+            // the target's createdDate + reject oversized edits.
+            const withinWindow = Date.now() - targetMsg.createdDate <= 15 * 60 * 1000;
+            const editedText = Array.isArray(editContent.editedText)
+              ? editContent.editedText.join('')
+              : editContent.editedText;
+            const withinLength = !editedText || editedText.length <= MAX_MESSAGE_LENGTH;
+
+            if (withinWindow && withinLength) {
+              const conversation = await storage.getConversation(conversationId);
+              const saveEditHistory = conversation?.saveEditHistory ?? false;
+              const applied = applyReceivedEdit(targetMsg, {
+                newText: editContent.editedText,
+                editedAt: editContent.editedAt,
+                editNonce: editContent.editNonce,
+                saveEditHistory,
+              });
+              // Replayed edit already applied → no-op (don't clobber history).
+              if (applied.changed) {
+                queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
+                  if (!old) return old;
+                  return { ...old, pages: old.pages.map((page) => ({
+                    ...page,
+                    messages: page.messages.map((m) => {
+                      if (m.messageId === editContent.originalMessageId && m.content.type === 'post') {
+                        return {
+                          ...m,
+                          modifiedDate: applied.modifiedDate,
+                          lastModifiedHash: applied.lastModifiedHash,
+                          content: { ...m.content, text: editContent.editedText },
+                          edits: applied.edits,
+                        };
+                      }
+                      return m;
+                    }),
+                  })) };
+                });
+                const updated: Message = {
+                  ...targetMsg,
+                  modifiedDate: applied.modifiedDate,
+                  lastModifiedHash: applied.lastModifiedHash,
+                  content: { ...targetMsg.content, text: editContent.editedText },
+                  edits: applied.edits,
+                };
+                await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
+                scheduleConversationRefresh(conversationId);
+              }
+            } else {
+              logger.debug(
+                `[DM] dropped edit-message for ${editContent.originalMessageId?.slice(0, 12)} (window=${withinWindow} length=${withinLength})`
+              );
+            }
+          } else if (!authorized) {
+            logger.debug(
+              `[DM] dropped unauthorized edit-message from ${editContent.senderId?.slice(0, 12)} for ${editContent.originalMessageId?.slice(0, 12)}`
+            );
+          }
+
+          // Best-effort: delete processed control message from inbox (same as
+          // the remove-message fold above).
+          const originalEditMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalEditMsg) {
+            const conversationKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(originalEditMsg.inboxAddress);
+            if (conversationKeypair?.signingPrivateKey && conversationKeypair?.signingPublicKey) {
+              const signingKey = {
+                publicKey: bytesToHex(conversationKeypair.signingPublicKey),
+                privateKey: bytesToHex(conversationKeypair.signingPrivateKey),
+              };
+              deleteConversationInboxMessages(originalEditMsg.inboxAddress, [originalEditMsg.timestamp], signingKey).catch(() => {});
+            } else {
+              getDeviceKeyset().then(dk => {
+                if (dk) deleteInboxMessages(originalEditMsg.inboxAddress, [originalEditMsg.timestamp], dk).catch(() => {});
               });
             }
           }

--- a/hooks/chat/useEditDirectMessage.ts
+++ b/hooks/chat/useEditDirectMessage.ts
@@ -1,16 +1,31 @@
 /**
- * useEditDirectMessage - Hook for editing direct messages (E2EE)
+ * useEditDirectMessage - edit your own DM, syncing to every device (matches desktop).
  *
- * Sends an edit-message type through the encrypted DM channel.
- * Enforces a 15-minute edit window.
- * Updates local cache and storage optimistically.
+ * After the optimistic local update, sends an `edit-message` control message
+ * over the SAME multi-device transport a normal text message uses
+ * (sendEncryptedMessageToAllDevices) — fanning out to the peer's devices AND
+ * your own other devices, bootstrapping sessions as needed. This is deliberately
+ * NOT the single-session reaction transport, which only reaches one inbox and so
+ * misses devices (see the DM-delete precedent). Receive-side auth
+ * (WebSocketContext) honors the edit only when the cryptographically-
+ * authenticated sender authored the target message.
+ *
+ * Enforces a 15-minute edit window and honors the conversation's "Save Edit
+ * History" setting. Stamps an `editNonce` so a duplicate delivery is a
+ * receive-side no-op (see utils/editHistory).
  */
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { useAuth } from '@/context';
+import { useAuth, useWebSocket } from '@/context';
 import { useStorageAdapter } from '@/context/StorageContext';
-import { queryKeys, type Message } from '@quilibrium/quorum-shared';
+import { getQuorumClient } from '@/services/api/quorumClient';
+import { encryptionService } from '@/services/crypto/encryption-service';
+import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
+import { generateNonce } from '@/services/onboarding/keyService';
+import { logger, queryKeys, type Message, type EditMessage } from '@quilibrium/quorum-shared';
 import { buildLocalEdits } from '@/utils/editHistory';
+import { sendEncryptedMessageToAllDevices } from './useSendDirectMessage';
+import type { InfiniteMessagesData } from './queryTypes';
 
 const EDIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -22,12 +37,19 @@ export interface UseEditDirectMessageParams {
   originalCreatedDate: number;
 }
 
-import type { MessagesPage, InfiniteMessagesData } from './queryTypes';
+type DeviceInfo = {
+  identityKey: number[];
+  signedPreKey: number[];
+  inboxAddress: string;
+  inboxEncryptionKey: number[];
+};
 
 export function useEditDirectMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
   const storage = useStorageAdapter();
+  const { enqueueOutbound, subscribe } = useWebSocket();
+  const apiClient = getQuorumClient();
 
   return useMutation({
     mutationFn: async (params: UseEditDirectMessageParams) => {
@@ -44,32 +66,40 @@ export function useEditDirectMessage() {
       // Honor the conversation's "Save Edit History" setting, matching
       // desktop (MessageEditTextarea.tsx / MessageService.ts): when OFF, drop
       // prior versions (edits: []) instead of accumulating. Default false to
-      // match desktop's default everywhere — keeping history is opt-in.
+      // match desktop's default everywhere — keeping history is opt-in. The
+      // receive path applies the same gate so the peer's echoed edit stays
+      // consistent with ours.
       const conversation = await storage.getConversation(params.conversationId);
       const saveEditHistory = conversation?.saveEditHistory ?? false;
 
-      // For DMs, editing is local-only (the encrypted message was already sent)
-      // We update the local message in storage
+      // Single edit timestamp + nonce, shared by the local write and the wire
+      // send so every device converges on the same edit metadata. The nonce is
+      // the receive-side replay guard (utils/editHistory applyReceivedEdit).
+      const editedAt = Date.now();
+      const editNonce = generateNonce();
+
+      // Local optimistic write to storage (the cache was already updated in
+      // onMutate). Keeps MMKV in sync so the edit survives query invalidation.
       const key = queryKeys.messages.infinite(params.recipientAddress, params.recipientAddress);
       const existingData = queryClient.getQueryData<InfiniteMessagesData>(key);
 
       if (existingData) {
-        // Find the message and update in storage
         for (const page of existingData.pages) {
           const msg = page.messages.find(m => m.messageId === params.messageId);
           if (msg && (msg.content.type === 'post' || msg.content.type === 'event')) {
             const updatedMsg: Message = {
               ...msg,
-              modifiedDate: Date.now(),
+              modifiedDate: editedAt,
+              lastModifiedHash: editNonce,
               content: {
                 ...msg.content,
                 text: params.newText,
               } as Message['content'],
-              edits: buildLocalEdits(msg.edits, params.newText, Date.now(), saveEditHistory),
+              edits: buildLocalEdits(msg.edits, params.newText, editedAt, saveEditHistory),
             };
             await storage.saveMessage(
               updatedMsg,
-              updatedMsg.modifiedDate,
+              updatedMsg.createdDate,
               params.recipientAddress,
               'dm',
               '',
@@ -78,6 +108,89 @@ export function useEditDirectMessage() {
             break;
           }
         }
+      }
+
+      // Transmit an `edit-message` control message to the peer's devices AND our
+      // own other devices, over the all-devices transport (mirrors the DM-delete
+      // path). Best-effort: a send failure must not undo the local edit.
+      try {
+        const senderId = user.address;
+
+        // NOTE: deliberately do NOT gate on isConnected — enqueueOutbound queues
+        // and the WS client flushes on (re)connect, so a transient disconnect
+        // must not silently drop the edit. We only need device keys to encrypt.
+        if (!encryptionService.hasDeviceKeys()) return params.messageId;
+
+        const deviceKeyset = await getDeviceKeyset();
+        if (!deviceKeyset) return params.messageId;
+
+        const nonce = generateNonce();
+        const createdDate = Date.now();
+        const controlMessageId = `${nonce}-${createdDate}`;
+
+        // Control message: transported only, never persisted as a chat row.
+        const message: Message = {
+          messageId: controlMessageId,
+          channelId: params.recipientAddress,
+          spaceId: params.recipientAddress,
+          digestAlgorithm: 'SHA-256',
+          nonce,
+          createdDate,
+          modifiedDate: createdDate,
+          lastModifiedHash: '',
+          content: {
+            type: 'edit-message',
+            senderId,
+            originalMessageId: params.messageId,
+            editedText: params.newText,
+            editedAt,
+            editNonce,
+          } as EditMessage,
+          reactions: [],
+          mentions: { memberIds: [], roleIds: [], channelIds: [] },
+        };
+
+        // Resolve all target devices exactly as a normal DM send / the DM-delete
+        // path does: recipient's devices + our own OTHER devices.
+        const { toAllDeviceInfos } = await import('./useRecipientRegistration');
+        let allTargetDevices: DeviceInfo[] = [];
+        try {
+          const recipientReg = await apiClient.fetchUserRegistration(params.recipientAddress);
+          if (recipientReg) allTargetDevices.push(...toAllDeviceInfos(recipientReg));
+          const senderReg = await apiClient.fetchUserRegistration(senderId);
+          if (senderReg) {
+            allTargetDevices.push(
+              ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
+            );
+          }
+        } catch {
+          // Registration fetch failed — fall through; with no devices the send
+          // is skipped below and the local edit still stands.
+        }
+
+        if (allTargetDevices.length === 0) return params.messageId;
+
+        logger.debug(
+          `[useEditDirectMessage] posting edit-message for ${params.messageId.slice(0, 12)} to ${allTargetDevices.length} device(s)`
+        );
+
+        await sendEncryptedMessageToAllDevices(
+          params.conversationId,
+          params.recipientAddress,
+          message,
+          allTargetDevices,
+          enqueueOutbound,
+          subscribe,
+          {
+            identityPublicKey: deviceKeyset.identityPublicKey,
+            inboxAddress: deviceKeyset.inboxAddress,
+            inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+          },
+          senderId,
+          user?.displayName,
+        );
+      } catch (err) {
+        logger.debug('[useEditDirectMessage] edit-message send failed (local edit stands)', err);
       }
 
       return params.messageId;


### PR DESCRIPTION
Message edits now propagate across devices in DMs, matching how spaces already behave and reaching parity with desktop.

## What changed
- **Send:** editing a DM now transmits an \`edit-message\` control message over the all-devices transport (the peer's devices AND your own other devices), instead of only updating the local copy. The optimistic local update is kept.
- **Receive:** both DM receive paths now handle an incoming \`edit-message\`, updating the stored and displayed message and showing the "(edited)" marker.
- **Removed** the \`edit-message\` carve-out from the DM default-deny guard now that a real handler exists.

## Security / correctness
- Edits are authorized by the cryptographically-authenticated session sender, **not** the spoofable payload \`senderId\` (same rule as the DM delete path and the desktop DM edit path).
- Receive re-validates the 15-minute edit window and the max message length (matching desktop).
- Honors the conversation's "Save Edit History" setting; replay-safe via \`editNonce\`.

## Verification
- **Send side: runtime-verified** on a physical device (edit posts to all resolved devices).
- **Receive side: review-only.** Cross-device DM delivery was unavailable during testing (a known intermittent issue affecting normal messages too), so the receive handler could not be exercised end-to-end. It was verified by static review against the existing, working DM delete handler it mirrors.
- No iOS runtime testing (reviewed only).
- Typecheck and lint pass with no new issues.