### PR TITLE
Sync DM conversation delete to your own other devices

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2887,12 +2887,27 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           return;
         }
 
-        // delete-conversation-self: not implemented on mobile yet — drop it so
-        // it isn't saved as a ghost row (forward-compat until mobile Part 2).
+        // delete-conversation-self, fallback path (mirrors the batch branch):
+        // another of OUR OWN devices deleted this DM — wipe the whole conversation
+        // here too (messages + row + session), gated to self. The counterparty
+        // also receives the fan-out but must NEVER delete our copy.
         if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
+          const selfContent = decryptedMessage.content as { senderId?: string; conversationAddress?: string };
+          const isSelfSender = !!selfContent.senderId && selfContent.senderId === user?.address;
+
+          // Always clear the processed control message from the inbox (self or not).
           getDeviceKeyset().then(dk => {
             if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
           });
+
+          if (isSelfSender) {
+            encryptionStateStorage.deleteAllEncryptionStates(conversationId);
+            await storage.deleteConversation(conversationId);
+            queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.messages.infinite(senderAddress, senderAddress),
+            });
+          }
           return;
         }
 
@@ -4050,17 +4065,37 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           continue;
         }
 
-        // delete-conversation-self: self-device delete-sync (desktop sends it).
-        // Mobile doesn't implement the wipe yet — drop it so it isn't saved as a
-        // ghost row. Forward-compat until mobile Part 2 lands. Never act on it
-        // from a non-self sender regardless.
+        // delete-conversation-self: another of OUR OWN devices deleted this DM.
+        // Delete the whole conversation here too (messages + row + session),
+        // distinct from the counterparty `delete-conversation` above which only
+        // resets the session. Gated to self — the counterparty also receives the
+        // fan-out but must NEVER delete our copy, so we act only when the
+        // authenticated conversation address is ourselves AND the payload sender
+        // is self. Runs before the conversation-save so it can't resurrect a row.
         if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
+          const selfContent = decryptedMessage.content as { senderId?: string; conversationAddress?: string };
+          const isSelfSender = !!selfContent.senderId && selfContent.senderId === user?.address;
+
+          // Always clear the processed control message from the inbox (self or not).
           const originalSelfMsg = batch.find(m => m.timestamp === msgResult.timestamp);
           if (originalSelfMsg) {
             getDeviceKeyset().then(dk => {
               if (dk) deleteInboxMessages(originalSelfMsg.inboxAddress, [originalSelfMsg.timestamp], dk).catch(() => {});
             });
           }
+
+          if (isSelfSender) {
+            // Wipe the whole conversation locally: session reset + row/messages +
+            // cache invalidation. Mirrors the local delete in dm/[id].tsx.
+            encryptionStateStorage.deleteAllEncryptionStates(conversationId);
+            await storage.deleteConversation(conversationId);
+            queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
+            queryClient.invalidateQueries({
+              queryKey: queryKeys.messages.infinite(resolvedSenderAddress, resolvedSenderAddress),
+            });
+          }
+          // Non-self delete-conversation-self is a no-op (defensive): the fan-out
+          // reaches the counterparty, but only self may delete our copy.
           continue;
         }
 

--- a/hooks/chat/useDeleteConversationSignal.ts
+++ b/hooks/chat/useDeleteConversationSignal.ts
@@ -1,11 +1,18 @@
 /**
- * useDeleteConversationSignal - tell the counterparty we deleted this DM.
+ * useDeleteConversationSignal - tell the counterparty AND our own devices that we
+ * deleted this DM.
  *
- * Matches desktop: send a `delete-conversation` control message before the local
- * delete. On receive the counterparty only resets its encryption session (it does
- * NOT delete its copy) so the next message re-handshakes cleanly. Best-effort —
- * a send failure must never block the local delete. Reuses the all-devices DM
- * transport.
+ * Two control messages, one all-devices fan-out (matches desktop's deleteConversation):
+ *   1. `delete-conversation`      → the counterparty resets its encryption session
+ *      (it does NOT delete its copy) so the next message re-handshakes cleanly.
+ *   2. `delete-conversation-self` → our OWN other devices delete the whole
+ *      conversation. The counterparty also receives it in the fan-out, but its
+ *      receive handler acts on this type ONLY when the sender is self, so it can
+ *      never trigger a delete on the counterparty.
+ *
+ * Both are best-effort — a send failure must never block the local delete. Reuses
+ * the all-devices DM transport (every device is an inbox, so the fan-out already
+ * reaches our own other devices).
  */
 
 import { useCallback } from 'react';
@@ -14,7 +21,11 @@ import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
 import { logger } from '@quilibrium/quorum-shared';
-import type { Message, DeleteConversationMessage } from '@quilibrium/quorum-shared';
+import type {
+  Message,
+  DeleteConversationMessage,
+  DeleteConversationSelfMessage,
+} from '@quilibrium/quorum-shared';
 import { sendEncryptedMessageToAllDevices } from './useSendDirectMessage';
 
 type DeviceInfo = {
@@ -43,31 +54,48 @@ export function useDeleteConversationSignal() {
         const deviceKeyset = await getDeviceKeyset();
         if (!deviceKeyset) return;
 
-        const nonce = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-          const r = (Math.random() * 16) | 0;
-          const v = c === 'x' ? r : (r & 0x3) | 0x8;
-          return v.toString(16);
-        });
-        const createdDate = Date.now();
-        const controlMessageId = `${nonce}-${createdDate}`;
+        const makeNonce = () =>
+          'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+            const r = (Math.random() * 16) | 0;
+            const v = c === 'x' ? r : (r & 0x3) | 0x8;
+            return v.toString(16);
+          });
 
-        // Control message: transported only, never persisted as a chat row.
-        const message: Message = {
-          messageId: controlMessageId,
-          channelId: recipientAddress,
-          spaceId: recipientAddress,
-          digestAlgorithm: 'SHA-256',
-          nonce,
-          createdDate,
-          modifiedDate: createdDate,
-          lastModifiedHash: '',
-          content: {
-            type: 'delete-conversation',
-            senderId,
-          } as DeleteConversationMessage,
-          reactions: [],
-          mentions: { memberIds: [], roleIds: [], channelIds: [] },
+        // Build a transport-only control message (never persisted as a chat row).
+        const buildControlMessage = (
+          content: DeleteConversationMessage | DeleteConversationSelfMessage,
+        ): Message => {
+          const nonce = makeNonce();
+          const createdDate = Date.now();
+          return {
+            messageId: `${nonce}-${createdDate}`,
+            channelId: recipientAddress,
+            spaceId: recipientAddress,
+            digestAlgorithm: 'SHA-256',
+            nonce,
+            createdDate,
+            modifiedDate: createdDate,
+            lastModifiedHash: '',
+            content,
+            reactions: [],
+            mentions: { memberIds: [], roleIds: [], channelIds: [] },
+          };
         };
+
+        // 1. Counterparty: reset your encryption session (do NOT delete their copy).
+        const resetMessage = buildControlMessage({
+          type: 'delete-conversation',
+          senderId,
+        } as DeleteConversationMessage);
+
+        // 2. Self-sync: tell OUR OWN other devices to delete the whole conversation.
+        // The fan-out reaches both parties; the receiver acts on this type only
+        // when the sender is self, so the counterparty can never delete our copy.
+        const selfMessage = buildControlMessage({
+          type: 'delete-conversation-self',
+          senderId,
+          conversationAddress: recipientAddress,
+        } as DeleteConversationSelfMessage);
 
         // Resolve target devices the same way a normal DM send does: the
         // recipient's devices + our own OTHER devices.
@@ -88,21 +116,28 @@ export function useDeleteConversationSignal() {
 
         if (allTargetDevices.length === 0) return;
 
-        await sendEncryptedMessageToAllDevices(
-          conversationId,
-          recipientAddress,
-          message,
-          allTargetDevices,
-          enqueueOutbound,
-          subscribe,
-          {
-            identityPublicKey: deviceKeyset.identityPublicKey,
-            inboxAddress: deviceKeyset.inboxAddress,
-            inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
-          },
-          senderId,
-          user?.displayName,
-        );
+        const deviceInfo = {
+          identityPublicKey: deviceKeyset.identityPublicKey,
+          inboxAddress: deviceKeyset.inboxAddress,
+          inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+        };
+
+        const sendControl = (message: Message) =>
+          sendEncryptedMessageToAllDevices(
+            conversationId,
+            recipientAddress,
+            message,
+            allTargetDevices,
+            enqueueOutbound,
+            subscribe,
+            deviceInfo,
+            senderId,
+            user?.displayName,
+          );
+
+        // Send both control messages over the same resolved device set. Each is
+        // independent best-effort — a failure of one must not skip the other.
+        await Promise.allSettled([sendControl(resetMessage), sendControl(selfMessage)]);
       } catch (err) {
         logger.debug('[useDeleteConversationSignal] send failed (local delete stands)', err);
       }


### PR DESCRIPTION
## What

When you delete a DM conversation, it now also disappears on your **own other devices** (phone ↔ desktop, phone ↔ phone), matching desktop.

Previously deleting a conversation only signalled the counterparty to reset their encryption session (already shipped in #144); your own other devices kept the conversation until manually deleted. This closes that gap.

## How

- **Send:** `useDeleteConversationSignal` now sends a `delete-conversation-self` control message alongside the existing counterparty reset signal, over the same all-devices DM fan-out. Both are independent best-effort (`Promise.allSettled`) so a failure of one never blocks the other or the local delete.
- **Receive:** both DM receive paths now wipe the whole conversation (messages + row + encryption session + cache) when a `delete-conversation-self` arrives **from your own account**. The wipe mirrors the local delete, so the result is identical to deleting on that device.
- **Safety:** the wipe is gated to self-sender (`senderId === your address`). The counterparty also receives the fan-out but the handler is a no-op for them, so they can never delete your copy.

Uses the `delete-conversation-self` wire type published in shared `2.1.0-34`. No shared or native changes; JS-only.

## Testing

- **Runtime-verified end-to-end:** same account on mobile + desktop. Deleted a DM on mobile → conversation vanished on desktop. (Send confirmed via a temporary log, since normal cross-device DM delivery was flaky that session; the delete still propagated.)
- **Review-only:** mobile *receiving* a self-message (the inverse direction) was not runtime-tested — cross-device delivery is unreliable. The receive handler is a direct mirror of desktop's already-merged, proven handler, with an identical self-gate.
- tsc + lint clean on changed files.

## Notes

- Desktop counterpart is already merged to `main`.
- No conflict with the in-flight space-message-auth work: this is a DM, session-anchored / self-gated feature and stays that way by design.