### PR TITLE
fix: space control message auth signatures

### DIFF
--- a/components/Chat/SpaceChatArea.tsx
+++ b/components/Chat/SpaceChatArea.tsx
@@ -469,7 +469,11 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         spaceChannels: channelsData?.map((c) => ({ channelId: c.channelId, channelName: c.channelName })),
         allowEveryone: canMentionEveryone,
         isRepudiable: spaceData?.isRepudiable,
-        skipSigning,
+        // Read-only channels force-sign: receivers only accept read-only
+        // posts from a VERIFIED manager, so an unsigned send would be
+        // dropped at every peer. The composer toggle is hidden for
+        // read-only channels; this is the wire-level backstop.
+        skipSigning: isReadOnlyChannel ? false : skipSigning,
       }, {
         onSettled: refocusInput,
       });
@@ -488,7 +492,8 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
         spaceChannels: channelsData?.map((c) => ({ channelId: c.channelId, channelName: c.channelName })),
         allowEveryone: canMentionEveryone,
         isRepudiable: spaceData?.isRepudiable,
-        skipSigning,
+        // Same read-only force-sign as the embed path above.
+        skipSigning: isReadOnlyChannel ? false : skipSigning,
       }, {
         onSettled: refocusInput,
       });
@@ -519,7 +524,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
       setAlsoReplyOnFarcaster(false);
       replyCastHashRef.current = null;
     }
-  }, [messageText, spaceId, channelId, sendMessageMutation, sendEmbedMutation, pendingAttachment, replyToMessage, editingMessage, editSpaceMessageMutation, draftsRef, alsoReplyOnFarcaster, isCastReply, farcasterAuthToken, spaceData, channelsData, canMentionEveryone, skipSigning]);
+  }, [messageText, spaceId, channelId, sendMessageMutation, sendEmbedMutation, pendingAttachment, replyToMessage, editingMessage, editSpaceMessageMutation, draftsRef, alsoReplyOnFarcaster, isCastReply, farcasterAuthToken, spaceData, channelsData, canMentionEveryone, skipSigning, isReadOnlyChannel]);
 
   const handleAttachmentPress = useCallback(async () => {
     const result = await pickImage('library');
@@ -815,7 +820,7 @@ export const SpaceChatArea = React.memo(function SpaceChatArea({
             editingMessage={editingMessage}
             onCancelEdit={handleCancelEdit}
             disabled={!canPost}
-            signingOptional={!!spaceData?.isRepudiable}
+            signingOptional={!!spaceData?.isRepudiable && !isReadOnlyChannel}
             skipSigning={skipSigning}
             onToggleSkipSigning={() => setSkipSigning((s) => !s)}
           />

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -66,8 +66,8 @@ import {
 import {
   authorizeSpaceControlMessage,
   isReadOnlyPostAuthorized,
+  isUpdateProfileAuthorized,
   shouldStripEveryoneMention,
-  verifySpaceMessageSignature,
 } from '../services/space/spaceMessageAuth';
 import {
   hasMuteId,
@@ -2146,15 +2146,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }
 
             if (contentType === 'update-profile') {
-              // Signature gate (desktop parity): a profile update rewrites
-              // another member's display identity, and doubles as their inbox
-              // key-rotation announcement — so an unsigned or invalid one is
-              // DROPPED, never applied. Verification is signature-only (no
-              // reverse member binding): a legitimately rotated key has no
-              // matching member row yet, exactly like desktop's update-profile
-              // carve-out in its verify block.
-              const profileSigner = await verifySpaceMessageSignature(spaceMessage, spaceId);
-              if (!profileSigner) {
+              // Profile updates rewrite a member's display identity, so they
+              // require a valid signature (unsigned/invalid → DROPPED, desktop
+              // parity) plus the known-key binding: a signing key already
+              // registered to a member may only speak for that member. A key
+              // matching no row is accepted — the message doubles as a
+              // key-rotation announcement. See isUpdateProfileAuthorized for
+              // why this is weaker than control-message auth and why the
+              // announced key is NOT written back to the member row.
+              const profileAuthorized = await isUpdateProfileAuthorized(spaceMessage, spaceId);
+              if (!profileAuthorized) {
                 logger.debug(
                   `[SpaceMsg] dropped unsigned/invalid update-profile for ${((spaceMessage.content as { senderId?: string })?.senderId ?? '').slice(0, 12)}`
                 );
@@ -3535,6 +3536,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         else entry.transforms.set(messageId, [transform]);
       };
 
+      // Member list memo for signature verification: a catch-up batch can hold
+      // hundreds of control messages and each verification needs the space's
+      // member list (reverse key→member lookup), which is one JSON.parse of
+      // the whole blob per read. Load lazily, once per space group, and
+      // invalidate whenever this loop processes something that writes member
+      // rows (join/kick via the control branch, update-profile below).
+      let batchMembersCache: SpaceMember[] | null = null;
+      const getBatchMembers = async () =>
+        (batchMembersCache ??= await getMMKVAdapter().getSpaceMembers(spaceId));
+
       for (const msgResult of groupResult.messages) {
         deleteTimestamps.push(msgResult.timestamp);
 
@@ -3588,6 +3599,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             } catch (err) {
               logger.warn(`[batch-control] handleIncomingMessage threw (ts=${msgResult.timestamp}): ${err instanceof Error ? err.message : String(err)}`);
             }
+            // Control messages (join/kick/…) may have written member rows.
+            batchMembersCache = null;
           } else {
             logger.debug(`[batch-control] dropped: no original batch message for ts=${msgResult.timestamp}`);
           }
@@ -3689,6 +3702,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               space: space ?? undefined,
               channel: editChannel,
               targetMessage: baseMsg,
+              members: await getBatchMembers(),
             });
             if (!editVerdict.allowed) {
               logger.debug(
@@ -3764,6 +3778,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               space: space ?? undefined,
               channel: removeChannel,
               targetMessage,
+              members: await getBatchMembers(),
             });
             if (!removeVerdict.allowed) {
               logger.debug(
@@ -3818,6 +3833,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               spaceId,
               space,
               channel: muteChannel,
+              members: await getBatchMembers(),
             });
             if (!muteVerdict.allowed) {
               logger.debug(
@@ -3850,11 +3866,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // the connect-time profile re-broadcast would be dropped and the
             // member's profile update would never reach this device.
             //
-            // Signature gate (desktop parity, same as live): unsigned or
-            // invalid → dropped, signature-only (no member reverse binding —
-            // the message doubles as a key-rotation announcement).
-            const profileSigner = await verifySpaceMessageSignature(spaceMessage, spaceId);
-            if (!profileSigner) {
+            // Signature + known-key-binding gate, same as live: unsigned or
+            // invalid → dropped; a signing key registered to a member may only
+            // speak for that member; unknown key accepted (rotation
+            // announcement). See isUpdateProfileAuthorized.
+            const profileAuthorized = await isUpdateProfileAuthorized(
+              spaceMessage, spaceId, await getBatchMembers()
+            );
+            if (!profileAuthorized) {
               logger.debug(
                 `[BatchMsg] dropped unsigned/invalid update-profile for ${((spaceMessage.content as { senderId?: string })?.senderId ?? '').slice(0, 12)}`
               );
@@ -3920,6 +3939,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             } as SpaceMember & { profileTimestamp: number; globalProfileTimestamp?: number; farcasterFid?: number; farcasterUsername?: string };
 
             await adapter.saveSpaceMember(spaceId, merged);
+            // Member rows changed — refresh the verification member memo.
+            batchMembersCache = null;
 
             queryClient.setQueryData(queryKeys.spaces.members(spaceId), (old: SpaceMember[] | undefined) => {
               if (!old) return old;
@@ -3971,7 +3992,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               ?.channels.find((c) => c.channelId === channelId);
             if (channel?.isReadOnly) {
               const canPost = await isReadOnlyPostAuthorized(
-                spaceMessage, spaceId, space ?? undefined, channel
+                spaceMessage, spaceId, space ?? undefined, channel, await getBatchMembers()
               );
               if (!canPost) {
                 const senderId = 'senderId' in spaceMessage.content
@@ -3989,7 +4010,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // `mentions.everyone` only when the verified signer matches the
           // claimed sender; otherwise strip the flag before the message is
           // stored or logged so badge, inbox, and rendering all agree.
-          if (spaceMessage.mentions && await shouldStripEveryoneMention(spaceMessage, spaceId)) {
+          if (spaceMessage.mentions && await shouldStripEveryoneMention(spaceMessage, spaceId, await getBatchMembers())) {
             logger.debug(
               `[BatchMsg] stripped unverified @everyone from ${spaceMessage.messageId?.slice(0, 12)}`
             );

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -10,8 +10,6 @@
 
 import {
   bytesToHex,
-  canManageReadOnlyChannel,
-  createChannelPermissionChecker,
   createRNWebSocketClient,
   int64ToBytes,
   logger,
@@ -65,6 +63,12 @@ import {
   clearSentEnvelope,
   isSentEnvelope,
 } from '../services/space/spaceMessageService';
+import {
+  authorizeSpaceControlMessage,
+  isReadOnlyPostAuthorized,
+  shouldStripEveryoneMention,
+  verifySpaceMessageSignature,
+} from '../services/space/spaceMessageAuth';
 import {
   hasMuteId,
   isUserMuted as isModMutedUser,
@@ -1877,6 +1881,54 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // Update existing message with edit
               const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number; editNonce?: string };
 
+              const dropEditInbox = () => {
+                if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                  deleteSpaceInboxMessages(
+                    spaceInboxKey.address,
+                    [message.timestamp],
+                    { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                  ).catch(err => {});
+                }
+              };
+
+              // Authorization runs against the VERIFIED SIGNER, never the
+              // payload senderId — spaces are many-party, so the ed448
+              // signature is the only per-message sender proof. The verdict
+              // (shared authorizeControlMessage) requires a verified signature
+              // regardless of space.isRepudiable and permits only edits of the
+              // signer's own message; the one exception is an unsigned edit of
+              // an unsigned own message in a repudiable space (deniable
+              // content stays at the trust level it always had). Target must
+              // exist locally: without it the own-author gate can't run.
+              const existingMsg = await storage.getMessage({ spaceId, channelId, messageId: editContent.originalMessageId });
+              const editChannel: Channel | undefined = space?.groups
+                ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+                ?.channels.find((c) => c.channelId === channelId);
+              const editVerdict = await authorizeSpaceControlMessage({
+                message: spaceMessage,
+                spaceId,
+                space: space ?? undefined,
+                channel: editChannel,
+                targetMessage: existingMsg,
+              });
+              if (!editVerdict.allowed) {
+                logger.debug(
+                  `[SpaceMsg] dropped unauthorized edit-message (${editVerdict.reason}) for ${editContent.originalMessageId?.slice(0, 12)}`
+                );
+                dropEditInbox();
+                return;
+              }
+
+              // Per-version signature truth: a signed, verified edit's
+              // signature attests the NEW text, so the stored row adopts the
+              // edit's publicKey/signature (otherwise the signed-state badge
+              // would vouch for text the original signature never covered).
+              // An accepted unsigned edit — only possible on an unsigned
+              // original — leaves the row unsigned.
+              const editSignatureFields = spaceMessage.signature && spaceMessage.publicKey
+                ? { publicKey: spaceMessage.publicKey, signature: spaceMessage.signature }
+                : {};
+
               // Honor the space's "Save Edit History" setting, matching desktop:
               // when OFF, don't retain prior versions (edits: []). Default false.
               const saveEditHistory = space?.saveEditHistory ?? false;
@@ -1905,6 +1957,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                             text: editContent.editedText,
                           },
                           edits: applied.edits,
+                          ...editSignatureFields,
                         };
                       }
                       return msg;
@@ -1916,7 +1969,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // remount / navigating away and back. Without this, the cache
               // update above gets overwritten the next time the infinite
               // query refetches from MMKV.
-              const existingMsg = await storage.getMessage({ spaceId, channelId, messageId: editContent.originalMessageId });
               if (existingMsg && existingMsg.content.type === 'post') {
                 const applied = applyReceivedEdit(existingMsg, {
                   newText: editContent.editedText,
@@ -1933,32 +1985,28 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     lastModifiedHash: applied.lastModifiedHash,
                     content: { ...existingMsg.content, text: editContent.editedText },
                     edits: applied.edits,
+                    ...editSignatureFields,
                   };
                   await storage.saveMessage(updated, updated.createdDate, '', '', '', '');
                 }
               }
               // Delete edit-message from inbox after processing
-              if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
-                deleteSpaceInboxMessages(
-                  spaceInboxKey.address,
-                  [message.timestamp],
-                  { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
-                ).catch(err => {});
-              }
+              dropEditInbox();
               return;
             }
 
             if (contentType === 'remove-message') {
               const removeContent = spaceMessage.content as RemoveMessage;
 
-              // Receive-side permission enforcement. The sender's own client
-              // gates the delete button, but we can't trust that — a modified
-              // or buggy client (or a space owner relying on the owner-bypass
-              // footgun) could broadcast a delete it shouldn't. So we re-validate
-              // here against the sender's role, exactly as desktop does
-              // (MessageService.ts remove-message handling). No isSpaceOwner
-              // bypass: receivers can't verify ownership, so owners must hold a
-              // role with message:delete to delete others' messages.
+              // Receive-side permission enforcement against the VERIFIED
+              // SIGNER, never the payload senderId (which any modified client
+              // can set to a role-holder or the target's author). The verdict
+              // (shared authorizeControlMessage) requires a valid ed448
+              // signature regardless of space.isRepudiable, resolves the
+              // signer via reverse key→member lookup (fail-closed), and then
+              // runs the role check desktop runs (no isSpaceOwner bypass:
+              // receivers can't verify ownership). Missing target → honored
+              // as a no-op removal, but only from a verified sender.
               //
               // Self-deletes never reach this handler — own echoes are filtered
               // upstream (sent-envelope / senderId checks) and the local removal
@@ -1969,37 +2017,33 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 messageId: removeContent.removeMessageId,
               });
 
-              if (targetMessage) {
-                // Resolve the channel for read-only / manager-role handling.
-                const channel: Channel | undefined = space?.groups
-                  ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-                  ?.channels.find((c) => c.channelId === channelId);
+              // Resolve the channel for read-only / manager-role handling.
+              const channel: Channel | undefined = space?.groups
+                ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+                ?.channels.find((c) => c.channelId === channelId);
 
-                const checker = createChannelPermissionChecker({
-                  userAddress: removeContent.senderId,
-                  isSpaceOwner: false,
-                  space: space ?? undefined,
-                  channel,
-                });
-
-                if (!checker.canDeleteMessage(targetMessage)) {
-                  // Unauthorized delete — drop it, but still clear the inbox
-                  // entry so we don't reprocess it on every reconnect.
-                  logger.debug(
-                    `[SpaceMsg] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
-                  );
-                  if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
-                    deleteSpaceInboxMessages(
-                      spaceInboxKey.address,
-                      [message.timestamp],
-                      { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
-                    ).catch(err => {});
-                  }
-                  return;
+              const removeVerdict = await authorizeSpaceControlMessage({
+                message: spaceMessage,
+                spaceId,
+                space: space ?? undefined,
+                channel,
+                targetMessage,
+              });
+              if (!removeVerdict.allowed) {
+                // Unauthorized delete — drop it, but still clear the inbox
+                // entry so we don't reprocess it on every reconnect.
+                logger.debug(
+                  `[SpaceMsg] dropped unauthorized remove-message (${removeVerdict.reason}) from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+                );
+                if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                  deleteSpaceInboxMessages(
+                    spaceInboxKey.address,
+                    [message.timestamp],
+                    { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                  ).catch(err => {});
                 }
+                return;
               }
-              // targetMessage missing → nothing to protect; honor the removal so
-              // a stale reference doesn't linger in the cache.
 
               // Remove message from cache and storage
               queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
@@ -2029,12 +2073,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             if (contentType === 'mute') {
               const muteContent = spaceMessage.content as MuteMessage;
 
-              // Receive-side moderation-mute enforcement. Like remove-message we
-              // NEVER trust the sender's client — we re-validate the sender holds
-              // the `user:mute` role before honoring the mute. No isSpaceOwner
-              // bypass: receivers can't verify ownership, so owners must hold a
-              // user:mute role too (matches desktop mute-user-system). Fail-secure:
-              // reject when space data is unavailable.
+              // Receive-side moderation-mute enforcement against the VERIFIED
+              // SIGNER, never the payload senderId. The verdict (shared
+              // authorizeControlMessage) requires a valid ed448 signature
+              // regardless of space.isRepudiable, resolves the signer via
+              // reverse key→member lookup (fail-closed), and checks the
+              // `user:mute` role. No isSpaceOwner bypass: receivers can't
+              // verify ownership, so owners must hold a user:mute role too
+              // (matches desktop mute-user-system). Fail-secure: reject when
+              // space data is unavailable.
               const dropMuteInbox = () => {
                 if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
                   deleteSpaceInboxMessages(
@@ -2065,15 +2112,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               const muteChannel: Channel | undefined = space.groups
                 ?.find((g) => g.channels.find((c) => c.channelId === channelId))
                 ?.channels.find((c) => c.channelId === channelId);
-              const muteChecker = createChannelPermissionChecker({
-                userAddress: muteContent.senderId,
-                isSpaceOwner: false,
+              const muteVerdict = await authorizeSpaceControlMessage({
+                message: spaceMessage,
+                spaceId,
                 space,
                 channel: muteChannel,
               });
-              if (!muteChecker.canMuteUser()) {
+              if (!muteVerdict.allowed) {
                 logger.debug(
-                  `[SpaceMsg] dropped unauthorized mute from ${muteContent.senderId?.slice(0, 12)} for ${muteContent.targetUserId?.slice(0, 12)}`
+                  `[SpaceMsg] dropped unauthorized mute (${muteVerdict.reason}) from ${muteContent.senderId?.slice(0, 12)} for ${muteContent.targetUserId?.slice(0, 12)}`
                 );
                 dropMuteInbox();
                 return;
@@ -2099,6 +2146,28 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }
 
             if (contentType === 'update-profile') {
+              // Signature gate (desktop parity): a profile update rewrites
+              // another member's display identity, and doubles as their inbox
+              // key-rotation announcement — so an unsigned or invalid one is
+              // DROPPED, never applied. Verification is signature-only (no
+              // reverse member binding): a legitimately rotated key has no
+              // matching member row yet, exactly like desktop's update-profile
+              // carve-out in its verify block.
+              const profileSigner = await verifySpaceMessageSignature(spaceMessage, spaceId);
+              if (!profileSigner) {
+                logger.debug(
+                  `[SpaceMsg] dropped unsigned/invalid update-profile for ${((spaceMessage.content as { senderId?: string })?.senderId ?? '').slice(0, 12)}`
+                );
+                if (spaceInboxKey?.address && spaceInboxKey.publicKey && spaceInboxKey.privateKey) {
+                  deleteSpaceInboxMessages(
+                    spaceInboxKey.address,
+                    [message.timestamp],
+                    { publicKey: spaceInboxKey.publicKey, privateKey: spaceInboxKey.privateKey }
+                  ).catch(err => {});
+                }
+                return;
+              }
+
               // Update member profile (display name, icon, bio) in storage and cache.
               // Two changes vs. the previous implementation:
               //   1. UPSERT instead of update-only — if we don't have a
@@ -2263,11 +2332,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }
 
             // Read-only channel enforcement (receive-side). Postable content
-            // (post/embed/sticker) authored by a non-manager must not land in a
-            // read-only channel — the sender's client should have blocked it, but
-            // we can't trust that (same reasoning as the remove-message guard).
-            // Covers all three postable types and runs BEFORE storage.saveMessage
-            // so a dropped message can't resurrect from disk on refetch.
+            // (post/embed/sticker) lands in a read-only channel only when its
+            // VERIFIED SIGNER is a manager — the claimed senderId proves
+            // nothing (a modified client sets it to any manager). Posting into
+            // a read-only channel is a privileged op, so the signature is
+            // required regardless of repudiability; unsigned → dropped. Runs
+            // BEFORE storage.saveMessage so a dropped message can't resurrect
+            // from disk on refetch.
             if (
               contentType === 'post' ||
               contentType === 'embed' ||
@@ -2278,12 +2349,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 ?.channels.find((c) => c.channelId === channelId);
 
               if (channel?.isReadOnly) {
-                const senderId = 'senderId' in spaceMessage.content
-                  ? spaceMessage.content.senderId
-                  : undefined;
-                const canPost = !!senderId
-                  && canManageReadOnlyChannel(senderId, false, space ?? undefined, channel);
+                const canPost = await isReadOnlyPostAuthorized(
+                  spaceMessage, spaceId, space ?? undefined, channel
+                );
                 if (!canPost) {
+                  const senderId = 'senderId' in spaceMessage.content
+                    ? spaceMessage.content.senderId
+                    : undefined;
                   logger.debug(
                     `[SpaceMsg] dropped read-only-channel post from ${senderId?.slice(0, 12)} in ${channelId?.slice(0, 12)}`
                   );
@@ -2297,6 +2369,23 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   return;
                 }
               }
+            }
+
+            // Receive-side @everyone gate: honor `mentions.everyone` only when
+            // the message's verified signer matches the claimed sender (whose
+            // mention:everyone role the downstream checks already require).
+            // Unverifiable → strip the flag BEFORE the message is stored or
+            // logged, so the badge, the notifications inbox, and the rendered
+            // "authorized @everyone" highlight all agree. The message itself
+            // still lands — it only loses the space-wide notification.
+            if (spaceMessage.mentions && await shouldStripEveryoneMention(spaceMessage, spaceId)) {
+              logger.debug(
+                `[SpaceMsg] stripped unverified @everyone from ${spaceMessage.messageId?.slice(0, 12)}`
+              );
+              spaceMessage = {
+                ...spaceMessage,
+                mentions: { ...spaceMessage.mentions, everyone: false },
+              };
             }
 
             // Regular message types (post, embed, sticker, join, leave, kick, etc.)
@@ -3581,6 +3670,41 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
           if (contentType === 'edit-message') {
             const editContent = spaceMessage.content as { originalMessageId: string; editedText: string | string[]; editedAt: number; editNonce?: string };
+
+            // Verified-signer authorization — same rule as the live path.
+            // Signature required regardless of repudiability (one exception:
+            // unsigned edit of an unsigned own message in a repudiable space);
+            // signer resolved by reverse key→member lookup; edits only of the
+            // signer's own message. Target must exist locally for the
+            // own-author gate to run. A check on one path but not the other
+            // would let cache and disk diverge, so this mirrors live exactly.
+            const baseMsg = pendingStorageUpdates.get(editContent.originalMessageId)
+              ?? await storage.getMessage({ spaceId, channelId, messageId: editContent.originalMessageId });
+            const editChannel: Channel | undefined = space?.groups
+              ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+              ?.channels.find((c) => c.channelId === channelId);
+            const editVerdict = await authorizeSpaceControlMessage({
+              message: spaceMessage,
+              spaceId,
+              space: space ?? undefined,
+              channel: editChannel,
+              targetMessage: baseMsg,
+            });
+            if (!editVerdict.allowed) {
+              logger.debug(
+                `[BatchMsg] dropped unauthorized edit-message (${editVerdict.reason}) for ${editContent.originalMessageId?.slice(0, 12)}`
+              );
+              continue;
+            }
+
+            // Per-version signature truth (same as live): a signed, verified
+            // edit's signature attests the NEW text — the stored row adopts
+            // the edit's publicKey/signature. An accepted unsigned edit (only
+            // possible on an unsigned original) leaves the row unsigned.
+            const editSignatureFields = spaceMessage.signature && spaceMessage.publicKey
+              ? { publicKey: spaceMessage.publicKey, signature: spaceMessage.signature }
+              : {};
+
             // Honor the space's "Save Edit History" setting, matching desktop:
             // when OFF, don't retain prior versions (edits: []). Default false.
             const saveEditHistory = space?.saveEditHistory ?? false;
@@ -3601,6 +3725,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 lastModifiedHash: applied.lastModifiedHash,
                 content: { ...msg.content, text: editContent.editedText },
                 edits: applied.edits,
+                ...editSignatureFields,
               };
             };
             queueCacheTransform(messagesKey, editContent.originalMessageId, applyEdit);
@@ -3608,8 +3733,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // query refetches from disk (e.g. on remount, invalidate, or when
             // the user navigates away and back), so the edit appears to "snap
             // back" to the original. Match what the cache update did above.
-            const baseMsg = pendingStorageUpdates.get(editContent.originalMessageId)
-              ?? await storage.getMessage({ spaceId, channelId, messageId: editContent.originalMessageId });
             if (baseMsg && baseMsg.content.type === 'post') {
               pendingStorageUpdates.set(editContent.originalMessageId, applyEdit(baseMsg));
             }
@@ -3619,32 +3742,34 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           if (contentType === 'remove-message') {
             const removeContent = spaceMessage.content as RemoveMessage;
 
-            // Receive-side permission enforcement — same rule as the live path
-            // above. Validate the sender's role before honoring a delete; never
-            // trust the sender's client. No isSpaceOwner bypass (receivers can't
-            // verify ownership). Self-deletes are filtered upstream as self-echoes,
-            // so this won't block legitimate own deletes.
+            // Verified-signer authorization — same rule as the live path
+            // above: valid signature required regardless of repudiability,
+            // signer resolved by reverse key→member lookup (fail-closed),
+            // role check via the shared verdict. Never the payload senderId.
+            // No isSpaceOwner bypass (receivers can't verify ownership).
+            // Missing target → honored as a no-op removal, but only from a
+            // verified sender. Self-deletes are filtered upstream as
+            // self-echoes, so this won't block legitimate own deletes.
             const targetMessage = await storage.getMessage({
               spaceId,
               channelId,
               messageId: removeContent.removeMessageId,
             });
-            if (targetMessage) {
-              const channel: Channel | undefined = space?.groups
-                ?.find((g) => g.channels.find((c) => c.channelId === channelId))
-                ?.channels.find((c) => c.channelId === channelId);
-              const checker = createChannelPermissionChecker({
-                userAddress: removeContent.senderId,
-                isSpaceOwner: false,
-                space: space ?? undefined,
-                channel,
-              });
-              if (!checker.canDeleteMessage(targetMessage)) {
-                logger.debug(
-                  `[BatchMsg] dropped unauthorized remove-message from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
-                );
-                continue;
-              }
+            const removeChannel: Channel | undefined = space?.groups
+              ?.find((g) => g.channels.find((c) => c.channelId === channelId))
+              ?.channels.find((c) => c.channelId === channelId);
+            const removeVerdict = await authorizeSpaceControlMessage({
+              message: spaceMessage,
+              spaceId,
+              space: space ?? undefined,
+              channel: removeChannel,
+              targetMessage,
+            });
+            if (!removeVerdict.allowed) {
+              logger.debug(
+                `[BatchMsg] dropped unauthorized remove-message (${removeVerdict.reason}) from ${removeContent.senderId?.slice(0, 12)} for ${removeContent.removeMessageId?.slice(0, 12)}`
+              );
+              continue;
             }
 
             queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {
@@ -3665,9 +3790,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           }
 
           if (contentType === 'mute') {
-            // Moderation-mute — same receive-side enforcement as the live path.
-            // Re-validate the sender's user:mute role; no isSpaceOwner bypass;
-            // fail-secure when space data is missing; reject self-mute + replays.
+            // Moderation-mute — same receive-side enforcement as the live
+            // path: verified-signer authorization via the shared verdict
+            // (signature required regardless of repudiability, reverse
+            // key→member lookup, user:mute role), never the payload senderId.
+            // No isSpaceOwner bypass; fail-secure when space data is missing;
+            // reject self-mute + replays.
             const muteContent = spaceMessage.content as MuteMessage;
 
             if (
@@ -3685,15 +3813,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             const muteChannel: Channel | undefined = space.groups
               ?.find((g) => g.channels.find((c) => c.channelId === channelId))
               ?.channels.find((c) => c.channelId === channelId);
-            const muteChecker = createChannelPermissionChecker({
-              userAddress: muteContent.senderId,
-              isSpaceOwner: false,
+            const muteVerdict = await authorizeSpaceControlMessage({
+              message: spaceMessage,
+              spaceId,
               space,
               channel: muteChannel,
             });
-            if (!muteChecker.canMuteUser()) {
+            if (!muteVerdict.allowed) {
               logger.debug(
-                `[BatchMsg] dropped unauthorized mute from ${muteContent.senderId?.slice(0, 12)} for ${muteContent.targetUserId?.slice(0, 12)}`
+                `[BatchMsg] dropped unauthorized mute (${muteVerdict.reason}) from ${muteContent.senderId?.slice(0, 12)} for ${muteContent.targetUserId?.slice(0, 12)}`
               );
               continue;
             }
@@ -3721,6 +3849,17 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // update-profile is an applied type, not persistable, so without this
             // the connect-time profile re-broadcast would be dropped and the
             // member's profile update would never reach this device.
+            //
+            // Signature gate (desktop parity, same as live): unsigned or
+            // invalid → dropped, signature-only (no member reverse binding —
+            // the message doubles as a key-rotation announcement).
+            const profileSigner = await verifySpaceMessageSignature(spaceMessage, spaceId);
+            if (!profileSigner) {
+              logger.debug(
+                `[BatchMsg] dropped unsigned/invalid update-profile for ${((spaceMessage.content as { senderId?: string })?.senderId ?? '').slice(0, 12)}`
+              );
+              continue;
+            }
             const profileContent = spaceMessage.content as {
               senderId: string;
               displayName?: string;
@@ -3818,8 +3957,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           }
 
           // Read-only channel enforcement (receive-side) — same rule as the
-          // live path above. Drop non-manager post/embed/sticker before the
-          // save so it can't resurrect from disk.
+          // live path above: only the VERIFIED SIGNER counts, and it must be
+          // a manager. Unsigned → dropped (privileged op, verified regardless
+          // of repudiability). Drops before the save so the message can't
+          // resurrect from disk.
           if (
             contentType === 'post' ||
             contentType === 'embed' ||
@@ -3829,18 +3970,33 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               ?.find((g) => g.channels.find((c) => c.channelId === channelId))
               ?.channels.find((c) => c.channelId === channelId);
             if (channel?.isReadOnly) {
-              const senderId = 'senderId' in spaceMessage.content
-                ? spaceMessage.content.senderId
-                : undefined;
-              const canPost = !!senderId
-                && canManageReadOnlyChannel(senderId, false, space ?? undefined, channel);
+              const canPost = await isReadOnlyPostAuthorized(
+                spaceMessage, spaceId, space ?? undefined, channel
+              );
               if (!canPost) {
+                const senderId = 'senderId' in spaceMessage.content
+                  ? spaceMessage.content.senderId
+                  : undefined;
                 logger.debug(
                   `[BatchMsg] dropped read-only-channel post from ${senderId?.slice(0, 12)} in ${channelId?.slice(0, 12)}`
                 );
                 continue;
               }
             }
+          }
+
+          // Receive-side @everyone gate — same rule as the live path: honor
+          // `mentions.everyone` only when the verified signer matches the
+          // claimed sender; otherwise strip the flag before the message is
+          // stored or logged so badge, inbox, and rendering all agree.
+          if (spaceMessage.mentions && await shouldStripEveryoneMention(spaceMessage, spaceId)) {
+            logger.debug(
+              `[BatchMsg] stripped unverified @everyone from ${spaceMessage.messageId?.slice(0, 12)}`
+            );
+            spaceMessage = {
+              ...spaceMessage,
+              mentions: { ...spaceMessage.mentions, everyone: false },
+            };
           }
 
           // Regular message - save and update cache

--- a/hooks/chat/useEditSpaceMessage.ts
+++ b/hooks/chat/useEditSpaceMessage.ts
@@ -10,7 +10,7 @@ import { useAuth, useWebSocket } from '@/context';
 import { sendEditMessage } from '@/services/space/spaceMessageService';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
 import { buildLocalEdits } from '@/utils/editHistory';
-import type { Message, GetMessagesResult } from '@quilibrium/quorum-shared';
+import { shouldSignEdit, type Message, type GetMessagesResult } from '@quilibrium/quorum-shared';
 
 const EDIT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 
@@ -56,6 +56,16 @@ export function useEditSpaceMessage() {
         throw new Error('Messages can only be edited within 15 minutes of sending');
       }
 
+      // Edit inherit rule: the edit is signed iff the original was signed, so
+      // a deliberately-unsigned (deniable) message never silently gains a
+      // signature. The optimistic onMutate write only replaces text and
+      // preserves the row's signature field, so this read is race-safe.
+      const storedOriginal = await getMMKVAdapter().getMessage({
+        spaceId: params.spaceId,
+        channelId: params.channelId,
+        messageId: params.messageId,
+      });
+
       const result = await sendEditMessage({
         spaceId: params.spaceId,
         channelId: params.channelId,
@@ -65,6 +75,9 @@ export function useEditSpaceMessage() {
         spaceRoles: params.spaceRoles,
         spaceChannels: params.spaceChannels,
         allowEveryone: params.allowEveryone,
+        // No stored row (shouldn't happen inside the edit window) → sign, the
+        // pre-existing behavior for every edit.
+        skipSigning: storedOriginal ? !shouldSignEdit(storedOriginal) : false,
       });
 
       // Send via WebSocket

--- a/services/space/spaceMessageAuth.ts
+++ b/services/space/spaceMessageAuth.ts
@@ -30,6 +30,7 @@ import {
   buildMessageFingerprint,
   bytesToHex,
   canManageReadOnlyChannel,
+  deriveInboxAddress,
   hexToBytes,
   isControlMessageType,
   resolveVerifiedSender,
@@ -38,6 +39,7 @@ import {
   type ControlMessageVerdict,
   type Message,
   type Space,
+  type SpaceMember,
   type VerifiedSender,
 } from '@quilibrium/quorum-shared';
 import { NativeSigningProvider } from '../crypto/native-signing-provider';
@@ -126,12 +128,14 @@ export async function verifySpaceMessageSignature(
  */
 export async function resolveVerifiedSpaceSender(
   message: Message,
-  spaceId: string
+  spaceId: string,
+  members?: SpaceMember[]
 ): Promise<VerifiedSender | null> {
   const publicKey = await verifySpaceMessageSignature(message, spaceId);
   if (!publicKey) return null;
-  const members = await getMMKVAdapter().getSpaceMembers(spaceId);
-  return resolveVerifiedSender(publicKey, members);
+  const memberList =
+    members ?? (await getMMKVAdapter().getSpaceMembers(spaceId));
+  return resolveVerifiedSender(publicKey, memberList);
 }
 
 /**
@@ -148,13 +152,16 @@ export async function authorizeSpaceControlMessage(params: {
   space: Space | undefined;
   channel: Channel | undefined;
   targetMessage?: Message;
+  /** Preloaded member list (batch catch-up passes one per space so hundreds
+   *  of control messages don't re-parse the member blob each). */
+  members?: SpaceMember[];
 }): Promise<ControlMessageVerdict> {
-  const { message, spaceId, space, channel, targetMessage } = params;
+  const { message, spaceId, space, channel, targetMessage, members } = params;
   const contentType = message.content?.type;
   if (!contentType || !isControlMessageType(contentType)) {
     return { allowed: false, reason: 'unknown-control-type' };
   }
-  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId, members);
   return authorizeControlMessage({
     content: message.content as ControlMessageContent,
     verifiedSender,
@@ -175,11 +182,52 @@ export async function isReadOnlyPostAuthorized(
   message: Message,
   spaceId: string,
   space: Space | undefined,
-  channel: Channel | undefined
+  channel: Channel | undefined,
+  members?: SpaceMember[]
 ): Promise<boolean> {
-  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId, members);
   if (!verifiedSender) return false;
   return canManageReadOnlyChannel(verifiedSender, false, space, channel);
+}
+
+/**
+ * update-profile acceptance. A profile update rewrites a member's display
+ * identity AND doubles as their inbox key-rotation announcement, which forces
+ * a weaker rule than control messages: a rotated key legitimately matches no
+ * member row yet, so the strict reverse binding of `resolveVerifiedSpaceSender`
+ * would permanently block every profile update after a rotation.
+ *
+ * Rule: signature required and valid (unsigned/invalid → drop, desktop
+ * parity), PLUS a known-key binding — when the signing key DOES map to an
+ * existing member row, the claimed senderId must be that member. This kills
+ * the cheap impersonation (a member signing with their own registered key
+ * while claiming someone else's senderId) while leaving genuine rotations
+ * (unknown key) accepted exactly as desktop does.
+ *
+ * Deliberately NOT mirrored from desktop: writing the announced key's inbox
+ * address onto the claimed member's row. Accepting an unproven key→member
+ * binding into the same table `resolveVerifiedSender` authorizes against
+ * would let a forged update-profile impersonate that member for CONTROL
+ * messages afterwards. Mobile member rows keep the join-broadcast binding.
+ */
+export async function isUpdateProfileAuthorized(
+  message: Message,
+  spaceId: string,
+  members?: SpaceMember[]
+): Promise<boolean> {
+  const publicKey = await verifySpaceMessageSignature(message, spaceId);
+  if (!publicKey) return false;
+  const senderId = (message.content as { senderId?: string })?.senderId;
+  if (!senderId) return false;
+  const memberList =
+    members ?? (await getMMKVAdapter().getSpaceMembers(spaceId));
+  const inboxAddress = deriveInboxAddress(publicKey);
+  const keyOwner = memberList.find(
+    (m) => m.inbox_address && m.inbox_address === inboxAddress
+  );
+  if (!keyOwner) return true; // unknown key: rotation announcement, accept
+  const ownerAddress = keyOwner.address || keyOwner.user_address;
+  return ownerAddress === senderId;
 }
 
 /**
@@ -198,11 +246,15 @@ export async function isReadOnlyPostAuthorized(
  */
 export async function shouldStripEveryoneMention(
   message: Message,
-  spaceId: string
+  spaceId: string,
+  members?: SpaceMember[]
 ): Promise<boolean> {
   if (message.mentions?.everyone !== true) return false;
   const senderId = (message.content as { senderId?: string })?.senderId;
   if (!senderId) return true;
-  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
-  return verifiedSender !== senderId;
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId, members);
+  // Strip when unverifiable OR when the signing key belongs to someone other
+  // than the claimed sender. (VerifiedSender is a branded string, so the
+  // runtime comparison is plain string equality.)
+  return verifiedSender === null || verifiedSender !== senderId;
 }

--- a/services/space/spaceMessageAuth.ts
+++ b/services/space/spaceMessageAuth.ts
@@ -1,0 +1,208 @@
+/*
+ * SpaceMessageAuth - Receive-side signature verification and authorization
+ * for space messages.
+ *
+ * The ONLY per-message sender proof in a space is the ed448 signature over the
+ * message fingerprint (spaces are many-party: group decrypt identifies no
+ * author, and the plaintext `content.senderId` is written by the sender's
+ * client, so a modified client can claim any identity). Every receive-side
+ * permission decision must therefore run against the VERIFIED signer:
+ *
+ *   verify ed448(signature, fingerprint-hash, publicKey)   -- key holds message
+ *   inboxAddress = base58btc(multihash(sha256(publicKey))) -- identity from key
+ *   sender = space member whose inbox_address matches       -- REVERSE lookup
+ *
+ * The reverse lookup is the critical shape: resolving the member FROM the key
+ * makes a missing/kicked member fail closed by construction and removes the
+ * spoofable `senderId` as an auth input entirely. Never look up the member BY
+ * the claimed senderId and compare - that is bypassable whenever the claimed
+ * member's row is missing locally (common; see the space-members-missing bug).
+ *
+ * Mirrors desktop MessageService.ts (isSpaceControlAuthorized /
+ * isReadOnlyPostAuthorized, desktop PR #241). The authorization verdicts
+ * themselves live in quorum-shared (`authorizeControlMessage`) so the two
+ * platforms can never disagree about whether a control message is honored.
+ */
+
+import { sha256 } from '@noble/hashes/sha2.js';
+import {
+  authorizeControlMessage,
+  buildMessageFingerprint,
+  bytesToHex,
+  canManageReadOnlyChannel,
+  hexToBytes,
+  isControlMessageType,
+  resolveVerifiedSender,
+  type Channel,
+  type ControlMessageContent,
+  type ControlMessageVerdict,
+  type Message,
+  type Space,
+  type VerifiedSender,
+} from '@quilibrium/quorum-shared';
+import { NativeSigningProvider } from '../crypto/native-signing-provider';
+import { getMMKVAdapter } from '../storage/mmkvAdapter';
+
+export type { ControlMessageVerdict, VerifiedSender };
+
+// Loop instead of spread to avoid stack overflow on large arrays (same pattern
+// as spaceMessageService).
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+/**
+ * Verify a space message's ed448 signature against its recomputed fingerprint.
+ *
+ * Recomputes the canonical fingerprint (shared `buildMessageFingerprint`, which
+ * scope-binds spaceId+channelId for control types so a signed control message
+ * can't be replayed into another space/channel), checks the wire messageId
+ * matches its hash, and runs the native ed448 verify over the hash bytes.
+ *
+ * The fingerprint is computed against the CONTEXT spaceId (the space whose
+ * hub/inbox delivered the message - the space the handlers will apply it to),
+ * not the wire `message.spaceId`, so the scope a signature attests is always
+ * the scope it takes effect in.
+ *
+ * Returns the signer's hex public key on success, null on missing/invalid
+ * signature or any error (fail closed). This proves key possession only - it
+ * does NOT bind the key to a member. Use `resolveVerifiedSpaceSender` for
+ * authorization decisions; the bare form exists for update-profile, where the
+ * message IS a key-rotation announcement so a member binding can't be required.
+ */
+export async function verifySpaceMessageSignature(
+  message: Message,
+  spaceId: string
+): Promise<string | null> {
+  try {
+    const { publicKey, signature, nonce, messageId } = message;
+    const senderId = (message.content as { senderId?: string })?.senderId;
+    if (!publicKey || !signature || !nonce || !messageId || !senderId) {
+      return null;
+    }
+
+    const fingerprint = buildMessageFingerprint({
+      nonce,
+      content: message.content as Parameters<
+        typeof buildMessageFingerprint
+      >[0]['content'],
+      senderId,
+      spaceId,
+      channelId: message.channelId ?? '',
+    });
+    const hashBytes = sha256(new TextEncoder().encode(fingerprint));
+
+    // The wire messageId must equal the fingerprint hash - otherwise the
+    // signature (over the hash) attests different content/scope than claimed.
+    if (bytesToHex(hashBytes) !== messageId) {
+      return null;
+    }
+
+    const signingProvider = new NativeSigningProvider();
+    const isValid = await signingProvider.verifyEd448(
+      bytesToBase64(Uint8Array.from(hexToBytes(publicKey))),
+      bytesToBase64(hashBytes),
+      bytesToBase64(Uint8Array.from(hexToBytes(signature)))
+    );
+    return isValid ? publicKey : null;
+  } catch {
+    // canonicalize throws on unknown content types; malformed hex throws in
+    // conversion. All failures are a verification failure - fail closed.
+    return null;
+  }
+}
+
+/**
+ * Resolve the cryptographically verified sender of a space message: signature
+ * verification + reverse key-to-member lookup. Null on any failure (unsigned,
+ * invalid signature, key matches no active member) - callers fail closed.
+ *
+ * `content.senderId` plays no role here beyond being bound inside the signed
+ * fingerprint; it remains display metadata only.
+ */
+export async function resolveVerifiedSpaceSender(
+  message: Message,
+  spaceId: string
+): Promise<VerifiedSender | null> {
+  const publicKey = await verifySpaceMessageSignature(message, spaceId);
+  if (!publicKey) return null;
+  const members = await getMMKVAdapter().getSpaceMembers(spaceId);
+  return resolveVerifiedSender(publicKey, members);
+}
+
+/**
+ * The single allow/drop verdict for a space control message (remove-message /
+ * edit-message / mute; pin when mobile grows a pin handler). Resolves the
+ * verified sender, then delegates to shared `authorizeControlMessage`, which
+ * requires the signature regardless of `space.isRepudiable` (with the one
+ * documented exception: an unsigned edit of an unsigned message in a
+ * repudiable space, claimed by the target's author).
+ */
+export async function authorizeSpaceControlMessage(params: {
+  message: Message;
+  spaceId: string;
+  space: Space | undefined;
+  channel: Channel | undefined;
+  targetMessage?: Message;
+}): Promise<ControlMessageVerdict> {
+  const { message, spaceId, space, channel, targetMessage } = params;
+  const contentType = message.content?.type;
+  if (!contentType || !isControlMessageType(contentType)) {
+    return { allowed: false, reason: 'unknown-control-type' };
+  }
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
+  return authorizeControlMessage({
+    content: message.content as ControlMessageContent,
+    verifiedSender,
+    space,
+    channel,
+    targetMessage,
+  });
+}
+
+/**
+ * Read-only channel post acceptance: a post/embed/sticker lands in a read-only
+ * channel only when its VERIFIED signer is a manager of that channel. Unsigned
+ * or unverifiable posts are dropped - posting into a read-only channel is a
+ * privileged operation, so the signature is required regardless of
+ * repudiability (parity with desktop's isReadOnlyPostAuthorized, live path).
+ */
+export async function isReadOnlyPostAuthorized(
+  message: Message,
+  spaceId: string,
+  space: Space | undefined,
+  channel: Channel | undefined
+): Promise<boolean> {
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
+  if (!verifiedSender) return false;
+  return canManageReadOnlyChannel(verifiedSender, false, space, channel);
+}
+
+/**
+ * Whether an incoming message's `mentions.everyone` flag must be stripped
+ * before the message is stored/logged. True (strip) unless the message's
+ * verified signer exists AND matches the claimed `content.senderId`.
+ *
+ * `mentions` is not covered by the signed fingerprint, so the signature can't
+ * attest the flag itself - but the threat is the SENDER's modified client
+ * setting the flag, and the sender is the signer. Anchoring senderId to the
+ * verified key makes the existing downstream role gate sound
+ * (`isMentionedWithSettings` already requires `senderId` to hold
+ * `mention:everyone`; the missing piece was that senderId was spoofable).
+ * @everyone-bearing posts are verified regardless of repudiability - an
+ * unsigned post keeps its text but loses the space-wide notification.
+ */
+export async function shouldStripEveryoneMention(
+  message: Message,
+  spaceId: string
+): Promise<boolean> {
+  if (message.mentions?.everyone !== true) return false;
+  const senderId = (message.content as { senderId?: string })?.senderId;
+  if (!senderId) return true;
+  const verifiedSender = await resolveVerifiedSpaceSender(message, spaceId);
+  return verifiedSender !== senderId;
+}

--- a/services/space/spaceMessageService.ts
+++ b/services/space/spaceMessageService.ts
@@ -15,11 +15,11 @@
 
 import { sha256 } from '@noble/hashes/sha2.js';
 import {
+  buildMessageFingerprint,
   bytesToHex,
   hexToBytes,
   extractMentionsFromText,
   type EditMessage,
-  type EmbedMessage,
   type Mentions,
   type Message,
   type MessageContent,
@@ -29,7 +29,6 @@ import {
   type RemoveMessage,
   type RemoveReactionMessage,
   type StickerMessage,
-  type UpdateProfileMessage,
   type SpaceCallStartMessage,
   type SpaceCallEndMessage,
   // New sync types
@@ -141,117 +140,29 @@ function generateNonce(): string {
 }
 
 /**
- * Canonicalize message content for hashing (matches desktop canonicalize function)
- * For 'post' type: returns the text
- * For 'sticker' type: returns type + stickerId
- * For 'embed' type: returns type + dimensions + urls
- * For 'reaction' type: returns type + messageId + reaction
- * etc.
- */
-function canonicalizeContent(content: MessageContent): string {
-  if (content.type === 'post') {
-    const postContent = content as PostMessage;
-    if (Array.isArray(postContent.text)) {
-      return postContent.text.join('');
-    }
-    return postContent.text ?? '';
-  }
-
-  if (content.type === 'sticker') {
-    const stickerContent = content as StickerMessage;
-    return content.type + stickerContent.stickerId + (stickerContent.repliesToMessageId ?? '');
-  }
-
-  if (content.type === 'embed') {
-    const embedContent = content as EmbedMessage;
-    return (
-      content.type +
-      (embedContent.width ?? '') +
-      (embedContent.height ?? '') +
-      (embedContent.imageUrl ?? '') +
-      (embedContent.repliesToMessageId ?? '') +
-      (embedContent.videoUrl ?? '')
-    );
-  }
-
-  if (content.type === 'reaction') {
-    const reactionContent = content as ReactionMessage;
-    return content.type + reactionContent.messageId + reactionContent.reaction;
-  }
-
-  if (content.type === 'remove-reaction') {
-    const removeReactionContent = content as RemoveReactionMessage;
-    return content.type + removeReactionContent.messageId + removeReactionContent.reaction;
-  }
-
-  if (content.type === 'remove-message') {
-    const removeContent = content as RemoveMessage;
-    return content.type + removeContent.removeMessageId;
-  }
-
-  // Mute (moderation). MUST match shared canonicalize() byte-for-byte
-  // (quorum-shared/src/utils/canonicalize.ts 'mute' branch) so a mute signed on
-  // mobile verifies on desktop and vice-versa.
-  if (content.type === 'mute') {
-    const muteContent = content as MuteMessage;
-    return (
-      content.type +
-      muteContent.targetUserId +
-      muteContent.muteId +
-      muteContent.timestamp +
-      muteContent.action +
-      (muteContent.duration ?? '')
-    );
-  }
-
-  if (content.type === 'edit-message') {
-    const editContent = content as EditMessage;
-    const editedText = Array.isArray(editContent.editedText)
-      ? editContent.editedText.join('')
-      : editContent.editedText;
-    return content.type + editContent.originalMessageId + editedText + editContent.editNonce;
-  }
-
-  if (content.type === 'space-call-start') {
-    const c = content as SpaceCallStartMessage;
-    return content.type + c.callId + c.mediaType;
-  }
-
-  if (content.type === 'space-call-end') {
-    const c = content as SpaceCallEndMessage;
-    return content.type + c.callId;
-  }
-
-  // update-profile. MUST match shared canonicalize() byte-for-byte
-  // (quorum-shared 'update-profile' branch: type + displayName + userIcon, raw
-  // concatenation with NO ?? '' fallback) so a profile update signed on mobile
-  // verifies on desktop. When a field is omitted on the wire, JS concatenates
-  // the literal string "undefined" — shared does the same, so do NOT add a
-  // fallback here. bio/farcaster fields are intentionally excluded from the hash
-  // on both sides; matching shared is the requirement, not covering more fields.
-  if (content.type === 'update-profile') {
-    const updateProfileContent = content as UpdateProfileMessage;
-    return content.type + updateProfileContent.displayName + updateProfileContent.userIcon;
-  }
-
-  // Default: stringify the content
-  return JSON.stringify(content);
-}
-
-/**
- * Generate message ID hash from content (matches desktop implementation)
- * Hash input: nonce + 'post' + senderAddress + canonicalizedContent
- * Returns both the hex messageId and the raw hash bytes for signing
+ * Generate message ID hash from content via the shared canonical fingerprint
+ * (`buildMessageFingerprint`), which both platforms use for signing AND
+ * receive-side verification - a locally-built fingerprint that diverges by
+ * even one byte makes honest signatures verify as forgeries on the other
+ * platform. Control types scope-bind spaceId+channelId (replay protection);
+ * post/embed/sticker keep the legacy format so existing messageIds are stable.
+ * Returns both the hex messageId and the raw hash bytes for signing.
  */
 function generateMessageIdHash(
   nonce: string,
   senderAddress: string,
-  content: MessageContent
+  content: MessageContent,
+  spaceId: string,
+  channelId: string
 ): { messageId: string; messageIdBytes: Uint8Array } {
-  const canonicalContent = canonicalizeContent(content);
-  const input = nonce + content.type + senderAddress + canonicalContent;
-  const inputBytes = new TextEncoder().encode(input);
-  const hashBytes = sha256(inputBytes);
+  const fingerprint = buildMessageFingerprint({
+    nonce,
+    content: content as Parameters<typeof buildMessageFingerprint>[0]['content'],
+    senderId: senderAddress,
+    spaceId,
+    channelId,
+  });
+  const hashBytes = sha256(new TextEncoder().encode(fingerprint));
   const messageId = bytesToHex(hashBytes);
   return { messageId, messageIdBytes: hashBytes };
 }
@@ -311,8 +222,7 @@ export async function sendSpaceMessage(
   };
 
   // 4. Generate message ID using SHA-256 hash (matches desktop implementation)
-  // Hash input: nonce + 'post' + senderAddress + text
-  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, messageContent);
+  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, messageContent, spaceId, channelId);
 
   // 5. Build full message object
   const message: Message = {
@@ -430,7 +340,7 @@ export async function sendStickerMessage(
   };
 
   // 4. Generate message ID using SHA-256 hash (matches desktop implementation)
-  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, messageContent);
+  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, messageContent, spaceId, channelId);
 
   // 5. Build full message object
   const message: Message = {
@@ -665,7 +575,7 @@ async function sendGenericMessage(
   }
 
   // Generate message ID using SHA-256 hash (matches desktop implementation)
-  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, content);
+  const { messageId, messageIdBytes } = generateMessageIdHash(nonce, senderAddress, content, spaceId, channelId);
 
   // Build full message object
   const message: Message = {
@@ -794,6 +704,13 @@ export interface SendEditMessageParams {
   spaceChannels?: Array<{ channelId: string; channelName: string }>;
   /** Sender may use @everyone (has mention:everyone) — gates @everyone in edits. */
   allowEveryone?: boolean;
+  /**
+   * Edit inherit rule: `!shouldSignEdit(original)` — an edit inherits the
+   * signed/unsigned state of the message it edits, so a deliberately-unsigned
+   * (deniable) message never silently gains a signature that would both
+   * badge it as signed and leak linkage to the original content hash.
+   */
+  skipSigning?: boolean;
 }
 
 /**
@@ -802,7 +719,7 @@ export interface SendEditMessageParams {
 export async function sendEditMessage(
   params: SendEditMessageParams
 ): Promise<SendGenericMessageResult> {
-  const { spaceId, channelId, originalMessageId, editedText, senderAddress, spaceRoles, spaceChannels, allowEveryone } = params;
+  const { spaceId, channelId, originalMessageId, editedText, senderAddress, spaceRoles, spaceChannels, allowEveryone, skipSigning } = params;
 
   const editedAt = Date.now();
   const editNonce = generateNonce();
@@ -822,6 +739,7 @@ export async function sendEditMessage(
     senderAddress,
     content,
     mentions: extractMentionsFromText(editedText, { spaceRoles, spaceChannels, allowEveryone }),
+    skipSigning,
   });
 }
 


### PR DESCRIPTION
## Summary

Space control messages (delete, edit, mute), read-only channel posts, profile updates, and @everyone mentions were authorized on receive using the plaintext `content.senderId`, which a modified client can set to any member. This PR makes the receive side authorize against the cryptographically verified signer instead: ed448 signature over the shared canonical fingerprint, then reverse key-to-member lookup that fails closed on missing or kicked members. Mirrors the desktop implementation (quorum-desktop #241/#242) using the shared primitives from `@quilibrium/quorum-shared@2.1.0-35`, so both platforms produce and verify identical signatures.

## Changes

- New `services/space/spaceMessageAuth.ts`: fingerprint verification, verified-sender resolution, and authorization wrappers around the shared `authorizeControlMessage` verdict
- Both receive paths (live + batch catch-up) enforce identically for edit-message, remove-message, mute, read-only posts, update-profile, and @everyone
- Space edit-message receive previously applied edits with no sender check at all; it now requires the verified author
- Send side adopts the shared `buildMessageFingerprint` (scope-binds spaceId/channelId for control types) so signatures verify cross-platform
- Edits inherit the original message's signed/unsigned state; an applied signed edit updates the stored signature so the signed badge attests the displayed text
- Read-only channels force-sign sends and hide the signing toggle so managers' posts pass receive-side verification
- update-profile requires a valid signature plus a known-key binding (a key registered to a member may only speak for that member; unknown keys accepted as rotation announcements), and never writes the announced key onto the member row
- Batch catch-up loads the member list once per space group instead of re-parsing it per message

## Commits

- a2f901f fix: authorize space control messages via verified signature, not payload senderId
- 585462a fix: harden update-profile auth and batch verification performance