### PR TITLE
feat: DM delivery and read receipts

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -15,7 +15,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { queryKeys } from '@quilibrium/quorum-shared';
 import type { Conversation } from '@quilibrium/quorum-shared';
 import { useUserPublicProfile } from '@/hooks/useUserPublicProfile';
-import { useBookmarks } from '@/hooks/useUserConfig';
+import { useBookmarks, useReceiptSettings } from '@/hooks/useUserConfig';
 import { useCall } from '@/context';
 import { useMiniappOverlay } from '@/context/MiniappOverlayContext';
 import { truncateAddress } from '@/utils/formatAddress';
@@ -246,6 +246,25 @@ export default function DMChatScreen() {
     [updateConversationSetting]
   );
 
+  // Per-conversation DM receipt override (stored on the local Conversation, like
+  // desktop; effective value = override ?? global). Cross-device sync is the
+  // unified conversation-settings task (2026-07-20). Delivery-off cascades read-off.
+  const { deliveryReceipts: globalDeliveryReceipts, readReceipts: globalReadReceipts } =
+    useReceiptSettings();
+  const handleSetDeliveryReceipts = useCallback(
+    (value: boolean) =>
+      updateConversationSetting(value ? { deliveryReceipts: true } : { deliveryReceipts: false, readReceipts: false }),
+    [updateConversationSetting]
+  );
+  const handleSetReadReceipts = useCallback(
+    (value: boolean) => updateConversationSetting({ readReceipts: value }),
+    [updateConversationSetting]
+  );
+  const handleResetReceipts = useCallback(
+    () => updateConversationSetting({ deliveryReceipts: undefined, readReceipts: undefined }),
+    [updateConversationSetting]
+  );
+
   // Delete this conversation. Like desktop, we FIRST signal the counterparty
   // (a `delete-conversation` control message) so they reset their encryption
   // session and the next message cleanly re-handshakes — they do NOT delete
@@ -457,6 +476,13 @@ export default function DMChatScreen() {
             onToggleEditHistory={handleToggleEditHistory}
             isMuted={conversationMuted}
             onToggleMute={handleToggleMute}
+            deliveryReceipts={conversation.deliveryReceipts}
+            readReceipts={conversation.readReceipts}
+            globalDeliveryReceipts={globalDeliveryReceipts}
+            globalReadReceipts={globalReadReceipts}
+            onSetDeliveryReceipts={handleSetDeliveryReceipts}
+            onSetReadReceipts={handleSetReadReceipts}
+            onResetReceipts={handleResetReceipts}
           />
         </Suspense>
       )}

--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -260,8 +260,14 @@ export default function DMChatScreen() {
     (value: boolean) => updateConversationSetting({ readReceipts: value }),
     [updateConversationSetting]
   );
-  const handleResetReceipts = useCallback(
+  // Reset delivery override also clears read (read inherits when delivery does),
+  // matching desktop; reset read clears read only.
+  const handleResetDelivery = useCallback(
     () => updateConversationSetting({ deliveryReceipts: undefined, readReceipts: undefined }),
+    [updateConversationSetting]
+  );
+  const handleResetRead = useCallback(
+    () => updateConversationSetting({ readReceipts: undefined }),
     [updateConversationSetting]
   );
 
@@ -482,7 +488,8 @@ export default function DMChatScreen() {
             globalReadReceipts={globalReadReceipts}
             onSetDeliveryReceipts={handleSetDeliveryReceipts}
             onSetReadReceipts={handleSetReadReceipts}
-            onResetReceipts={handleResetReceipts}
+            onResetDelivery={handleResetDelivery}
+            onResetRead={handleResetRead}
           />
         </Suspense>
       )}

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -29,8 +29,9 @@ import type {
   MessageUserInfo,
 } from '@/components/Chat';
 
-import { useAuth } from '@/context';
+import { useAuth, useWebSocket } from '@/context';
 import { useToast } from '@/context/ToastContext';
+import { useIsFocused } from '@react-navigation/native';
 import { flattenMessages, useMessages } from '@/hooks/chat/useMessages';
 import { useMembersWithPublicProfileFallback } from '@/hooks/useMembersWithPublicProfileFallback';
 import { useSendDirectMessage } from '@/hooks/chat/useSendDirectMessage';
@@ -180,6 +181,22 @@ export const DMChatArea = React.memo(function DMChatArea({
   }, [dmMessagesPages, effectiveDmMemberMap, user?.address]);
 
   const dmSearch = useMessageSearch(dmMessages);
+
+  // Read receipts: while this DM is on screen, mark the partner's newest message
+  // read. The ReceiptService dedups via a high-water mark and flushes a read-ack
+  // (5s). notifyDmRead is a no-op when the read-receipts setting is off.
+  const { notifyDmRead } = useWebSocket();
+  const isFocused = useIsFocused();
+  useEffect(() => {
+    if (!isFocused || !recipientAddress || !dmMessagesPages) return;
+    let newest: Message | undefined;
+    for (const m of flattenMessages(dmMessagesPages.pages)) {
+      if (m.content?.senderId && m.content.senderId !== user?.address) {
+        if (!newest || m.createdDate > newest.createdDate) newest = m;
+      }
+    }
+    if (newest) notifyDmRead(recipientAddress, newest.messageId, newest.createdDate);
+  }, [isFocused, recipientAddress, dmMessagesPages, user?.address, notifyDmRead]);
 
   // Draft management
   const prevConversationIdRef = useRef(conversationId);

--- a/components/Chat/DMChatArea.tsx
+++ b/components/Chat/DMChatArea.tsx
@@ -187,15 +187,22 @@ export const DMChatArea = React.memo(function DMChatArea({
   // (5s). notifyDmRead is a no-op when the read-receipts setting is off.
   const { notifyDmRead } = useWebSocket();
   const isFocused = useIsFocused();
+  // Skip re-marking the same message on every cache-driven re-render (the effect
+  // re-runs whenever dmMessagesPages changes reference, incl. our own readAt patch).
+  const lastMarkedReadRef = useRef<string | null>(null);
   useEffect(() => {
-    if (!isFocused || !recipientAddress || !dmMessagesPages) return;
+    if (!isFocused) { lastMarkedReadRef.current = null; return; }
+    if (!recipientAddress || !dmMessagesPages) return;
     let newest: Message | undefined;
     for (const m of flattenMessages(dmMessagesPages.pages)) {
       if (m.content?.senderId && m.content.senderId !== user?.address) {
         if (!newest || m.createdDate > newest.createdDate) newest = m;
       }
     }
-    if (newest) notifyDmRead(recipientAddress, newest.messageId, newest.createdDate);
+    if (newest && lastMarkedReadRef.current !== newest.messageId) {
+      lastMarkedReadRef.current = newest.messageId;
+      notifyDmRead(recipientAddress, newest.messageId, newest.createdDate);
+    }
   }, [isFocused, recipientAddress, dmMessagesPages, user?.address, notifyDmRead]);
 
   // Draft management

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -33,6 +33,17 @@ interface DMSettingsSheetProps {
   onToggleEditHistory?: (value: boolean) => void;
   isMuted?: boolean;
   onToggleMute?: (value: boolean) => void;
+  /** Per-conversation DM receipt override. Raw values are the override
+   *  (undefined = inherit global); the effective display value is
+   *  `override ?? global`. Local to this device for now — cross-device sync is
+   *  the unified conversation-settings task (2026-07-20). */
+  deliveryReceipts?: boolean;
+  readReceipts?: boolean;
+  globalDeliveryReceipts?: boolean;
+  globalReadReceipts?: boolean;
+  onSetDeliveryReceipts?: (value: boolean) => void;
+  onSetReadReceipts?: (value: boolean) => void;
+  onResetReceipts?: () => void;
 }
 
 export function DMSettingsSheet({
@@ -50,8 +61,21 @@ export function DMSettingsSheet({
   onToggleEditHistory,
   isMuted,
   onToggleMute,
+  deliveryReceipts,
+  readReceipts,
+  globalDeliveryReceipts = false,
+  globalReadReceipts = false,
+  onSetDeliveryReceipts,
+  onSetReadReceipts,
+  onResetReceipts,
 }: DMSettingsSheetProps) {
   const styles = createStyles(theme);
+  // Effective receipt display = per-conversation override ?? global.
+  const effectiveDelivery = deliveryReceipts ?? globalDeliveryReceipts;
+  const effectiveRead = readReceipts ?? globalReadReceipts;
+  const deliveryOverridden = deliveryReceipts !== undefined;
+  const readOverridden = readReceipts !== undefined;
+  const receiptsOverridden = deliveryOverridden || readOverridden;
   const { confirm, confirmDialog } = useConfirmDialog();
   // While a confirm dialog is open on top of this sheet, swallow the sheet's own
   // back/backdrop dismissal so an Android back cancels the confirm rather than
@@ -135,6 +159,50 @@ export function DMSettingsSheet({
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
                 />
               }
+            />
+          )}
+          {onSetDeliveryReceipts && (
+            <ActionRow
+              icon="checkmark"
+              label="Delivery receipts"
+              sublabel={
+                deliveryOverridden
+                  ? 'This conversation overrides your global setting. Tap "Reset to global" to use your global preference.'
+                  : 'Uses your global setting. Toggle to override for this conversation only.'
+              }
+              trailing={
+                <Switch
+                  value={effectiveDelivery}
+                  onValueChange={onSetDeliveryReceipts}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                />
+              }
+            />
+          )}
+          {onSetReadReceipts && effectiveDelivery && (
+            <ActionRow
+              icon="checkmark.circle"
+              label="Read receipts"
+              sublabel={
+                readOverridden
+                  ? 'This conversation overrides your global setting. Tap "Reset to global" to use your global preference.'
+                  : 'Uses your global setting. Toggle to override for this conversation only.'
+              }
+              trailing={
+                <Switch
+                  value={effectiveRead}
+                  onValueChange={onSetReadReceipts}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                />
+              }
+            />
+          )}
+          {onResetReceipts && receiptsOverridden && (
+            <ActionRow
+              icon="arrow.counterclockwise"
+              label="Reset to global"
+              sublabel="Use your global receipt settings for this conversation"
+              onPress={onResetReceipts}
             />
           )}
           {onToggleRepudiable && (

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -87,7 +87,14 @@ export function DMSettingsSheet({
     overridden ? (
       <>
         This conversation overrides your global setting. Tap{' '}
-        <Text style={styles.resetLink} onPress={onReset}>Reset to global</Text>
+        <Text
+          style={styles.resetLink}
+          onPress={onReset}
+          suppressHighlighting={false}
+          accessibilityRole="link"
+        >
+          Reset to global
+        </Text>
         {' '}to use your global preference.
       </>
     ) : (
@@ -137,7 +144,7 @@ export function DMSettingsSheet({
   };
 
   return (
-    <BaseModal visible={visible} onClose={guardedClose} showHandle>
+    <BaseModal visible={visible} onClose={guardedClose} showHandle scrollable>
       <View style={styles.container}>
         <View style={styles.header}>
           {address != null && (
@@ -204,6 +211,7 @@ export function DMSettingsSheet({
                   value={effectiveDelivery}
                   onValueChange={onSetDeliveryReceipts}
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  thumbColor="#fff"
                 />
               }
             />
@@ -218,6 +226,7 @@ export function DMSettingsSheet({
                   value={effectiveRead}
                   onValueChange={onSetReadReceipts}
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  thumbColor="#fff"
                 />
               }
             />

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -43,7 +43,10 @@ interface DMSettingsSheetProps {
   globalReadReceipts?: boolean;
   onSetDeliveryReceipts?: (value: boolean) => void;
   onSetReadReceipts?: (value: boolean) => void;
-  onResetReceipts?: () => void;
+  /** Reset delivery override (cascades read, like desktop). */
+  onResetDelivery?: () => void;
+  /** Reset read override only. */
+  onResetRead?: () => void;
 }
 
 export function DMSettingsSheet({
@@ -67,7 +70,8 @@ export function DMSettingsSheet({
   globalReadReceipts = false,
   onSetDeliveryReceipts,
   onSetReadReceipts,
-  onResetReceipts,
+  onResetDelivery,
+  onResetRead,
 }: DMSettingsSheetProps) {
   const styles = createStyles(theme);
   // Effective receipt display = per-conversation override ?? global.
@@ -75,7 +79,20 @@ export function DMSettingsSheet({
   const effectiveRead = readReceipts ?? globalReadReceipts;
   const deliveryOverridden = deliveryReceipts !== undefined;
   const readOverridden = readReceipts !== undefined;
-  const receiptsOverridden = deliveryOverridden || readOverridden;
+
+  // Receipt row description = desktop's exact tooltip copy. When the field is
+  // overridden, "Reset to global" is an inline tappable link (desktop parity;
+  // "Click" -> "Tap" for touch), replacing the old separate reset row.
+  const receiptSublabel = (overridden: boolean, onReset?: () => void) =>
+    overridden ? (
+      <>
+        This conversation overrides your global setting. Tap{' '}
+        <Text style={styles.resetLink} onPress={onReset}>Reset to global</Text>
+        {' '}to use your global preference.
+      </>
+    ) : (
+      'Uses your global setting. Toggle to override for this conversation only.'
+    );
   const { confirm, confirmDialog } = useConfirmDialog();
   // While a confirm dialog is open on top of this sheet, swallow the sheet's own
   // back/backdrop dismissal so an Android back cancels the confirm rather than
@@ -148,6 +165,22 @@ export function DMSettingsSheet({
             dividers between rows and drops the last one; no arbitrary
             sub-grouping. */}
         <ActionRowGroup style={styles.group}>
+          {onToggleRepudiable && (
+            <ActionRow
+              icon="lock"
+              label="Always sign messages"
+              sublabel="Proves messages come from your key"
+              trailing={
+                <Switch
+                  // ON ⇔ signed ⇔ isRepudiable false. Default ON.
+                  value={!(isRepudiable ?? false)}
+                  onValueChange={(signOn) => onToggleRepudiable(!signOn)}
+                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
+                  thumbColor="#fff"
+                />
+              }
+            />
+          )}
           {onToggleMute && (
             <ActionRow
               icon="bell.slash"
@@ -165,11 +198,7 @@ export function DMSettingsSheet({
             <ActionRow
               icon="checkmark"
               label="Delivery receipts"
-              sublabel={
-                deliveryOverridden
-                  ? 'This conversation overrides your global setting. Tap "Reset to global" to use your global preference.'
-                  : 'Uses your global setting. Toggle to override for this conversation only.'
-              }
+              sublabel={receiptSublabel(deliveryOverridden, onResetDelivery)}
               trailing={
                 <Switch
                   value={effectiveDelivery}
@@ -183,40 +212,12 @@ export function DMSettingsSheet({
             <ActionRow
               icon="checkmark.circle"
               label="Read receipts"
-              sublabel={
-                readOverridden
-                  ? 'This conversation overrides your global setting. Tap "Reset to global" to use your global preference.'
-                  : 'Uses your global setting. Toggle to override for this conversation only.'
-              }
+              sublabel={receiptSublabel(readOverridden, onResetRead)}
               trailing={
                 <Switch
                   value={effectiveRead}
                   onValueChange={onSetReadReceipts}
                   trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                />
-              }
-            />
-          )}
-          {onResetReceipts && receiptsOverridden && (
-            <ActionRow
-              icon="arrow.counterclockwise"
-              label="Reset to global"
-              sublabel="Use your global receipt settings for this conversation"
-              onPress={onResetReceipts}
-            />
-          )}
-          {onToggleRepudiable && (
-            <ActionRow
-              icon="lock.fill"
-              label="Always sign messages"
-              sublabel="Proves messages come from your key"
-              trailing={
-                <Switch
-                  // ON ⇔ signed ⇔ isRepudiable false. Default ON.
-                  value={!(isRepudiable ?? false)}
-                  onValueChange={(signOn) => onToggleRepudiable(!signOn)}
-                  trackColor={{ false: theme.colors.surface5, true: theme.colors.primary }}
-                  thumbColor="#fff"
                 />
               }
             />
@@ -262,6 +263,11 @@ const createStyles = (theme: AppTheme) =>
       paddingHorizontal: Skin.space(12),
       paddingTop: Skin.space(12),
       paddingBottom: Skin.space(8),
+    },
+    // Inline "Reset to global" link inside a receipt row's description.
+    resetLink: {
+      color: theme.colors.primary,
+      fontWeight: '600',
     },
     header: {
       alignItems: 'center',

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -790,6 +790,23 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     [styles, theme, renderUnsignedWarning]
   );
 
+  // DM delivery/read receipt tick on own messages (✓ delivered / ✓✓ read). A
+  // text glyph so it flows inline natively (IconSymbol SVGs can't sit in a
+  // <Text>). Display is unconditional — the master switch gates persistence.
+  const renderReceipt = useCallback(
+    (item: DisplayMessage) => {
+      if (!isDM || item.userId !== currentUserId) return null;
+      if (!item.deliveredAt && !item.readAt) return null;
+      const read = !!item.readAt;
+      return (
+        <Text style={[styles.receiptIndicator, read && styles.receiptIndicatorRead]}>
+          {read ? '✓✓' : '✓'}
+        </Text>
+      );
+    },
+    [isDM, currentUserId, styles]
+  );
+
   const renderReactions = useCallback(
     (reactions: DisplayReaction[], messageId: string) => {
       if (!reactions || reactions.length === 0) return null;
@@ -1182,6 +1199,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                   onLinkPress={onLinkPress}
                 />
               ) : null}
+              {renderReceipt(item)}
               {/* Per-message indicators on grouped continuation rows (header hidden) */}
               {isCompact && renderCompactIndicators(item, { isSending })}
               {/* Render invite link card if detected */}
@@ -1222,7 +1240,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         </Pressable>
       );
     },
-    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, renderUnsignedWarning, renderCompactIndicators, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress, compactMessageIds]
+    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, renderUnsignedWarning, renderCompactIndicators, renderReceipt, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress, compactMessageIds]
   );
 
   const renderCast = useCallback(
@@ -1623,6 +1641,17 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontSize: Skin.font(11),
     fontFamily: theme.fonts.regular.fontFamily,
     marginLeft: Skin.space(6),
+  },
+  // DM receipt tick — trailing, bottom-right of own message content.
+  receiptIndicator: {
+    alignSelf: 'flex-end',
+    color: theme.colors.textSubtle,
+    fontSize: Skin.font(11),
+    fontFamily: theme.fonts.regular.fontFamily,
+    marginTop: Skin.space(2),
+  },
+  receiptIndicatorRead: {
+    color: theme.colors.primary,
   },
   // Row below a compact continuation message holding its per-message indicators
   // ((edited) + unsigned + sending), since the header is hidden when grouped.

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -798,9 +798,14 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
       if (!isDM || item.userId !== currentUserId) return null;
       if (!item.deliveredAt && !item.readAt) return null;
       const read = !!item.readAt;
+      // U+FE0E forces text (not emoji) presentation of the check glyph on iOS.
+      const tick = read ? '✓︎✓︎' : '✓︎';
       return (
-        <Text style={[styles.receiptIndicator, read && styles.receiptIndicatorRead]}>
-          {read ? '✓✓' : '✓'}
+        <Text
+          style={[styles.receiptIndicator, read && styles.receiptIndicatorRead]}
+          accessibilityLabel={read ? 'Read' : 'Delivered'}
+        >
+          {tick}
         </Text>
       );
     },

--- a/components/Chat/types.ts
+++ b/components/Chat/types.ts
@@ -121,6 +121,9 @@ export interface DisplayMessage {
   stickerId?: string;
   // Reactions on this message
   reactions?: DisplayReaction[];
+  // DM receipt state (own DM messages only) — drives the inline ✓ / ✓✓
+  deliveredAt?: number;
+  readAt?: number;
   // Edit info
   isEdited?: boolean;
   editedAt?: number;
@@ -400,6 +403,8 @@ export function toDisplayMessage(
     content: getMessageText(message, memberName),
     sendStatus: message.sendStatus,
     sendError: message.sendError,
+    deliveredAt: message.deliveredAt,
+    readAt: message.readAt,
     originalMessage: message,
     renderType,
     errorDetail,

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -34,7 +34,7 @@ import {
   useValidateInviteCode,
 } from '@/hooks/useQNS';
 import { useWarpcastWallet } from '@/hooks/useWarpcastWallet';
-import { useSyncSettings } from '@/hooks/useUserConfig';
+import { useSyncSettings, useReceiptSettings } from '@/hooks/useUserConfig';
 import { useOtaUpdate } from '@/hooks/useOtaUpdate';
 import { getQuorumClient, type DeviceRegistration } from '@/services/api/quorumClient';
 import {
@@ -364,6 +364,13 @@ export default function ProfileModal({
   const { enqueueOutbound, subscribe } = useWebSocket();
   const { showToast } = useToast();
   const { allowSync, setAllowSync, isLoading: isSyncLoading } = useSyncSettings();
+  const {
+    deliveryReceipts,
+    readReceipts,
+    setDeliveryReceipts,
+    setReadReceipts,
+    isLoading: isReceiptsLoading,
+  } = useReceiptSettings();
   const queryClient = useQueryClient();
   const insets = useSafeAreaInsets();
   const [internalTab, setInternalTab] = React.useState<ProfileSection>('profile');
@@ -793,6 +800,29 @@ export default function ProfileModal({
       setIsSyncToggling(false);
     }
   }, [setAllowSync]);
+
+  // DM receipt toggles. Persisted + synced cross-device via the config blob.
+  const [isReceiptsToggling, setIsReceiptsToggling] = React.useState(false);
+  const handleToggleDeliveryReceipts = React.useCallback(async (enabled: boolean) => {
+    setIsReceiptsToggling(true);
+    try {
+      await setDeliveryReceipts(enabled);
+    } catch {
+      Alert.alert('Error', 'Failed to update delivery receipts. Please try again.');
+    } finally {
+      setIsReceiptsToggling(false);
+    }
+  }, [setDeliveryReceipts]);
+  const handleToggleReadReceipts = React.useCallback(async (enabled: boolean) => {
+    setIsReceiptsToggling(true);
+    try {
+      await setReadReceipts(enabled);
+    } catch {
+      Alert.alert('Error', 'Failed to update read receipts. Please try again.');
+    } finally {
+      setIsReceiptsToggling(false);
+    }
+  }, [setReadReceipts]);
 
   const handleResetAppData = async () => {
     setShowResetConfirm(false);
@@ -2198,6 +2228,11 @@ export default function ProfileModal({
               allowSync={allowSync}
               onToggleSync={handleToggleSync}
               syncDisabled={isSyncLoading || isSyncToggling}
+              deliveryReceipts={deliveryReceipts}
+              readReceipts={readReceipts}
+              onToggleDeliveryReceipts={handleToggleDeliveryReceipts}
+              onToggleReadReceipts={handleToggleReadReceipts}
+              receiptsDisabled={isReceiptsLoading || isReceiptsToggling}
               notifications={notifications}
               onToggleNotifications={setNotifications}
               privacyLevel={user?.privacyLevel}
@@ -4141,6 +4176,11 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
   allowSync,
   onToggleSync,
   syncDisabled,
+  deliveryReceipts,
+  readReceipts,
+  onToggleDeliveryReceipts,
+  onToggleReadReceipts,
+  receiptsDisabled,
   notifications,
   onToggleNotifications,
   privacyLevel,
@@ -4152,6 +4192,11 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
   allowSync: boolean;
   onToggleSync: (enabled: boolean) => void;
   syncDisabled: boolean;
+  deliveryReceipts: boolean;
+  readReceipts: boolean;
+  onToggleDeliveryReceipts: (enabled: boolean) => void;
+  onToggleReadReceipts: (enabled: boolean) => void;
+  receiptsDisabled: boolean;
   notifications: boolean;
   onToggleNotifications: (enabled: boolean) => void;
   /** Read-only display of the account's privacy level (moved here from the old
@@ -4190,6 +4235,36 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             disabled={syncDisabled}
             trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
             thumbColor={allowSync ? '#ffffff' : '#f4f3f4'}
+          />
+        </View>
+        <View style={styles.settingRow}>
+          <View style={styles.settingLeft}>
+            <Text style={styles.settingLabel}>Send Delivery Receipts</Text>
+            <Text style={styles.settingDescription}>
+              Let people you DM see a ✓ once their message reaches your device. Off by default.
+            </Text>
+          </View>
+          <Switch
+            value={deliveryReceipts}
+            onValueChange={onToggleDeliveryReceipts}
+            disabled={receiptsDisabled}
+            trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+            thumbColor={deliveryReceipts ? '#ffffff' : '#f4f3f4'}
+          />
+        </View>
+        <View style={styles.settingRow}>
+          <View style={styles.settingLeft}>
+            <Text style={styles.settingLabel}>Send Read Receipts</Text>
+            <Text style={styles.settingDescription}>
+              Let people you DM see ✓✓ once you have read their message. Off by default.
+            </Text>
+          </View>
+          <Switch
+            value={readReceipts}
+            onValueChange={onToggleReadReceipts}
+            disabled={receiptsDisabled}
+            trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+            thumbColor={readReceipts ? '#ffffff' : '#f4f3f4'}
           />
         </View>
         {/* "Show Online Status" toggle removed: there is no presence/online-status

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -807,12 +807,14 @@ export default function ProfileModal({
     setIsReceiptsToggling(true);
     try {
       await setDeliveryReceipts(enabled);
+      // Cascade: turning delivery off also turns read off (matches desktop).
+      if (!enabled) await setReadReceipts(false);
     } catch {
       Alert.alert('Error', 'Failed to update delivery receipts. Please try again.');
     } finally {
       setIsReceiptsToggling(false);
     }
-  }, [setDeliveryReceipts]);
+  }, [setDeliveryReceipts, setReadReceipts]);
   const handleToggleReadReceipts = React.useCallback(async (enabled: boolean) => {
     setIsReceiptsToggling(true);
     try {
@@ -4239,9 +4241,9 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
         </View>
         <View style={styles.settingRow}>
           <View style={styles.settingLeft}>
-            <Text style={styles.settingLabel}>Send Delivery Receipts</Text>
+            <Text style={styles.settingLabel}>Delivery receipts</Text>
             <Text style={styles.settingDescription}>
-              Let people you DM see a ✓ once their message reaches your device. Off by default.
+              When on, senders see when their messages reach your device, and you see when yours reach theirs.
             </Text>
           </View>
           <Switch
@@ -4252,21 +4254,25 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             thumbColor={deliveryReceipts ? '#ffffff' : '#f4f3f4'}
           />
         </View>
-        <View style={styles.settingRow}>
-          <View style={styles.settingLeft}>
-            <Text style={styles.settingLabel}>Send Read Receipts</Text>
-            <Text style={styles.settingDescription}>
-              Let people you DM see ✓✓ once you have read their message. Off by default.
-            </Text>
+        {/* Read receipts only make sense once delivery receipts are on (matches
+            desktop, which hides this row while delivery is off). */}
+        {deliveryReceipts && (
+          <View style={styles.settingRow}>
+            <View style={styles.settingLeft}>
+              <Text style={styles.settingLabel}>Read receipts</Text>
+              <Text style={styles.settingDescription}>
+                When on, senders see when you&apos;ve read their messages, and you see when yours are read.
+              </Text>
+            </View>
+            <Switch
+              value={readReceipts}
+              onValueChange={onToggleReadReceipts}
+              disabled={receiptsDisabled}
+              trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+              thumbColor={readReceipts ? '#ffffff' : '#f4f3f4'}
+            />
           </View>
-          <Switch
-            value={readReceipts}
-            onValueChange={onToggleReadReceipts}
-            disabled={receiptsDisabled}
-            trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
-            thumbColor={readReceipts ? '#ffffff' : '#f4f3f4'}
-          />
-        </View>
+        )}
         {/* "Show Online Status" toggle removed: there is no presence/online-status
             feature behind it, so the control was a non-functional decoration
             (hardcoded on, no handler). Re-add a real toggle here if/when presence

--- a/components/shared/ActionRow.tsx
+++ b/components/shared/ActionRow.tsx
@@ -37,8 +37,8 @@ export interface ActionRowProps {
   onPress?: () => void;
   destructive?: boolean;
   disabled?: boolean;
-  /** Optional secondary line under the label. */
-  sublabel?: string;
+  /** Optional secondary line under the label. A node may embed inline links. */
+  sublabel?: React.ReactNode;
   /** Trailing affordance: a chevron, or any custom node (toggle, send icon…). */
   trailing?: 'chevron' | React.ReactNode;
   /** Success-tinted active state (e.g. selected / recasted). */

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -15,6 +15,7 @@ import {
   logger,
   MAX_MESSAGE_LENGTH,
   queryKeys,
+  ReceiptService,
 } from '@quilibrium/quorum-shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { PERSISTABLE_TYPES, DM_GUARD_PASSTHROUGH_TYPES } from '@/components/Chat/types';
@@ -43,6 +44,7 @@ import type {
   KickMessage,
   Message,
   MuteMessage,
+  ReceiptControlMessage,
   RemoveMessage,
   SealedMessage,
   Space,
@@ -51,6 +53,10 @@ import type {
   WebSocketClient,
   WebSocketConnectionState,
 } from '@quilibrium/quorum-shared';
+import { getLocalUserConfig } from '../services/config/configService';
+import { updateMessageDeliveredAt, updateMessagesReadAt } from '../services/storage/messagesDb';
+import { sendEncryptedMessageToAllDevices } from '../hooks/chat/useSendDirectMessage';
+import { toAllDeviceInfos, type DeviceInfo } from '../hooks/chat/useRecipientRegistration';
 import { getQuorumClient } from '../services/api/quorumClient';
 import { getAllSpaceInboxAddresses, getInboxToSpaceMap, getSpace, getSpaceByHubAddress, getSpaceIds, getSpaceKey, saveSpace, saveSpaceKey } from '../services/config/spaceStorage';
 import { encryptionService } from '../services/crypto/encryption-service';
@@ -101,6 +107,9 @@ interface WebSocketContextValue {
   // Inbox subscriptions
   subscribe: (inboxAddresses: string[]) => Promise<void>;
   unsubscribe: (inboxAddresses: string[]) => Promise<void>;
+
+  // DM read receipts — mark a partner's message read (gated on the read setting)
+  notifyDmRead: (partnerAddress: string, messageId: string, timestamp: number) => void;
 
   // Kick events - space ID that user was kicked from, null when acknowledged
   kickedFromSpaceId: string | null;
@@ -484,6 +493,67 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       );
     }, CONVERSATION_REFRESH_DEBOUNCE_MS);
   }, [queryClient]);
+
+  // ── DM delivery + read receipts (WhatsApp-style ✓ / ✓✓) ──────────────────
+  // One ReceiptService per session buffers acks and flushes them (10s delivery,
+  // 5s read timers + flush on background). Created + wired to the send transport
+  // and cache below, after enqueueOutbound/subscribe are defined.
+  const receiptServiceRef = useRef<ReceiptService | null>(null);
+  const sendDmReceiptAckRef = useRef<((partnerAddress: string, ack: ReceiptControlMessage) => void) | null>(null);
+
+  // Global receipt master switches. Default OFF (matches desktop). Read live
+  // from the local config blob so a settings toggle takes effect immediately.
+  const isReceiptEnabled = useCallback((kind: 'delivery' | 'read'): boolean => {
+    const self = fullUserAddrRef.current;
+    if (!self) return false;
+    const cfg = getLocalUserConfig(self);
+    return kind === 'delivery' ? (cfg?.deliveryReceipts ?? false) : (cfg?.readReceipts ?? false);
+  }, []);
+
+  // Intercept DM receipts on the decrypt path (both receive branches), BEFORE
+  // the self-echo drop. Flat delivery-ack/read-ack (top-level `type`, no
+  // `content`) are processed and reported as handled (never saved). Normal
+  // messages have their piggybacked acks processed + stripped, are buffered for
+  // an outbound delivery ack, and fall through (returns false). `partner` is the
+  // conversation owner (pre self-sync rewrite).
+  const handleDmReceipt = useCallback((decryptedMessage: Message, partner: string): boolean => {
+    const raw = decryptedMessage as any;
+    const svc = receiptServiceRef.current;
+    const self = fullUserAddrRef.current;
+
+    // Only acks the PARTNER sent (about OUR messages) are actionable. Our own
+    // acks (about the partner's messages) fan out to our other devices too — a
+    // self-echoed read-ack would otherwise mark our own sent messages read.
+    if (raw.type === 'delivery-ack') {
+      if (svc && raw.senderId !== self && isReceiptEnabled('delivery')) svc.onAckReceived(raw.messageIds ?? []);
+      return true;
+    }
+    if (raw.type === 'read-ack') {
+      if (svc && raw.senderId !== self && isReceiptEnabled('read') && raw.upToMessageId && raw.upToTimestamp) {
+        svc.onReadAckReceived(raw.upToMessageId, raw.upToTimestamp, partner);
+      }
+      return true;
+    }
+
+    // Piggybacked acks on a normal message — process (only if from the partner,
+    // not our own echo), then strip before persist regardless.
+    if (svc) {
+      const fromPartner = decryptedMessage.content?.senderId !== self;
+      if (fromPartner && raw.ackMessageIds && isReceiptEnabled('delivery')) svc.onAckReceived(raw.ackMessageIds);
+      if (fromPartner && raw.readAckUpTo && isReceiptEnabled('read')) {
+        svc.onReadAckReceived(raw.readAckUpTo.messageId, raw.readAckUpTo.timestamp, partner);
+      }
+      delete raw.ackMessageIds;
+      delete raw.readAckUpTo;
+
+      // Buffer a delivery ack for an inbound post from the partner (flushed via
+      // timer / background / piggyback).
+      if (fromPartner && isReceiptEnabled('delivery') && decryptedMessage.content?.type === 'post') {
+        svc.onMessageReceived(partner, decryptedMessage.messageId);
+      }
+    }
+    return false;
+  }, [isReceiptEnabled]);
 
   // Receive side of DM profile sync. A `dm-update-profile` control message
   // carries a partner's GLOBAL profile change (displayName / userIcon / bio)
@@ -2808,6 +2878,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             return;
           }
 
+          // DM receipts (before the self-echo guard): flat delivery/read-ack are
+          // consumed here and never saved; normal messages buffer + strip acks.
+          if (handleDmReceipt(decryptedMessage, conversationId.split('/')[0])) {
+            getDeviceKeyset().then(dk => {
+              if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+            });
+            return;
+          }
+
           // Handle same-user multi-device sync:
           // When receiving a message from our own address (different device),
           // the conversation should be with the actual recipient (channelId), not ourselves.
@@ -4187,6 +4266,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           continue;
         }
 
+        // DM receipts (before the self-echo guard): flat delivery/read-ack are
+        // consumed here and never saved; normal messages buffer + strip acks.
+        if (handleDmReceipt(decryptedMessage, conversationId.split('/')[0])) {
+          const originalMsg = batch.find(m => m.timestamp === msgResult.timestamp);
+          if (originalMsg) {
+            getDeviceKeyset().then(dk => {
+              if (dk) deleteInboxMessages(originalMsg.inboxAddress, [originalMsg.timestamp], dk).catch(() => {});
+            });
+          }
+          continue;
+        }
+
         // Handle same-user multi-device sync. A true (pre-rewrite) sender === us
         // means our own message echoed from another device; its user_profile is
         // OURS, not the partner's (see the JS path's self-sync guard).
@@ -5054,6 +5145,142 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     inboxAddresses.forEach((addr) => subscribedInboxesRef.current.delete(addr));
   }, []);
 
+  // ── DM receipt transport ──────────────────────────────────────────────────
+  // Send a flat receipt control message to the partner's every device (+ our
+  // own other devices), mirroring the delete/edit fan-out. The flat ack is
+  // JSON-serialized on the wire and intercepted by handleDmReceipt (no `content`
+  // wrapper). Stored in a ref so the ReceiptService below never needs recreating.
+  const sendDmReceiptAck = useCallback(
+    async (partnerAddress: string, ack: ReceiptControlMessage) => {
+      try {
+        const senderId = fullUserAddrRef.current;
+        if (!senderId || !encryptionService.hasDeviceKeys()) return;
+        const deviceKeyset = await getDeviceKeyset();
+        if (!deviceKeyset) return;
+
+        const apiClient = getQuorumClient();
+        const allTargetDevices: DeviceInfo[] = [];
+        try {
+          const recipientReg = await apiClient.fetchUserRegistration(partnerAddress);
+          if (recipientReg) allTargetDevices.push(...toAllDeviceInfos(recipientReg));
+          const senderReg = await apiClient.fetchUserRegistration(senderId);
+          if (senderReg) {
+            allTargetDevices.push(
+              ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
+            );
+          }
+        } catch {
+          // Registration fetch failed — with no devices the send is skipped below.
+        }
+        if (allTargetDevices.length === 0) return;
+
+        await sendEncryptedMessageToAllDevices(
+          `${partnerAddress}/${partnerAddress}`,
+          partnerAddress,
+          ack as unknown as Message,
+          allTargetDevices,
+          enqueueOutbound,
+          subscribe,
+          {
+            identityPublicKey: deviceKeyset.identityPublicKey,
+            inboxAddress: deviceKeyset.inboxAddress,
+            inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
+          },
+          senderId,
+          user?.displayName,
+        );
+      } catch (err) {
+        logger.debug('[DM-receipts] ack send failed', err);
+      }
+    },
+    [enqueueOutbound, subscribe, user?.displayName],
+  );
+  sendDmReceiptAckRef.current = sendDmReceiptAck;
+
+  // Mark a partner's DM message read → buffers a read ack (5s flush). Gated on
+  // the read-receipts master switch, per the ReceiptService contract.
+  const notifyDmRead = useCallback((partnerAddress: string, messageId: string, timestamp: number) => {
+    if (!isReceiptEnabled('read')) return;
+    receiptServiceRef.current?.onMessageRead(partnerAddress, messageId, timestamp);
+  }, [isReceiptEnabled]);
+
+  // Build the ReceiptService once per session. Callbacks bridge to the send
+  // transport (via ref, so display-name changes don't recreate it), the React
+  // Query cache and SQLite. Display is unconditional; the master switch only
+  // gates whether acks are sent/consumed (in handleDmReceipt + onMessageRead).
+  useEffect(() => {
+    const self = user?.address;
+    if (!self) return;
+
+    const service = new ReceiptService({
+      onFlush: (address, messageIds) => {
+        sendDmReceiptAckRef.current?.(address, { senderId: self, type: 'delivery-ack', messageIds });
+      },
+      onAckProcessed: (messageIds) => {
+        const now = Date.now();
+        const ids = new Set(messageIds);
+        // We don't know which conversation — patch deliveredAt across all DM caches.
+        queryClient.setQueriesData<InfiniteMessagesData>({ queryKey: ['messages', 'infinite'] }, (old) => {
+          if (!old?.pages) return old;
+          let changed = false;
+          const pages = old.pages.map((page) => {
+            let pageChanged = false;
+            const messages = page.messages.map((m) => {
+              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; return { ...m, deliveredAt: now }; }
+              return m;
+            });
+            return pageChanged ? { ...page, messages } : page;
+          });
+          return changed ? { ...old, pages } : old;
+        });
+        for (const id of messageIds) updateMessageDeliveredAt(id, now).catch(() => {});
+      },
+      onReadFlush: (address, hwm) => {
+        sendDmReceiptAckRef.current?.(address, {
+          senderId: self, type: 'read-ack', upToMessageId: hwm.messageId, upToTimestamp: hwm.timestamp,
+        });
+      },
+      onReadAckProcessed: (upToMessageId, upToTimestamp, conversationAddress) => {
+        const now = Date.now();
+        const key = queryKeys.messages.infinite(conversationAddress, conversationAddress);
+        queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
+          if (!old?.pages) return old;
+          let changed = false;
+          const pages = old.pages.map((page) => {
+            let pageChanged = false;
+            const messages = page.messages.map((m) => {
+              if (m.content?.senderId === self && m.createdDate <= upToTimestamp && !m.readAt) {
+                changed = true; pageChanged = true;
+                return { ...m, readAt: now, deliveredAt: m.deliveredAt || now };
+              }
+              return m;
+            });
+            return pageChanged ? { ...page, messages } : page;
+          });
+          return changed ? { ...old, pages } : old;
+        });
+        updateMessagesReadAt(conversationAddress, self, upToTimestamp, now).catch(() => {});
+      },
+    });
+
+    receiptServiceRef.current = service;
+    return () => {
+      service.destroy();
+      receiptServiceRef.current = null;
+    };
+  }, [user?.address, queryClient]);
+
+  // Flush pending acks when the app backgrounds (RN has no visibilitychange, so
+  // the ReceiptService relies on this signal — see its docstring).
+  useEffect(() => {
+    const sub = AppState.addEventListener('change', (state: AppStateStatus) => {
+      if (state === 'background' || state === 'inactive') {
+        receiptServiceRef.current?.flushAll();
+      }
+    });
+    return () => sub.remove();
+  }, []);
+
   // triggerSyncRequest removed — peer-to-peer mesh sync is gone. Catch-up
   // is handled exclusively by the per-hub log transport (listen-hub +
   // log-since). Joiners do not request history from peers.
@@ -5378,12 +5605,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       enqueueOutbound,
       subscribe,
       unsubscribe,
+      notifyDmRead,
       kickedFromSpaceId,
       clearKickedFromSpace,
       registerCallSignalingHandler,
       registerLogFrameHandler,
     }),
-    [connectionState, connect, disconnect, enqueueOutbound, subscribe, unsubscribe, kickedFromSpaceId, clearKickedFromSpace, registerCallSignalingHandler, registerLogFrameHandler]
+    [connectionState, connect, disconnect, enqueueOutbound, subscribe, unsubscribe, notifyDmRead, kickedFromSpaceId, clearKickedFromSpace, registerCallSignalingHandler, registerLogFrameHandler]
   );
 
   return (

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -532,15 +532,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
     if (raw.type === 'delivery-ack') {
-      const gate = isReceiptEnabled('delivery', partner);
-      logger.log(`[RECEIPTS] RECV delivery-ack from=${raw.senderId?.slice(0, 8)} ids=${raw.messageIds?.length ?? 0} svc=${!!svc} notSelf=${raw.senderId !== self} gate=${gate}`);
-      if (svc && raw.senderId !== self && gate) svc.onAckReceived(raw.messageIds ?? []);
+      if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
       return true;
     }
     if (raw.type === 'read-ack') {
-      const gate = isReceiptEnabled('read', partner);
-      logger.log(`[RECEIPTS] RECV read-ack from=${raw.senderId?.slice(0, 8)} upTo=${raw.upToMessageId?.slice(0, 8)} svc=${!!svc} notSelf=${raw.senderId !== self} gate=${gate}`);
-      if (svc && raw.senderId !== self && gate && raw.upToMessageId && raw.upToTimestamp) {
+      if (svc && raw.senderId !== self && isReceiptEnabled('read', partner) && raw.upToMessageId && raw.upToTimestamp) {
         svc.onReadAckReceived(raw.upToMessageId, raw.upToTimestamp, partner);
       }
       return true;
@@ -559,12 +555,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
       // Buffer a delivery ack for an inbound post from the partner (flushed via
       // timer / background / piggyback).
-      if (decryptedMessage.content?.type === 'post') {
-        const gate = isReceiptEnabled('delivery', partner);
-        logger.log(`[RECEIPTS] RECV post ${decryptedMessage.messageId?.slice(0, 8)} from=${decryptedMessage.content?.senderId?.slice(0, 8)} partner=${partner?.slice(0, 8)} fromPartner=${fromPartner} deliveryGate=${gate} -> ${fromPartner && gate ? 'BUFFER ack' : 'skip'}`);
-        if (fromPartner && gate) {
-          svc.onMessageReceived(partner, decryptedMessage.messageId);
-        }
+      if (fromPartner && isReceiptEnabled('delivery', partner) && decryptedMessage.content?.type === 'post') {
+        svc.onMessageReceived(partner, decryptedMessage.messageId);
       }
     }
     return false;
@@ -5169,13 +5161,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     async (partnerAddress: string, ack: ReceiptControlMessage) => {
       try {
         const senderId = fullUserAddrRef.current;
-        logger.log(`[RECEIPTS] SEND ${ack.type} -> ${partnerAddress?.slice(0, 8)} (self=${senderId?.slice(0, 8)})`);
-        if (!senderId || !encryptionService.hasDeviceKeys()) {
-          logger.log(`[RECEIPTS] SEND aborted — no senderId or device keys (hasKeys=${encryptionService.hasDeviceKeys()})`);
-          return;
-        }
+        if (!senderId || !encryptionService.hasDeviceKeys()) return;
         const deviceKeyset = await getDeviceKeyset();
-        if (!deviceKeyset) { logger.log('[RECEIPTS] SEND aborted — no deviceKeyset'); return; }
+        if (!deviceKeyset) return;
 
         const apiClient = getQuorumClient();
         const allTargetDevices: DeviceInfo[] = [];
@@ -5188,12 +5176,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
             );
           }
-        } catch (regErr) {
-          logger.log(`[RECEIPTS] SEND registration fetch failed: ${String(regErr)}`);
+        } catch {
+          // Registration fetch failed — with no devices the send is skipped below.
         }
-        if (allTargetDevices.length === 0) { logger.log('[RECEIPTS] SEND aborted — 0 target devices'); return; }
+        if (allTargetDevices.length === 0) return;
 
-        logger.log(`[RECEIPTS] SEND ${ack.type} encrypting to ${allTargetDevices.length} device(s)`);
         await sendEncryptedMessageToAllDevices(
           `${partnerAddress}/${partnerAddress}`,
           partnerAddress,
@@ -5209,9 +5196,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           senderId,
           user?.displayName,
         );
-        logger.log(`[RECEIPTS] SEND ${ack.type} enqueued OK`);
       } catch (err) {
-        logger.log(`[RECEIPTS] SEND failed: ${String(err)}`);
+        logger.debug('[DM-receipts] ack send failed', err);
       }
     },
     [enqueueOutbound, subscribe, user?.displayName],
@@ -5221,9 +5207,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // Mark a partner's DM message read → buffers a read ack (5s flush). Gated on
   // the read-receipts master switch, per the ReceiptService contract.
   const notifyDmRead = useCallback((partnerAddress: string, messageId: string, timestamp: number) => {
-    const gate = isReceiptEnabled('read', partnerAddress);
-    logger.log(`[RECEIPTS] notifyDmRead partner=${partnerAddress?.slice(0, 8)} msg=${messageId?.slice(0, 8)} readGate=${gate}`);
-    if (!gate) return;
+    if (!isReceiptEnabled('read', partnerAddress)) return;
     receiptServiceRef.current?.onMessageRead(partnerAddress, messageId, timestamp);
   }, [isReceiptEnabled]);
 
@@ -5237,13 +5221,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
     const service = new ReceiptService({
       onFlush: (address, messageIds) => {
-        logger.log(`[RECEIPTS] FLUSH delivery-ack -> ${address?.slice(0, 8)} ids=${messageIds.length}`);
         sendDmReceiptAckRef.current?.(address, { senderId: self, type: 'delivery-ack', messageIds });
       },
       onAckProcessed: (messageIds) => {
         const now = Date.now();
         const ids = new Set(messageIds);
-        let hit = false;
         // We don't know which conversation — patch deliveredAt across all DM caches.
         queryClient.setQueriesData<InfiniteMessagesData>({ queryKey: ['messages', 'infinite'] }, (old) => {
           if (!old?.pages) return old;
@@ -5251,25 +5233,22 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           const pages = old.pages.map((page) => {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
-              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; hit = true; return { ...m, deliveredAt: now }; }
+              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; return { ...m, deliveredAt: now }; }
               return m;
             });
             return pageChanged ? { ...page, messages } : page;
           });
           return changed ? { ...old, pages } : old;
         });
-        logger.log(`[RECEIPTS] PROCESS delivery-ack ids=${messageIds.length} cacheHit=${hit} -> deliveredAt set`);
         for (const id of messageIds) updateMessageDeliveredAt(id, now).catch(() => {});
       },
       onReadFlush: (address, hwm) => {
-        logger.log(`[RECEIPTS] FLUSH read-ack -> ${address?.slice(0, 8)} upTo=${hwm.messageId?.slice(0, 8)}`);
         sendDmReceiptAckRef.current?.(address, {
           senderId: self, type: 'read-ack', upToMessageId: hwm.messageId, upToTimestamp: hwm.timestamp,
         });
       },
       onReadAckProcessed: (upToMessageId, upToTimestamp, conversationAddress) => {
         const now = Date.now();
-        let hit = false;
         const key = queryKeys.messages.infinite(conversationAddress, conversationAddress);
         queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
           if (!old?.pages) return old;
@@ -5278,7 +5257,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
               if (m.content?.senderId === self && m.createdDate <= upToTimestamp && !m.readAt) {
-                changed = true; pageChanged = true; hit = true;
+                changed = true; pageChanged = true;
                 return { ...m, readAt: now, deliveredAt: m.deliveredAt || now };
               }
               return m;
@@ -5287,7 +5266,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           });
           return changed ? { ...old, pages } : old;
         });
-        logger.log(`[RECEIPTS] PROCESS read-ack conv=${conversationAddress?.slice(0, 8)} upToTs=${upToTimestamp} cacheHit=${hit} -> readAt set`);
         updateMessagesReadAt(conversationAddress, self, upToTimestamp, now).catch(() => {});
       },
     });

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -84,7 +84,7 @@ import {
 } from '../services/space/modMuteStorage';
 import { buildListenHubFrame, buildLogSinceFrame } from '../services/space/hubLogSync';
 import { getHubLastSeq, setHubLastSeq } from '../services/space/hubLogCursor';
-import { getMMKVAdapter } from '../services/storage/mmkvAdapter';
+import { getMMKVAdapter, getConversationSync } from '../services/storage/mmkvAdapter';
 import { useAuth } from './AuthContext';
 import { useStorageAdapter } from './StorageContext';
 
@@ -501,13 +501,20 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const receiptServiceRef = useRef<ReceiptService | null>(null);
   const sendDmReceiptAckRef = useRef<((partnerAddress: string, ack: ReceiptControlMessage) => void) | null>(null);
 
-  // Global receipt master switches. Default OFF (matches desktop). Read live
-  // from the local config blob so a settings toggle takes effect immediately.
-  const isReceiptEnabled = useCallback((kind: 'delivery' | 'read'): boolean => {
+  // Effective receipt switch: per-conversation override (stored on the local
+  // Conversation, like desktop) wins over the global setting, else the global
+  // (default OFF). Read live so a settings toggle takes effect immediately.
+  // `partner` is the DM partner address (conversationId is `partner/partner`).
+  // NOTE: the per-conversation override is NOT synced across devices yet — that's
+  // the unified conversation-settings sync task (2026-07-20).
+  const isReceiptEnabled = useCallback((kind: 'delivery' | 'read', partner?: string): boolean => {
     const self = fullUserAddrRef.current;
     if (!self) return false;
     const cfg = getLocalUserConfig(self);
-    return kind === 'delivery' ? (cfg?.deliveryReceipts ?? false) : (cfg?.readReceipts ?? false);
+    const conv = partner ? getConversationSync(`${partner}/${partner}`) : undefined;
+    return kind === 'delivery'
+      ? (conv?.deliveryReceipts ?? cfg?.deliveryReceipts ?? false)
+      : (conv?.readReceipts ?? cfg?.readReceipts ?? false);
   }, []);
 
   // Intercept DM receipts on the decrypt path (both receive branches), BEFORE
@@ -525,11 +532,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
     if (raw.type === 'delivery-ack') {
-      if (svc && raw.senderId !== self && isReceiptEnabled('delivery')) svc.onAckReceived(raw.messageIds ?? []);
+      if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
       return true;
     }
     if (raw.type === 'read-ack') {
-      if (svc && raw.senderId !== self && isReceiptEnabled('read') && raw.upToMessageId && raw.upToTimestamp) {
+      if (svc && raw.senderId !== self && isReceiptEnabled('read', partner) && raw.upToMessageId && raw.upToTimestamp) {
         svc.onReadAckReceived(raw.upToMessageId, raw.upToTimestamp, partner);
       }
       return true;
@@ -539,8 +546,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // not our own echo), then strip before persist regardless.
     if (svc) {
       const fromPartner = decryptedMessage.content?.senderId !== self;
-      if (fromPartner && raw.ackMessageIds && isReceiptEnabled('delivery')) svc.onAckReceived(raw.ackMessageIds);
-      if (fromPartner && raw.readAckUpTo && isReceiptEnabled('read')) {
+      if (fromPartner && raw.ackMessageIds && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.ackMessageIds);
+      if (fromPartner && raw.readAckUpTo && isReceiptEnabled('read', partner)) {
         svc.onReadAckReceived(raw.readAckUpTo.messageId, raw.readAckUpTo.timestamp, partner);
       }
       delete raw.ackMessageIds;
@@ -548,7 +555,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
       // Buffer a delivery ack for an inbound post from the partner (flushed via
       // timer / background / piggyback).
-      if (fromPartner && isReceiptEnabled('delivery') && decryptedMessage.content?.type === 'post') {
+      if (fromPartner && isReceiptEnabled('delivery', partner) && decryptedMessage.content?.type === 'post') {
         svc.onMessageReceived(partner, decryptedMessage.messageId);
       }
     }
@@ -5200,7 +5207,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // Mark a partner's DM message read → buffers a read ack (5s flush). Gated on
   // the read-receipts master switch, per the ReceiptService contract.
   const notifyDmRead = useCallback((partnerAddress: string, messageId: string, timestamp: number) => {
-    if (!isReceiptEnabled('read')) return;
+    if (!isReceiptEnabled('read', partnerAddress)) return;
     receiptServiceRef.current?.onMessageRead(partnerAddress, messageId, timestamp);
   }, [isReceiptEnabled]);
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -532,11 +532,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
     if (raw.type === 'delivery-ack') {
-      if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
+      const gate = isReceiptEnabled('delivery', partner);
+      logger.log(`[RECEIPTS] RECV delivery-ack from=${raw.senderId?.slice(0, 8)} ids=${raw.messageIds?.length ?? 0} svc=${!!svc} notSelf=${raw.senderId !== self} gate=${gate}`);
+      if (svc && raw.senderId !== self && gate) svc.onAckReceived(raw.messageIds ?? []);
       return true;
     }
     if (raw.type === 'read-ack') {
-      if (svc && raw.senderId !== self && isReceiptEnabled('read', partner) && raw.upToMessageId && raw.upToTimestamp) {
+      const gate = isReceiptEnabled('read', partner);
+      logger.log(`[RECEIPTS] RECV read-ack from=${raw.senderId?.slice(0, 8)} upTo=${raw.upToMessageId?.slice(0, 8)} svc=${!!svc} notSelf=${raw.senderId !== self} gate=${gate}`);
+      if (svc && raw.senderId !== self && gate && raw.upToMessageId && raw.upToTimestamp) {
         svc.onReadAckReceived(raw.upToMessageId, raw.upToTimestamp, partner);
       }
       return true;
@@ -555,8 +559,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
       // Buffer a delivery ack for an inbound post from the partner (flushed via
       // timer / background / piggyback).
-      if (fromPartner && isReceiptEnabled('delivery', partner) && decryptedMessage.content?.type === 'post') {
-        svc.onMessageReceived(partner, decryptedMessage.messageId);
+      if (decryptedMessage.content?.type === 'post') {
+        const gate = isReceiptEnabled('delivery', partner);
+        logger.log(`[RECEIPTS] RECV post ${decryptedMessage.messageId?.slice(0, 8)} from=${decryptedMessage.content?.senderId?.slice(0, 8)} partner=${partner?.slice(0, 8)} fromPartner=${fromPartner} deliveryGate=${gate} -> ${fromPartner && gate ? 'BUFFER ack' : 'skip'}`);
+        if (fromPartner && gate) {
+          svc.onMessageReceived(partner, decryptedMessage.messageId);
+        }
       }
     }
     return false;
@@ -5161,9 +5169,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     async (partnerAddress: string, ack: ReceiptControlMessage) => {
       try {
         const senderId = fullUserAddrRef.current;
-        if (!senderId || !encryptionService.hasDeviceKeys()) return;
+        logger.log(`[RECEIPTS] SEND ${ack.type} -> ${partnerAddress?.slice(0, 8)} (self=${senderId?.slice(0, 8)})`);
+        if (!senderId || !encryptionService.hasDeviceKeys()) {
+          logger.log(`[RECEIPTS] SEND aborted — no senderId or device keys (hasKeys=${encryptionService.hasDeviceKeys()})`);
+          return;
+        }
         const deviceKeyset = await getDeviceKeyset();
-        if (!deviceKeyset) return;
+        if (!deviceKeyset) { logger.log('[RECEIPTS] SEND aborted — no deviceKeyset'); return; }
 
         const apiClient = getQuorumClient();
         const allTargetDevices: DeviceInfo[] = [];
@@ -5176,11 +5188,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               ...toAllDeviceInfos(senderReg).filter((d) => d.inboxAddress !== deviceKeyset.inboxAddress)
             );
           }
-        } catch {
-          // Registration fetch failed — with no devices the send is skipped below.
+        } catch (regErr) {
+          logger.log(`[RECEIPTS] SEND registration fetch failed: ${String(regErr)}`);
         }
-        if (allTargetDevices.length === 0) return;
+        if (allTargetDevices.length === 0) { logger.log('[RECEIPTS] SEND aborted — 0 target devices'); return; }
 
+        logger.log(`[RECEIPTS] SEND ${ack.type} encrypting to ${allTargetDevices.length} device(s)`);
         await sendEncryptedMessageToAllDevices(
           `${partnerAddress}/${partnerAddress}`,
           partnerAddress,
@@ -5196,8 +5209,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           senderId,
           user?.displayName,
         );
+        logger.log(`[RECEIPTS] SEND ${ack.type} enqueued OK`);
       } catch (err) {
-        logger.debug('[DM-receipts] ack send failed', err);
+        logger.log(`[RECEIPTS] SEND failed: ${String(err)}`);
       }
     },
     [enqueueOutbound, subscribe, user?.displayName],
@@ -5207,7 +5221,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // Mark a partner's DM message read → buffers a read ack (5s flush). Gated on
   // the read-receipts master switch, per the ReceiptService contract.
   const notifyDmRead = useCallback((partnerAddress: string, messageId: string, timestamp: number) => {
-    if (!isReceiptEnabled('read', partnerAddress)) return;
+    const gate = isReceiptEnabled('read', partnerAddress);
+    logger.log(`[RECEIPTS] notifyDmRead partner=${partnerAddress?.slice(0, 8)} msg=${messageId?.slice(0, 8)} readGate=${gate}`);
+    if (!gate) return;
     receiptServiceRef.current?.onMessageRead(partnerAddress, messageId, timestamp);
   }, [isReceiptEnabled]);
 
@@ -5221,11 +5237,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
     const service = new ReceiptService({
       onFlush: (address, messageIds) => {
+        logger.log(`[RECEIPTS] FLUSH delivery-ack -> ${address?.slice(0, 8)} ids=${messageIds.length}`);
         sendDmReceiptAckRef.current?.(address, { senderId: self, type: 'delivery-ack', messageIds });
       },
       onAckProcessed: (messageIds) => {
         const now = Date.now();
         const ids = new Set(messageIds);
+        let hit = false;
         // We don't know which conversation — patch deliveredAt across all DM caches.
         queryClient.setQueriesData<InfiniteMessagesData>({ queryKey: ['messages', 'infinite'] }, (old) => {
           if (!old?.pages) return old;
@@ -5233,22 +5251,25 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           const pages = old.pages.map((page) => {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
-              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; return { ...m, deliveredAt: now }; }
+              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; hit = true; return { ...m, deliveredAt: now }; }
               return m;
             });
             return pageChanged ? { ...page, messages } : page;
           });
           return changed ? { ...old, pages } : old;
         });
+        logger.log(`[RECEIPTS] PROCESS delivery-ack ids=${messageIds.length} cacheHit=${hit} -> deliveredAt set`);
         for (const id of messageIds) updateMessageDeliveredAt(id, now).catch(() => {});
       },
       onReadFlush: (address, hwm) => {
+        logger.log(`[RECEIPTS] FLUSH read-ack -> ${address?.slice(0, 8)} upTo=${hwm.messageId?.slice(0, 8)}`);
         sendDmReceiptAckRef.current?.(address, {
           senderId: self, type: 'read-ack', upToMessageId: hwm.messageId, upToTimestamp: hwm.timestamp,
         });
       },
       onReadAckProcessed: (upToMessageId, upToTimestamp, conversationAddress) => {
         const now = Date.now();
+        let hit = false;
         const key = queryKeys.messages.infinite(conversationAddress, conversationAddress);
         queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
           if (!old?.pages) return old;
@@ -5257,7 +5278,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
               if (m.content?.senderId === self && m.createdDate <= upToTimestamp && !m.readAt) {
-                changed = true; pageChanged = true;
+                changed = true; pageChanged = true; hit = true;
                 return { ...m, readAt: now, deliveredAt: m.deliveredAt || now };
               }
               return m;
@@ -5266,6 +5287,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           });
           return changed ? { ...old, pages } : old;
         });
+        logger.log(`[RECEIPTS] PROCESS read-ack conv=${conversationAddress?.slice(0, 8)} upToTs=${upToTimestamp} cacheHit=${hit} -> readAt set`);
         updateMessagesReadAt(conversationAddress, self, upToTimestamp, now).catch(() => {});
       },
     });

--- a/hooks/useUserConfig.ts
+++ b/hooks/useUserConfig.ts
@@ -33,6 +33,8 @@ interface UseUserConfigReturn {
   updateNotificationSettings: (
     settings: UserConfig['notificationSettings']
   ) => Promise<void>;
+  updateDeliveryReceipts: (enabled: boolean) => Promise<void>;
+  updateReadReceipts: (enabled: boolean) => Promise<void>;
 }
 
 export function useUserConfig(): UseUserConfigReturn {
@@ -117,6 +119,26 @@ export function useUserConfig(): UseUserConfigReturn {
     [user?.address, config]
   );
 
+  // DM receipt master switches. Persisted to the config blob (typed in shared
+  // 2.1.0-34+) and synced cross-device via saveConfig like every other setting.
+  const updateDeliveryReceipts = useCallback(
+    async (enabled: boolean) => {
+      if (!user?.address) return;
+      const updated = await updateConfig(user.address, { deliveryReceipts: enabled });
+      setConfig(updated);
+    },
+    [user?.address]
+  );
+
+  const updateReadReceipts = useCallback(
+    async (enabled: boolean) => {
+      if (!user?.address) return;
+      const updated = await updateConfig(user.address, { readReceipts: enabled });
+      setConfig(updated);
+    },
+    [user?.address]
+  );
+
   return {
     config,
     isLoading,
@@ -124,6 +146,25 @@ export function useUserConfig(): UseUserConfigReturn {
     refreshConfig,
     updateAllowSync,
     updateNotificationSettings,
+    updateDeliveryReceipts,
+    updateReadReceipts,
+  };
+}
+
+/**
+ * Hook for DM delivery + read receipt settings. Both default OFF (matches
+ * desktop). Turning delivery off implicitly disables read (you can't confirm
+ * reads without confirming delivery).
+ */
+export function useReceiptSettings() {
+  const { config, isLoading, updateDeliveryReceipts, updateReadReceipts } = useUserConfig();
+
+  return {
+    deliveryReceipts: config?.deliveryReceipts ?? false,
+    readReceipts: config?.readReceipts ?? false,
+    isLoading,
+    setDeliveryReceipts: updateDeliveryReceipts,
+    setReadReceipts: updateReadReceipts,
   };
 }
 

--- a/services/storage/messagesDb.ts
+++ b/services/storage/messagesDb.ts
@@ -606,6 +606,54 @@ export async function deleteMessage(messageId: string): Promise<void> {
 }
 
 /**
+ * DM delivery receipt: stamp deliveredAt on a single sent message. Patches
+ * the JSON payload (deliveredAt is not a dedicated column). No-op if the row
+ * is gone or already delivered.
+ */
+export async function updateMessageDeliveredAt(messageId: string, deliveredAt: number): Promise<void> {
+  const db = await ensureDb();
+  if (!db) return;
+  const row = db.getFirstSync<{ payload: string }>(
+    `SELECT payload FROM messages WHERE message_id = ? LIMIT 1;`,
+    [messageId]
+  );
+  if (!row) return;
+  let msg: Message;
+  try { msg = JSON.parse(row.payload) as Message; } catch { return; }
+  if (msg.deliveredAt) return;
+  msg.deliveredAt = deliveredAt;
+  db.runSync(`UPDATE messages SET payload = ? WHERE message_id = ?;`, [JSON.stringify(msg), messageId]);
+}
+
+/**
+ * DM read receipt: stamp readAt (and deliveredAt if missing) on all OWN
+ * messages in a conversation up to a high-water timestamp. DM spaceId and
+ * channelId are both the partner address.
+ */
+export async function updateMessagesReadAt(
+  conversationAddress: string,
+  selfAddress: string,
+  upToTimestamp: number,
+  readAt: number
+): Promise<void> {
+  const db = await ensureDb();
+  if (!db) return;
+  const rows = db.getAllSync<{ message_id: string; payload: string }>(
+    `SELECT message_id, payload FROM messages
+     WHERE space_id = ? AND channel_id = ? AND created_date <= ?;`,
+    [conversationAddress, conversationAddress, upToTimestamp]
+  );
+  for (const row of rows) {
+    let msg: Message;
+    try { msg = JSON.parse(row.payload) as Message; } catch { continue; }
+    if (msg.content?.senderId !== selfAddress || msg.readAt) continue;
+    msg.readAt = readAt;
+    if (!msg.deliveredAt) msg.deliveredAt = readAt;
+    db.runSync(`UPDATE messages SET payload = ? WHERE message_id = ?;`, [JSON.stringify(msg), row.message_id]);
+  }
+}
+
+/**
  * Per-space "we already asked the server to replay the full hub log"
  * flag. Synchronous because the open-empty-channel detector in
  * useMessages needs to short-circuit without waiting on a microtask.

--- a/services/storage/mmkvAdapter.ts
+++ b/services/storage/mmkvAdapter.ts
@@ -254,6 +254,16 @@ export class MMKVAdapter implements StorageAdapter {
   }
 }
 
+/**
+ * Synchronous conversation read (MMKV is sync-backed). Used where an async
+ * getConversation can't be awaited — e.g. the DM receipt gate on the inbound
+ * decrypt path.
+ */
+export function getConversationSync(conversationId: string): Conversation | undefined {
+  const data = storage.getString(KEYS.CONVERSATION(conversationId));
+  return data ? (JSON.parse(data) as Conversation) : undefined;
+}
+
 // Singleton instance
 let adapter: MMKVAdapter | null = null;
 


### PR DESCRIPTION
Adds WhatsApp-style DM delivery and read receipts (✓ delivered / ✓✓ read), gated by privacy settings. Pure additive wiring on the published shared package.

## Pipeline
- Wire the shared `ReceiptService` into the DM receive/send path: buffer acks on inbound DMs, fan out flat `delivery-ack` / `read-ack` to the partner's devices, and intercept inbound acks (before the self-echo guard, in both receive branches) to stamp `deliveredAt` / `readAt` in the query cache + SQLite. Guards against self-echoed acks fanning back to our own devices. Flushes pending acks on app background.
- Storage helpers to persist `deliveredAt` / `readAt`.

## Rendering
- Inline ✓ / ✓✓ glyph on own DM messages (text glyph with accessibility labels and forced text presentation).
- Mark the partner's newest message read while the conversation is focused.

## Settings
- Global "Delivery receipts" / "Read receipts" toggles in Privacy & Sync, synced across devices via the config blob. Default off; read row hidden until delivery is on; toggling delivery off cascades read off.
- Per-conversation override in the DM conversation settings sheet (effective value = override ?? global), with an inline "Reset to global" link. The per-conversation override is stored locally per device for now; unifying per-conversation-settings sync across devices is a tracked follow-up.

Copy matches the desktop client. Typecheck clean.
