### PR TITLE
Fix DM messages silently dropping by serializing encryption state updates

### DIFF
--- a/__tests__/dmRatchetSerialization.test.ts
+++ b/__tests__/dmRatchetSerialization.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Serialization test for DM Double Ratchet state operations.
+ *
+ * The KeyedMutex logic itself is unit-tested in quorum-shared. This test proves
+ * MOBILE's wiring: that encryptionService.decryptMessage actually routes its
+ * read-state -> ratchet-op -> save-state critical section through the shared
+ * ratchetMutex, so two operations racing on the SAME conversation can't fork
+ * the ratchet (the desktop "DM never arrives" bug), while operations on
+ * DIFFERENT conversations still run concurrently.
+ *
+ * The model: ratchet state is a monotonically increasing counter stored as a
+ * string. Each decrypt reads the current state, yields to the event loop (the
+ * real native call is async — this is the interleaving window), then saves
+ * state+1. Serialized => 0 -> 1 -> 2. Forked (no lock) => both read 0, both
+ * save 1, one advance silently lost.
+ *
+ * Only the two boundaries are mocked (the native crypto provider and the MMKV
+ * state store); the real encryption-service and the real ratchetMutex run.
+ */
+
+const textEncoder = new TextEncoder();
+
+// --- in-memory ratchet state store, keyed by `${conversationId}::${inboxId}` ---
+const store = new Map<string, { state: string; inboxId: string; conversationId: string }>();
+const key = (conversationId: string, inboxId: string) => `${conversationId}::${inboxId}`;
+
+const mockGetEncryptionState = jest.fn((conversationId: string, inboxId: string) => {
+  return store.get(key(conversationId, inboxId)) ?? null;
+});
+const mockSaveEncryptionState = jest.fn(
+  (newState: { state: string; inboxId: string; conversationId: string }) => {
+    store.set(key(newState.conversationId, newState.inboxId), newState);
+  },
+);
+
+jest.mock('../services/crypto/encryption-state-storage', () => ({
+  encryptionStateStorage: {
+    getEncryptionState: (c: string, i: string) => mockGetEncryptionState(c, i),
+    saveEncryptionState: (s: { state: string; inboxId: string; conversationId: string }) =>
+      mockSaveEncryptionState(s),
+  },
+}));
+
+// deriveAddress is imported at module top of encryption-service but unused on
+// the decrypt path — stub it so the module loads.
+jest.mock('../services/onboarding/keyService', () => ({
+  deriveAddress: jest.fn(() => 'addr'),
+}));
+
+// Concurrency gauge — records the peak number of decrypts in flight at once.
+// Deterministic (no wall-clock assertions): serialized ops peak at 1, truly
+// concurrent ops peak at 2.
+const gauge = { inFlight: 0, max: 0 };
+
+// Native provider: decrypt reads the incoming ratchet_state counter, waits a
+// tick (forces interleaving if unserialized), and returns state+1 with a
+// non-empty plaintext so decryptMessage treats it as a success.
+const mockDoubleRatchetDecrypt = jest.fn(
+  async (arg: { ratchet_state: string; envelope: string }) => {
+    gauge.inFlight += 1;
+    gauge.max = Math.max(gauge.max, gauge.inFlight);
+    const current = Number(arg.ratchet_state);
+    await new Promise((r) => setTimeout(r, 5)); // interleaving window
+    gauge.inFlight -= 1;
+    return {
+      ratchet_state: String(current + 1),
+      message: Array.from(textEncoder.encode('ok')),
+    };
+  },
+);
+jest.mock('../services/crypto/native-provider', () => ({
+  // Method (not a field) so the lookup of mockDoubleRatchetDecrypt is deferred
+  // to call-time. The encryptionService singleton is constructed at import,
+  // before the test's mock fn is assigned, so eager field capture would bind
+  // undefined.
+  NativeCryptoProvider: class {
+    doubleRatchetDecrypt(arg: { ratchet_state: string; envelope: string }) {
+      return mockDoubleRatchetDecrypt(arg);
+    }
+  },
+}));
+
+import { encryptionService } from '../services/crypto/encryption-service';
+
+function seed(conversationId: string, inboxId: string) {
+  store.set(key(conversationId, inboxId), { state: '0', inboxId, conversationId });
+}
+
+beforeEach(() => {
+  store.clear();
+  gauge.inFlight = 0;
+  gauge.max = 0;
+  mockDoubleRatchetDecrypt.mockClear();
+  mockGetEncryptionState.mockClear();
+  mockSaveEncryptionState.mockClear();
+});
+
+test('concurrent decrypts on the SAME conversation are serialized (no forked ratchet)', async () => {
+  const conv = 'alice/alice';
+  const inbox = 'inbox-1';
+  seed(conv, inbox);
+
+  // Fire both without awaiting the first — they race for the same ratchet.
+  await Promise.all([
+    encryptionService.decryptMessage(conv, inbox, 'env-a'),
+    encryptionService.decryptMessage(conv, inbox, 'env-b'),
+  ]);
+
+  // Serialized: 0 -> 1 -> 2. Forked: both read 0, final state stuck at 1.
+  expect(store.get(key(conv, inbox))?.state).toBe('2');
+
+  // The second op must have READ the state the first one SAVED (value '1'),
+  // never the stale '0' twice.
+  const seenInputs = mockDoubleRatchetDecrypt.mock.calls
+    .map((c) => c[0].ratchet_state)
+    .sort();
+  expect(seenInputs).toEqual(['0', '1']);
+
+  // Never more than one ratchet op in flight for this conversation.
+  expect(gauge.max).toBe(1);
+});
+
+test('decrypts on DIFFERENT conversations still run concurrently', async () => {
+  const inbox = 'inbox-1';
+  seed('alice/alice', inbox);
+  seed('bob/bob', inbox);
+
+  await Promise.all([
+    encryptionService.decryptMessage('alice/alice', inbox, 'env-a'),
+    encryptionService.decryptMessage('bob/bob', inbox, 'env-b'),
+  ]);
+
+  // Each conversation advances independently 0 -> 1.
+  expect(store.get(key('alice/alice', inbox))?.state).toBe('1');
+  expect(store.get(key('bob/bob', inbox))?.state).toBe('1');
+
+  // Different keys don't block each other: both ops overlap in flight.
+  expect(gauge.max).toBe(2);
+});

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -9,6 +9,7 @@ import { useStorageAdapter } from '@/context/StorageContext';
 import { useAuth, useWebSocket } from '@/context';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
+import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
@@ -642,6 +643,7 @@ async function encryptWithExistingSession(
   plaintext: string,
   cryptoProvider: any
 ): Promise<{ envelope: string; ephemeralPublicKey: string }> {
+  return ratchetMutex.runExclusive(conversationId, async () => {
   const encryptionState = encryptionStateStorage.getEncryptionState(
     conversationId,
     inboxAddress
@@ -699,4 +701,5 @@ async function encryptWithExistingSession(
   }, true);
 
   return { envelope: result.envelope, ephemeralPublicKey };
+  });
 }

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -13,6 +13,7 @@ import { useStorageAdapter } from '@/context/StorageContext';
 import { useAuth, useWebSocket } from '@/context';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
+import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
@@ -1148,6 +1149,7 @@ async function encryptWithExistingSession(
   inboxAddress: string,
   plaintext: string
 ): Promise<{ envelope: string; ephemeralPublicKey: string }> {
+  return ratchetMutex.runExclusive(conversationId, async () => {
   const encryptionState = encryptionStateStorage.getEncryptionState(
     conversationId,
     inboxAddress
@@ -1229,6 +1231,7 @@ async function encryptWithExistingSession(
   }, true);
 
   return { envelope: result.envelope, ephemeralPublicKey };
+  });
 }
 
 /**

--- a/hooks/chat/useSendDirectReaction.ts
+++ b/hooks/chat/useSendDirectReaction.ts
@@ -9,6 +9,7 @@ import { useStorageAdapter } from '@/context/StorageContext';
 import { useAuth, useWebSocket } from '@/context';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
+import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
 import { queryKeys, bytesToHex, hexToBytes } from '@quilibrium/quorum-shared';
@@ -489,6 +490,7 @@ async function encryptWithExistingSession(
   plaintext: string,
   cryptoProvider: any
 ): Promise<{ envelope: string; ephemeralPublicKey: string }> {
+  return ratchetMutex.runExclusive(conversationId, async () => {
   const encryptionState = encryptionStateStorage.getEncryptionState(
     conversationId,
     inboxAddress
@@ -546,4 +548,5 @@ async function encryptWithExistingSession(
   }, true);
 
   return { envelope: result.envelope, ephemeralPublicKey };
+  });
 }

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -16,6 +16,7 @@ import {
   type SendingInbox,
   type ConversationInboxKeypair,
 } from './encryption-state-storage';
+import { ratchetMutex } from './ratchet-mutex';
 import { deriveAddress } from '../onboarding/keyService';
 
 import type {
@@ -103,6 +104,7 @@ class EncryptionService {
     plaintext: string,
     senderDeviceInboxAddress?: string
   ): Promise<EncryptedEnvelope> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
     if (!this.deviceKeys) {
       throw new Error('Device keys not initialized');
     }
@@ -177,6 +179,7 @@ class EncryptionService {
       ephemeralPublicKey, // Only set for first message (new session)
       ephemeralPrivateKey, // Only set for first message (new session) - needed for sealing
     };
+    });
   }
 
   /**
@@ -199,6 +202,7 @@ class EncryptionService {
     senderDeviceInboxAddress: string,
     deviceTag: string
   ): Promise<EncryptedEnvelope> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
     if (!this.deviceKeys) {
       throw new Error('Device keys not initialized');
     }
@@ -255,6 +259,7 @@ class EncryptionService {
       ephemeralPublicKey,
       ephemeralPrivateKey,
     };
+    });
   }
 
   /**
@@ -266,6 +271,7 @@ class EncryptionService {
     senderInboxAddress: string,
     envelope: string
   ): Promise<string | null> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
     // Get the encryption state for this specific inbox
     // IMPORTANT: Do NOT fall back to other states - each inbox has its own session
     // If we don't have a state for this inbox, the message cannot be decrypted
@@ -332,6 +338,7 @@ class EncryptionService {
     encryptionStateStorage.saveEncryptionState(newState, false);
 
     return decryptedText;
+    });
   }
 
   /**
@@ -448,6 +455,7 @@ class EncryptionService {
       inboxAddress: string;
     }
   ): Promise<void> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
     if (!this.deviceKeys) {
       throw new Error('Device keys not initialized');
     }
@@ -489,6 +497,7 @@ class EncryptionService {
 
     encryptionStateStorage.saveEncryptionState(encryptionState, true);
     encryptionStateStorage.saveInboxMapping(senderInfo.inboxAddress, conversationId);
+    });
   }
 
   /**
@@ -636,12 +645,14 @@ class EncryptionService {
       userIcon?: string;
     };
   } | null> {
+    // Derive conversation ID from sender address (needed as the mutex key
+    // before we enter the critical section).
+    const conversationId = `${unsealed.user_address}/${unsealed.user_address}`;
+
+    return ratchetMutex.runExclusive(conversationId, async () => {
     if (!this.deviceKeys) {
       throw new Error('Device keys not initialized');
     }
-
-    // Derive conversation ID from sender address
-    const conversationId = `${unsealed.user_address}/${unsealed.user_address}`;
 
     // FIRST: Check if we have a cached state for this specific ephemeral key
     // This handles multiple messages sent with the same X3DH session before our reply.
@@ -939,6 +950,7 @@ class EncryptionService {
       ourConversationInbox: conversationInboxAddress,
       userProfile,
     };
+    });
   }
 
   /**

--- a/services/crypto/ratchet-mutex.ts
+++ b/services/crypto/ratchet-mutex.ts
@@ -1,0 +1,32 @@
+/**
+ * ratchetMutex — app-level per-conversation lock for Double Ratchet state.
+ *
+ * Double Ratchet state is strictly linear: every operation (encrypt on send,
+ * decrypt on receive) must read the latest saved state, advance it, and save
+ * the result atomically. Mobile runs these concurrently — a user send, a
+ * receive-decrypt from the WebSocket handler, and receipt sends fired by the
+ * ReceiptService timer all funnel through the same conversation's ratchet.
+ * Two operations that read the same state snapshot fork the ratchet: whichever
+ * save lands last silently erases the other's advance, and the peer then gets
+ * `aead::Error` on subsequent frames (a forked/dead session). This is the
+ * mobile mirror of desktop's 6-month "DM never arrives" bug.
+ *
+ * Wrap every read-state → native-ratchet-op → save-state critical section in
+ * `ratchetMutex.runExclusive(conversationId, fn)`. Different conversations
+ * don't block each other; operations on the same conversation run FIFO.
+ *
+ * DO NOT hold the lock across transport delivery (enqueueOutbound / socket
+ * send) — the critical section is crypto + MMKV only. Callers acquire the lock
+ * inside the outbound-prepare callback around the encrypt, and release before
+ * the sealed bytes reach the wire.
+ *
+ * Serializes within THIS JS context only. The Android background notification
+ * task (BackgroundMessageService) runs in a separate context, but it never
+ * decrypts DMs or advances the ratchet (presence-only), so no cross-context
+ * lock is needed today. If background DM decryption is ever added, this JS
+ * mutex will NOT cover it — a native/single-writer mechanism would be required.
+ */
+
+import { KeyedMutex } from '@quilibrium/quorum-shared';
+
+export const ratchetMutex = new KeyedMutex();


### PR DESCRIPTION
## Problem

Direct messages could silently stop arriving after a conversation had been active for a while. When two encryption operations for the same conversation ran at the same time (for example a message being received while the user sends one, or while a delivery/read receipt is sent), both read the same saved encryption state, and whichever finished last overwrote the other's update. That desynchronizes the two devices' encryption ratchets, and from that point on the other side can no longer decrypt subsequent messages in that conversation. This is the mobile side of the long-standing desktop "DM never arrives" issue, and it became easier to hit once delivery/read receipts started sending automatically in the background.

## Fix

Added a small per-conversation lock so that all encryption-state updates for a given conversation run one at a time instead of overlapping. Sends, receives, and receipts for the same conversation now take turns; different conversations are unaffected and still run in parallel. The lock only covers the encryption + local-storage step, never network delivery.

## Tests

Added a unit test proving that concurrent operations on the same conversation are serialized (no lost update / desynced ratchet) while operations on different conversations still run concurrently. Full suite passes (28/28); type-check and lint clean.