### PR TITLE
fix: adopt shared applyEdit, preserve original in message edit history

### DIFF
--- a/components/Chat/EditHistoryModal.tsx
+++ b/components/Chat/EditHistoryModal.tsx
@@ -29,8 +29,13 @@ interface EditEntry {
 interface EditHistoryModalProps {
   visible: boolean;
   onClose: () => void;
-  originalText: string;
-  originalDate: number;
+  /** Current (live) message text — appended as the latest timeline entry. */
+  currentText: string;
+  /** Current message modifiedDate (the timestamp of the latest edit). */
+  currentDate: number;
+  /** Original message createdDate — identifies which entry is the Original. */
+  createdDate: number;
+  /** Prior versions, oldest first (edits[0] is the seeded original). */
   edits: EditEntry[];
   theme: AppTheme;
 }
@@ -38,34 +43,35 @@ interface EditHistoryModalProps {
 export const EditHistoryModal = React.memo(function EditHistoryModal({
   visible,
   onClose,
-  originalText,
-  originalDate,
+  currentText,
+  currentDate,
+  createdDate,
   edits,
   theme,
 }: EditHistoryModalProps) {
   const styles = useMemo(() => createStyles(theme), [theme]);
   const insets = useSafeAreaInsets();
 
-  // Build timeline: original + all edits, newest first
+  // Build timeline oldest → newest, mirroring desktop: the prior versions in
+  // edits[] (oldest first, with edits[0] the seeded original) followed by the
+  // CURRENT message text appended as the latest entry. This never loses the
+  // original and never duplicates the current version. The "Original" label is
+  // whichever entry's modifiedDate equals the message createdDate (edits[0]).
   const timeline = useMemo(() => {
-    const entries = [
-      ...edits.map((edit, index) => ({
-        text: Array.isArray(edit.text) ? edit.text.join('\n') : edit.text,
-        date: edit.modifiedDate,
-        isOriginal: false,
-        index: index + 1,
-      })),
-      {
-        text: originalText,
-        date: originalDate,
-        isOriginal: true,
-        index: 0,
-      },
-    ];
-    // Sort newest first
-    entries.sort((a, b) => b.date - a.date);
+    const entries = edits.map((edit) => ({
+      text: Array.isArray(edit.text) ? edit.text.join('\n') : edit.text,
+      date: edit.modifiedDate,
+      isOriginal: edit.modifiedDate === createdDate,
+      isCurrent: false,
+    }));
+    entries.push({
+      text: Array.isArray(currentText) ? currentText.join('\n') : currentText,
+      date: currentDate,
+      isOriginal: edits.length === 0 && currentDate === createdDate,
+      isCurrent: true,
+    });
     return entries;
-  }, [originalText, originalDate, edits]);
+  }, [currentText, currentDate, createdDate, edits]);
 
   if (!visible) return null;
 
@@ -93,14 +99,22 @@ export const EditHistoryModal = React.memo(function EditHistoryModal({
             contentContainerStyle={styles.scrollContent}
             showsVerticalScrollIndicator={false}
           >
-            {timeline.map((entry) => (
+            {timeline.map((entry, index) => (
               <View
-                key={`${entry.date}-${entry.index}`}
-                style={[styles.editCard, entry.isOriginal && styles.originalCard]}
+                key={`${entry.date}-${index}`}
+                style={[
+                  styles.editCard,
+                  entry.isOriginal && styles.originalCard,
+                  entry.isCurrent && styles.currentCard,
+                ]}
               >
                 <View style={styles.editHeader}>
                   <Text style={styles.editLabel}>
-                    {entry.isOriginal ? 'Original' : `Edit #${entry.index}`}
+                    {entry.isCurrent
+                      ? 'Current'
+                      : entry.isOriginal
+                        ? 'Original'
+                        : `Edit #${index}`}
                   </Text>
                   <Text style={styles.editTimestamp}>
                     {formatTime(entry.date)}
@@ -170,6 +184,12 @@ const createStyles = (theme: AppTheme) =>
     // background so it reads as the baseline the edits diverge from.
     originalCard: {
       backgroundColor: theme.colors.accentSoft,
+    },
+    // The Current (live) version gets an accent border so it reads as the
+    // message as it stands now, mirroring desktop's bordered "Current" card.
+    currentCard: {
+      borderWidth: 1,
+      borderColor: theme.colors.primary,
     },
     editHeader: {
       flexDirection: 'row',

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -1419,8 +1419,13 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     <EditHistoryModal
       visible={!!editHistoryMessage}
       onClose={() => setEditHistoryMessage(null)}
-      originalText={editHistoryMessage?.content ?? ''}
-      originalDate={editHistoryMessage?.timestamp ?? 0}
+      currentText={editHistoryMessage?.content ?? ''}
+      currentDate={
+        editHistoryMessage?.originalMessage?.modifiedDate ??
+        editHistoryMessage?.timestamp ??
+        0
+      }
+      createdDate={editHistoryMessage?.timestamp ?? 0}
       edits={editHistoryMessage?.originalMessage?.edits ?? []}
       theme={theme}
     />

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -35,7 +35,7 @@ import { recordSpaceActivity } from '@/hooks/chat/useSpaceActivity';
 import { logMentionOrReply } from '@/services/notifications/logMentionOrReply';
 import { shouldNotifyForContext } from '@/services/notifications/notificationPrefs';
 import { messagePreview as getSpaceMessagePreview, messageSenderName } from '@/utils/messagePreview';
-import { applyReceivedEdit, MESSAGE_EDIT_WINDOW_MS } from '@quilibrium/quorum-shared';
+import { applyEdit, MESSAGE_EDIT_WINDOW_MS } from '@quilibrium/quorum-shared';
 import { sha256 } from '@noble/hashes/sha2.js';
 import type {
   Channel,
@@ -2018,12 +2018,21 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     ...page,
                     messages: page.messages.map((msg) => {
                       if (msg.messageId === editContent.originalMessageId && msg.content.type === 'post') {
-                        const applied = applyReceivedEdit(msg, {
-                          newText: editContent.editedText,
-                          editedAt: editContent.editedAt,
-                          editNonce: editContent.editNonce,
-                          saveEditHistory,
-                        });
+                        const applied = applyEdit(
+                          {
+                            text: msg.content.text,
+                            createdDate: msg.createdDate,
+                            modifiedDate: msg.modifiedDate,
+                            nonce: msg.nonce,
+                            lastModifiedHash: msg.lastModifiedHash,
+                            edits: msg.edits,
+                          },
+                          {
+                            editedAt: editContent.editedAt,
+                            editNonce: editContent.editNonce,
+                            saveEditHistory,
+                          },
+                        );
                         if (!applied.changed) return msg;
                         return {
                           ...msg,
@@ -2047,12 +2056,21 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // update above gets overwritten the next time the infinite
               // query refetches from MMKV.
               if (existingMsg && existingMsg.content.type === 'post') {
-                const applied = applyReceivedEdit(existingMsg, {
-                  newText: editContent.editedText,
-                  editedAt: editContent.editedAt,
-                  editNonce: editContent.editNonce,
-                  saveEditHistory,
-                });
+                const applied = applyEdit(
+                  {
+                    text: existingMsg.content.text,
+                    createdDate: existingMsg.createdDate,
+                    modifiedDate: existingMsg.modifiedDate,
+                    nonce: existingMsg.nonce,
+                    lastModifiedHash: existingMsg.lastModifiedHash,
+                    edits: existingMsg.edits,
+                  },
+                  {
+                    editedAt: editContent.editedAt,
+                    editNonce: editContent.editNonce,
+                    saveEditHistory,
+                  },
+                );
                 // Skip the write when the edit was already applied — a replayed
                 // edit-message must not clobber stored history.
                 if (applied.changed) {
@@ -2999,12 +3017,21 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             if (withinWindow && withinLength) {
               const conversation = await storage.getConversation(conversationId);
               const saveEditHistory = conversation?.saveEditHistory ?? false;
-              const applied = applyReceivedEdit(targetMsg, {
-                newText: editContent.editedText,
-                editedAt: editContent.editedAt,
-                editNonce: editContent.editNonce,
-                saveEditHistory,
-              });
+              const applied = applyEdit(
+                {
+                  text: targetMsg.content.text,
+                  createdDate: targetMsg.createdDate,
+                  modifiedDate: targetMsg.modifiedDate,
+                  nonce: targetMsg.nonce,
+                  lastModifiedHash: targetMsg.lastModifiedHash,
+                  edits: targetMsg.edits,
+                },
+                {
+                  editedAt: editContent.editedAt,
+                  editNonce: editContent.editNonce,
+                  saveEditHistory,
+                },
+              );
               // Replayed edit already applied → no-op (don't clobber history).
               if (applied.changed) {
                 const key = queryKeys.messages.infinite(senderAddress, senderAddress);
@@ -3808,14 +3835,23 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // Honor the space's "Save Edit History" setting, matching desktop:
             // when OFF, don't retain prior versions (edits: []). Default false.
             const saveEditHistory = space?.saveEditHistory ?? false;
-            const applyEdit = (msg: Message): Message => {
+            const transformEdit = (msg: Message): Message => {
               if (msg.content.type !== 'post') return msg;
-              const applied = applyReceivedEdit(msg, {
-                newText: editContent.editedText,
-                editedAt: editContent.editedAt,
-                editNonce: editContent.editNonce,
-                saveEditHistory,
-              });
+              const applied = applyEdit(
+                {
+                  text: msg.content.text,
+                  createdDate: msg.createdDate,
+                  modifiedDate: msg.modifiedDate,
+                  nonce: msg.nonce,
+                  lastModifiedHash: msg.lastModifiedHash,
+                  edits: msg.edits,
+                },
+                {
+                  editedAt: editContent.editedAt,
+                  editNonce: editContent.editNonce,
+                  saveEditHistory,
+                },
+              );
               // Replayed edit already applied → leave the message untouched so a
               // duplicate delivery can't wipe stored history.
               if (!applied.changed) return msg;
@@ -3828,13 +3864,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 ...editSignatureFields,
               };
             };
-            queueCacheTransform(messagesKey, editContent.originalMessageId, applyEdit);
+            queueCacheTransform(messagesKey, editContent.originalMessageId, transformEdit);
             // Persist to storage too. Cache-only updates revert as soon as the
             // query refetches from disk (e.g. on remount, invalidate, or when
             // the user navigates away and back), so the edit appears to "snap
             // back" to the original. Match what the cache update did above.
             if (baseMsg && baseMsg.content.type === 'post') {
-              pendingStorageUpdates.set(editContent.originalMessageId, applyEdit(baseMsg));
+              pendingStorageUpdates.set(editContent.originalMessageId, transformEdit(baseMsg));
             }
             continue;
           }
@@ -4558,12 +4594,21 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             if (withinWindow && withinLength) {
               const conversation = await storage.getConversation(conversationId);
               const saveEditHistory = conversation?.saveEditHistory ?? false;
-              const applied = applyReceivedEdit(targetMsg, {
-                newText: editContent.editedText,
-                editedAt: editContent.editedAt,
-                editNonce: editContent.editNonce,
-                saveEditHistory,
-              });
+              const applied = applyEdit(
+                {
+                  text: targetMsg.content.text,
+                  createdDate: targetMsg.createdDate,
+                  modifiedDate: targetMsg.modifiedDate,
+                  nonce: targetMsg.nonce,
+                  lastModifiedHash: targetMsg.lastModifiedHash,
+                  edits: targetMsg.edits,
+                },
+                {
+                  editedAt: editContent.editedAt,
+                  editNonce: editContent.editNonce,
+                  saveEditHistory,
+                },
+              );
               // Replayed edit already applied → no-op (don't clobber history).
               if (applied.changed) {
                 queryClient.setQueryData<InfiniteMessagesData>(messagesKey, (old) => {

--- a/hooks/chat/useEditDirectMessage.ts
+++ b/hooks/chat/useEditDirectMessage.ts
@@ -23,7 +23,7 @@ import { encryptionService } from '@/services/crypto/encryption-service';
 import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
 import { generateNonce } from '@/services/onboarding/keyService';
 import {
-  buildLocalEdits,
+  applyEdit,
   logger,
   MESSAGE_EDIT_WINDOW_MS,
   queryKeys,
@@ -78,7 +78,7 @@ export function useEditDirectMessage() {
 
       // Single edit timestamp + nonce, shared by the local write and the wire
       // send so every device converges on the same edit metadata. The nonce is
-      // the receive-side replay guard (quorum-shared applyReceivedEdit).
+      // the receive-side replay guard (quorum-shared applyEdit).
       const editedAt = Date.now();
       const editNonce = generateNonce();
 
@@ -91,15 +91,26 @@ export function useEditDirectMessage() {
         for (const page of existingData.pages) {
           const msg = page.messages.find(m => m.messageId === params.messageId);
           if (msg && (msg.content.type === 'post' || msg.content.type === 'event')) {
+            const applied = applyEdit(
+              {
+                text: msg.content.text,
+                createdDate: msg.createdDate,
+                modifiedDate: msg.modifiedDate,
+                nonce: msg.nonce,
+                lastModifiedHash: msg.lastModifiedHash,
+                edits: msg.edits,
+              },
+              { editedAt, editNonce, saveEditHistory },
+            );
             const updatedMsg: Message = {
               ...msg,
-              modifiedDate: editedAt,
-              lastModifiedHash: editNonce,
+              modifiedDate: applied.modifiedDate,
+              lastModifiedHash: applied.lastModifiedHash,
               content: {
                 ...msg.content,
                 text: params.newText,
               } as Message['content'],
-              edits: buildLocalEdits(msg.edits, params.newText, editedAt, saveEditHistory),
+              edits: applied.edits,
             };
             await storage.saveMessage(
               updatedMsg,
@@ -214,6 +225,12 @@ export function useEditDirectMessage() {
       const conversation = await storage.getConversation(params.conversationId);
       const saveEditHistory = conversation?.saveEditHistory ?? false;
 
+      // Single edit timestamp for this optimistic pass so modifiedDate and the
+      // retained prior version share one time. The authoritative editNonce is
+      // generated in mutationFn; the optimistic edits[] is transient and gets
+      // reconciled by the storage write + query invalidation.
+      const editedAt = Date.now();
+
       // Optimistically update the message text in cache
       queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
         if (!old) return old;
@@ -224,14 +241,25 @@ export function useEditDirectMessage() {
             ...page,
             messages: page.messages.map((m) => {
               if (m.messageId === params.messageId && m.content.type === 'post') {
+                const applied = applyEdit(
+                  {
+                    text: m.content.text,
+                    createdDate: m.createdDate,
+                    modifiedDate: m.modifiedDate,
+                    nonce: m.nonce,
+                    lastModifiedHash: m.lastModifiedHash,
+                    edits: m.edits,
+                  },
+                  { editedAt, saveEditHistory },
+                );
                 return {
                   ...m,
-                  modifiedDate: Date.now(),
+                  modifiedDate: applied.modifiedDate,
                   content: {
                     ...m.content,
                     text: params.newText,
                   },
-                  edits: buildLocalEdits(m.edits, params.newText, Date.now(), saveEditHistory),
+                  edits: applied.edits,
                 };
               }
               return m;

--- a/hooks/chat/useEditSpaceMessage.ts
+++ b/hooks/chat/useEditSpaceMessage.ts
@@ -10,7 +10,7 @@ import { useAuth, useWebSocket } from '@/context';
 import { sendEditMessage } from '@/services/space/spaceMessageService';
 import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
 import {
-  buildLocalEdits,
+  applyEdit,
   MESSAGE_EDIT_WINDOW_MS,
   shouldSignEdit,
   type Message,
@@ -132,14 +132,26 @@ export function useEditSpaceMessage() {
               ...page,
               messages: page.messages.map((m: Message) => {
                 if (m.messageId === params.messageId && m.content.type === 'post') {
+                  const applied = applyEdit(
+                    {
+                      text: m.content.text,
+                      createdDate: m.createdDate,
+                      modifiedDate: m.modifiedDate,
+                      nonce: m.nonce,
+                      lastModifiedHash: m.lastModifiedHash,
+                      edits: m.edits,
+                    },
+                    { editedAt, saveEditHistory },
+                  );
                   return {
                     ...m,
-                    modifiedDate: editedAt,
+                    modifiedDate: applied.modifiedDate,
+                    lastModifiedHash: applied.lastModifiedHash,
                     content: {
                       ...m.content,
                       text: params.newText,
                     },
-                    edits: buildLocalEdits(m.edits, params.newText, editedAt, saveEditHistory),
+                    edits: applied.edits,
                   };
                 }
                 return m;
@@ -154,11 +166,23 @@ export function useEditSpaceMessage() {
       // MMKV, since storage still held the original text. Writing here
       // keeps disk and cache in sync.
       if (previousStored && previousStored.content.type === 'post') {
+        const applied = applyEdit(
+          {
+            text: previousStored.content.text,
+            createdDate: previousStored.createdDate,
+            modifiedDate: previousStored.modifiedDate,
+            nonce: previousStored.nonce,
+            lastModifiedHash: previousStored.lastModifiedHash,
+            edits: previousStored.edits,
+          },
+          { editedAt, saveEditHistory },
+        );
         const updated: Message = {
           ...previousStored,
-          modifiedDate: editedAt,
+          modifiedDate: applied.modifiedDate,
+          lastModifiedHash: applied.lastModifiedHash,
           content: { ...previousStored.content, text: params.newText },
-          edits: buildLocalEdits(previousStored.edits, params.newText, editedAt, saveEditHistory),
+          edits: applied.edits,
         };
         await adapter.saveMessage(updated, updated.createdDate, '', '', '', '');
       }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@polkadot/keyring": "14.0.1",
     "@polkadot/util": "14.0.1",
     "@polkadot/util-crypto": "14.0.1",
-    "@quilibrium/quorum-shared": "2.1.0-35",
+    "@quilibrium/quorum-shared": "2.1.0-36",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "7.4.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@
     tslib "^2.8.0"
     ws "^8.18.0"
 
-"@quilibrium/quorum-shared@2.1.0-35":
-  version "2.1.0-35"
-  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-35.tgz#091fe12cc4280c85f98466633fd311dc7cf16085"
-  integrity sha512-NGZSgDTXECzhuUEKNSh+jU52QI92nMMvITw7Lo0mXftH5M2hCCEJyDJjtoRc2kQBnHTf7OpqDe/C1oXNkxtQPg==
+"@quilibrium/quorum-shared@2.1.0-36":
+  version "2.1.0-36"
+  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-36.tgz#9419072b792c24e74f8f18918f5fc65d6dc87314"
+  integrity sha512-SBXBHrP0+Ly0GbKEjpsghjJ9a8dVDL3kb3cwEfo6OKFtRo88cDUp+K9Fgj1WcTOq/x2AI3Ys8KIFhtEx7LQbHg==
   dependencies:
     "@noble/hashes" "1.8.0"
     dayjs "1.11.19"


### PR DESCRIPTION
Adopt the shared `applyEdit` helper for message edits and fix the edit-history display so the original version is preserved.

The old `buildLocalEdits`/`applyReceivedEdit` helpers (removed upstream) appended the new text to `edits[]` and never captured the original, so the first version of an edited message was lost and the current version duplicated in the timeline. `applyEdit` retains prior versions oldest-first (seeding the original on the first edit) and keeps the receive-side replay guard.

Highlights:
- Send/optimistic: DM and space edit hooks now call `applyEdit`.
- Receive: all edit-message handlers in WebSocketContext use `applyEdit` (a local function that shadowed the import was renamed).
- Display: EditHistoryModal builds the timeline as prior versions + the current message appended last, mirroring desktop; the call site no longer mislabels the current text as the original.