### PR TITLE
feat: per-device signing keys (mobile receive + send) [validate cross-device before merge]

### DIFF
--- a/__tests__/deviceKeyStatements.test.ts
+++ b/__tests__/deviceKeyStatements.test.ts
@@ -1,0 +1,210 @@
+/**
+ * Wiring tests for per-device signing-key statements (deviceKeyStatements.ts).
+ *
+ * The shared statement crypto (buildDeviceKeyStatementBytes /
+ * verifyDeviceKeyStatement) is unit-tested in quorum-shared. These prove
+ * MOBILE's wiring: the announce/revoke frames carry the right statement, the
+ * signed payload is the canonical cross-platform bytes (or signatures split
+ * with desktop), and the receive path stores admissions/tombstones. Only the
+ * native crypto + storage are mocked; all shared logic runs for real.
+ */
+import {
+  buildDeviceKeyStatementBytes,
+  deriveInboxAddress,
+  type DeviceKeyStatement,
+} from '@quilibrium/quorum-shared';
+
+// --- mocks (must be prefixed `mock*` for jest.mock factories) ---
+const mockSignEd448 = jest.fn(async () => btoa('mock-signature'));
+const mockSealHubEnvelope = jest.fn(async (_addr: string, _kp: unknown, payload: string) => ({
+  sealed: 'envelope',
+  payload,
+}));
+jest.mock('../services/crypto/native-provider', () => ({
+  NativeCryptoProvider: jest.fn(() => ({
+    signEd448: mockSignEd448,
+    sealHubEnvelope: mockSealHubEnvelope,
+  })),
+}));
+
+const mockVerifyEd448 = jest.fn<Promise<boolean>, unknown[]>();
+jest.mock('../services/crypto/native-signing-provider', () => ({
+  NativeSigningProvider: jest.fn(() => ({ verifyEd448: mockVerifyEd448 })),
+}));
+
+const mockGetSpaceKey = jest.fn();
+const mockGetSpaceSigningKey = jest.fn();
+jest.mock('../services/config/spaceStorage', () => ({
+  getSpaceKey: (...a: unknown[]) => mockGetSpaceKey(...a),
+  getSpaceSigningKey: (...a: unknown[]) => mockGetSpaceSigningKey(...a),
+}));
+
+const mockGetSpaceMemberDevice = jest.fn();
+const mockSaveSpaceMemberDevice = jest.fn();
+jest.mock('../services/storage/mmkvAdapter', () => ({
+  getMMKVAdapter: () => ({
+    getSpaceMemberDevice: mockGetSpaceMemberDevice,
+    saveSpaceMemberDevice: mockSaveSpaceMemberDevice,
+  }),
+}));
+
+import {
+  buildAnnounceKeysFrame,
+  buildRevokeDeviceFrames,
+  processDeviceKeyStatement,
+} from '../services/space/deviceKeyStatements';
+
+const SPACE = 'space-pdk';
+const USER_PUB = 'ab'.repeat(57);
+const USER_ADDRESS = deriveInboxAddress(USER_PUB);
+const SIGNING_PUB = 'cd'.repeat(57); // key the device signs with (signing ?? inbox)
+const DEVICE_KEY_PUB = 'ef'.repeat(57);
+const DEVICE_INBOX = 'dev-inbox-1';
+const master = { privateKeyHex: '99'.repeat(57), publicKeyHex: USER_PUB };
+
+/** base64 of the UTF-8 bytes of a string (matches the sign path). */
+function b64Utf8(s: string): string {
+  const bytes = new TextEncoder().encode(s);
+  let bin = '';
+  for (let i = 0; i < bytes.length; i++) bin += String.fromCharCode(bytes[i]);
+  return btoa(bin);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetSpaceSigningKey.mockReturnValue({ publicKey: SIGNING_PUB });
+  mockGetSpaceKey.mockImplementation((_spaceId: string, keyId: string) =>
+    keyId === 'hub'
+      ? { address: 'hub-addr', publicKey: '1122', privateKey: '3344' }
+      : keyId === 'config'
+        ? { publicKey: '5566', privateKey: '7788' }
+        : null
+  );
+});
+
+describe('buildAnnounceKeysFrame', () => {
+  it('builds a control envelope announcing the signed key', async () => {
+    const frame = await buildAnnounceKeysFrame(SPACE, master, DEVICE_INBOX);
+    expect(frame).toBeTruthy();
+
+    const payload = JSON.parse(mockSealHubEnvelope.mock.calls[0][2]);
+    expect(payload.type).toBe('control');
+    expect(payload.message).toMatchObject({
+      type: 'announce-keys',
+      userAddress: USER_ADDRESS,
+      userPublicKey: USER_PUB,
+      spaceId: SPACE,
+      deviceInboxAddress: DEVICE_INBOX,
+      spaceKeyPublicKey: SIGNING_PUB,
+    });
+    expect(typeof payload.message.signature).toBe('string');
+    expect(payload.message.signature.length).toBeGreaterThan(0);
+  });
+
+  it('signs the canonical shared bytes (cross-platform gate)', async () => {
+    await buildAnnounceKeysFrame(SPACE, master, DEVICE_INBOX);
+    const stmt = JSON.parse(mockSealHubEnvelope.mock.calls[0][2]).message;
+    // The signed message MUST be exactly buildDeviceKeyStatementBytes(stmt) —
+    // if mobile and desktop serialize differently, signatures fail silently.
+    expect(mockSignEd448.mock.calls[0][1]).toBe(
+      b64Utf8(buildDeviceKeyStatementBytes(stmt))
+    );
+  });
+
+  it('returns null when the space has no signing key', async () => {
+    mockGetSpaceSigningKey.mockReturnValue(null);
+    const frame = await buildAnnounceKeysFrame(SPACE, master, DEVICE_INBOX);
+    expect(frame).toBeNull();
+    expect(mockSealHubEnvelope).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildRevokeDeviceFrames', () => {
+  it('builds one revoke-device frame per (space, device)', async () => {
+    const frames = await buildRevokeDeviceFrames(
+      ['s1', 's2'],
+      ['d1', 'd2'],
+      master
+    );
+    expect(frames).toHaveLength(4);
+    const payload = JSON.parse(mockSealHubEnvelope.mock.calls[0][2]);
+    expect(payload.message).toMatchObject({
+      type: 'revoke-device',
+      userAddress: USER_ADDRESS,
+      deviceInboxAddress: 'd1',
+    });
+  });
+
+  it('returns nothing for an empty device list', async () => {
+    const frames = await buildRevokeDeviceFrames(['s1'], [], master);
+    expect(frames).toHaveLength(0);
+  });
+});
+
+describe('processDeviceKeyStatement', () => {
+  const announce = {
+    type: 'announce-keys',
+    userAddress: USER_ADDRESS,
+    userPublicKey: USER_PUB,
+    spaceId: SPACE,
+    deviceInboxAddress: DEVICE_INBOX,
+    spaceKeyPublicKey: DEVICE_KEY_PUB,
+    timestamp: 1000,
+    signature: 'ab'.repeat(57),
+  } as DeviceKeyStatement;
+
+  it('persists an admission for a valid announce-keys', async () => {
+    mockVerifyEd448.mockResolvedValue(true);
+    mockGetSpaceMemberDevice.mockResolvedValue(undefined);
+
+    await processDeviceKeyStatement(announce, SPACE);
+
+    expect(mockSaveSpaceMemberDevice).toHaveBeenCalledTimes(1);
+    expect(mockSaveSpaceMemberDevice.mock.calls[0][0]).toMatchObject({
+      spaceId: SPACE,
+      userAddress: USER_ADDRESS,
+      deviceInboxAddress: DEVICE_INBOX,
+      inboxAddress: deriveInboxAddress(DEVICE_KEY_PUB),
+      revoked: false,
+    });
+  });
+
+  it('drops a statement whose spaceId does not match the delivering space', async () => {
+    mockVerifyEd448.mockResolvedValue(true);
+    await processDeviceKeyStatement({ ...announce, spaceId: 'other' }, SPACE);
+    expect(mockSaveSpaceMemberDevice).not.toHaveBeenCalled();
+  });
+
+  it('writes a tombstone for a valid revoke-device', async () => {
+    mockVerifyEd448.mockResolvedValue(true);
+    mockGetSpaceMemberDevice.mockResolvedValue({
+      spaceId: SPACE,
+      userAddress: USER_ADDRESS,
+      deviceInboxAddress: DEVICE_INBOX,
+      inboxAddress: deriveInboxAddress(DEVICE_KEY_PUB),
+      spaceKeyPublicKey: DEVICE_KEY_PUB,
+      timestamp: 500,
+      revoked: false,
+    });
+
+    await processDeviceKeyStatement(
+      {
+        type: 'revoke-device',
+        userAddress: USER_ADDRESS,
+        userPublicKey: USER_PUB,
+        spaceId: SPACE,
+        deviceInboxAddress: DEVICE_INBOX,
+        timestamp: 2000,
+        signature: 'ab'.repeat(57),
+      } as DeviceKeyStatement,
+      SPACE
+    );
+
+    expect(mockSaveSpaceMemberDevice).toHaveBeenCalledTimes(1);
+    expect(mockSaveSpaceMemberDevice.mock.calls[0][0]).toMatchObject({
+      deviceInboxAddress: DEVICE_INBOX,
+      revoked: true,
+      timestamp: 2000,
+    });
+  });
+});

--- a/__tests__/deviceKeyStatements.test.ts
+++ b/__tests__/deviceKeyStatements.test.ts
@@ -15,7 +15,9 @@ import {
 } from '@quilibrium/quorum-shared';
 
 // --- mocks (must be prefixed `mock*` for jest.mock factories) ---
-const mockSignEd448 = jest.fn(async () => btoa('mock-signature'));
+const mockSignEd448 = jest.fn<Promise<string>, [string, string]>(
+  async () => btoa('mock-signature')
+);
 const mockSealHubEnvelope = jest.fn(async (_addr: string, _kp: unknown, payload: string) => ({
   sealed: 'envelope',
   payload,

--- a/__tests__/spaceMessageAuth.test.ts
+++ b/__tests__/spaceMessageAuth.test.ts
@@ -22,8 +22,12 @@ jest.mock('../services/crypto/native-signing-provider', () => ({
   NativeSigningProvider: jest.fn(() => ({ verifyEd448: mockVerifyEd448 })),
 }));
 const mockGetSpaceMembers = jest.fn();
+const mockGetSpaceMemberDevices = jest.fn(async () => []);
 jest.mock('../services/storage/mmkvAdapter', () => ({
-  getMMKVAdapter: () => ({ getSpaceMembers: mockGetSpaceMembers }),
+  getMMKVAdapter: () => ({
+    getSpaceMembers: mockGetSpaceMembers,
+    getSpaceMemberDevices: mockGetSpaceMemberDevices,
+  }),
 }));
 
 import {

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -54,7 +54,8 @@ import {
 } from '@/services/translation/translationPrefs';
 import { languageName } from '@/components/translation/languages';
 import { TranslateLanguageModal } from '@/components/translation/TranslateLanguageModal';
-import { getAllSpaces } from '@/services/config/spaceStorage';
+import { getAllSpaces, getSpaceIds } from '@/services/config/spaceStorage';
+import { buildRevokeDeviceFrames } from '@/services/space/deviceKeyStatements';
 import { encryptionStateStorage } from '@/services/crypto/encryption-state-storage';
 import {
   deriveFarcasterKeys,
@@ -641,6 +642,11 @@ export default function ProfileModal({
           throw new Error('Missing keys for device removal');
         }
 
+        // The removed device's DM inbox address is its revocation handle.
+        const removedInbox = deviceRegistrations.find(
+          (d) => d.identity_public_key === identityPublicKey
+        )?.inbox_registration?.inbox_address;
+
         // Filter out the device to remove
         const remainingDevices = deviceRegistrations.filter(
           (d) => d.identity_public_key !== identityPublicKey
@@ -654,6 +660,21 @@ export default function ProfileModal({
           remainingDevices
         );
 
+        // Broadcast master-signed revoke-device tombstones across every space so
+        // receivers stop admitting the removed device's per-device signing key.
+        if (removedInbox) {
+          try {
+            const frames = await buildRevokeDeviceFrames(
+              getSpaceIds(),
+              [removedInbox],
+              { privateKeyHex: userPrivateKey, publicKeyHex: userPublicKey }
+            );
+            for (const frame of frames) enqueueOutbound(async () => [frame]);
+          } catch {
+            // Best-effort; receivers also drop the device on the next re-announce.
+          }
+        }
+
         // Update local state
         setDeviceRegistrations(remainingDevices);
         Alert.alert('Success', 'Device removed successfully.');
@@ -663,7 +684,7 @@ export default function ProfileModal({
         setIsRemovingDevice(false);
       }
     })();
-  }, [user?.address, deviceRegistrations, confirm]);
+  }, [user?.address, deviceRegistrations, confirm, enqueueOutbound]);
 
   // Handle reset all DM sessions
   const handleResetAllSessions = React.useCallback(() => {

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -65,6 +65,12 @@ import { NativeCryptoProvider, SyncSealedMessage, type BatchSpaceGroup, type Bat
 import { NativeSigningProvider } from '../services/crypto/native-signing-provider';
 import { mmkvStorage } from '../services/offline/storage';
 import { getDeviceKeyset, type DeviceKeyset } from '../services/onboarding/secureStorage';
+import { getPrivateKey, getPublicKey } from '../services/onboarding/secureStorage';
+import {
+  buildAnnounceKeysFrame,
+  processDeviceKeyStatement,
+} from '../services/space/deviceKeyStatements';
+import type { DeviceKeyStatement } from '@quilibrium/quorum-shared';
 import {
   clearSentEnvelope,
   isSentEnvelope,
@@ -1187,6 +1193,20 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                       });
                     }
                   } catch (verifyError) {
+                  }
+                  break;
+                }
+
+                case 'announce-keys':
+                case 'revoke-device': {
+                  // Per-device signing-key admission / revocation. Verified and
+                  // stored by the shared statement logic; fails closed. Inert
+                  // until the send-side flip is live on both platforms.
+                  if (spaceId) {
+                    await processDeviceKeyStatement(
+                      controlPayload.message as unknown as DeviceKeyStatement,
+                      spaceId
+                    );
                   }
                   break;
                 }
@@ -5470,6 +5490,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       if (cancelled) return;
       try {
         const spaceIds = getSpaceIds();
+        // Master keys + this device's inbox tag for the per-space announce-keys
+        // broadcast (self-healing for receivers that missed a prior announce).
+        const [annPriv, annPub, annDeviceKeyset] = await Promise.all([
+          getPrivateKey(),
+          getPublicKey(),
+          getDeviceKeyset(),
+        ]);
+        const announceMaster =
+          annPriv && annPub ? { privateKeyHex: annPriv, publicKeyHex: annPub } : null;
+        const announceDeviceInbox = annDeviceKeyset?.inboxAddress;
         for (const spaceId of spaceIds) {
           if (cancelled) break;
           const hubKey = getSpaceKey(spaceId, 'hub');
@@ -5494,6 +5524,20 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             await requestLogSince(hubKey.address, lastSeq);
           } catch (e) {
             logger.warn('[hub-log] log-since build failed', e);
+          }
+          // Re-announce this device's per-space signing key. Idempotent,
+          // fire-and-forget; behaviour-neutral until the flip is live.
+          if (announceMaster && announceDeviceInbox) {
+            try {
+              const frame = await buildAnnounceKeysFrame(
+                spaceId,
+                announceMaster,
+                announceDeviceInbox
+              );
+              if (frame) enqueueOutbound(async () => [frame]);
+            } catch (e) {
+              logger.warn('[DeviceKeys] announce build failed', e);
+            }
           }
         }
       } catch (e) {

--- a/services/config/spaceSyncService.ts
+++ b/services/config/spaceSyncService.ts
@@ -84,41 +84,14 @@ export async function syncSpaceFromConfig(
   // Check if space already exists locally
   const existingSpace = getSpace(spaceId);
   if (existingSpace) {
-    // Heal path: a space synced before the signing-key split has only its
-    // per-device (fresh) inbox key, whose signatures no receiver's member
-    // table can resolve — so control messages (delete/edit/mute/…) from this
-    // device get dropped fleet-wide. When another device has since published
-    // the original join-bound keypair under 'signing', adopt it.
-    //
-    // Adoption rule: a key this device holds with 'origin' provenance (its
-    // own create/join flow — provably correct) is NEVER replaced. Anything
-    // else ('promoted' = migration guess that misfires on pre-split synced
-    // devices, 'adopted', or unmarked) yields to the blob, so a device that
-    // wrongly self-promoted converges to the join device's published key as
-    // soon as that device's config save reaches the blob.
-    // Best-effort: storage failures are swallowed and the whole block re-runs
-    // on the next config receive; all steps are idempotent.
+    // Heal path (Option A): no longer ADOPTS the shared join key from the blob.
+    // A device without a `signing` slot (fresh second device) signs with its own
+    // per-device `inbox` key and announces it via announce-keys; a device that
+    // already holds a `signing` slot keeps it (getSpaceSigningKey reads
+    // `signing ?? inbox`), so existing setups don't regress. The only heal still
+    // done here: re-anchor the self member row to the signing identity when they
+    // disagree. Best-effort + idempotent; re-runs on every config receive.
     try {
-      const localSigning = getSpaceKey(spaceId, 'signing');
-      if (!localSigning || localSigning.provenance !== 'origin') {
-        const payloadSigning = keys.find((k) => k.keyId === 'signing');
-        if (
-          payloadSigning?.privateKey &&
-          payloadSigning.publicKey &&
-          payloadSigning.publicKey !== localSigning?.publicKey
-        ) {
-          saveSpaceKey({
-            spaceId,
-            keyId: 'signing',
-            address:
-              payloadSigning.address ??
-              deriveAddress(Uint8Array.from(hexToBytes(payloadSigning.publicKey))),
-            publicKey: payloadSigning.publicKey,
-            privateKey: payloadSigning.privateKey,
-            provenance: 'adopted',
-          });
-        }
-      }
       // Re-anchor the local self member row to the signing identity whenever
       // they disagree — the pre-split sync bound it to this device's fresh
       // mailbox key, which breaks resolving the user's OTHER devices'
@@ -154,17 +127,17 @@ export async function syncSpaceFromConfig(
       return false;
     }
 
-    // Save all keys first. A payload 'signing' key is marked 'adopted' (came
-    // from the blob, replaceable if the blob later offers a different one);
-    // provenance is a local-only field, never serialized back into the blob.
+    // Save all keys first. Per-device-signing flip (Option A): skip the shared
+    // `signing` key so a fresh device falls through to its own per-device
+    // `inbox` key (getSpaceSigningKey = signing ?? inbox) and announces it.
     for (const key of keys) {
+      if (key.keyId === 'signing') continue;
       saveSpaceKey({
         spaceId: key.spaceId,
         keyId: key.keyId,
         address: key.address,
         publicKey: key.publicKey,
         privateKey: key.privateKey,
-        ...(key.keyId === 'signing' ? { provenance: 'adopted' as const } : {}),
       });
     }
 
@@ -283,14 +256,10 @@ export async function syncSpaceFromConfig(
     }
 
     // Save inbox key — the per-device MAILBOX key (hub registration + WS
-    // listen + inbox deletion). This deliberately overwrites the payload's
-    // 'inbox' entry (another device's mailbox, useless here). It is NOT the
-    // signing identity: that is the 'signing' key the payload loop saved
-    // above — the join-bound keypair every receiver's member table resolves
-    // signatures against. Pre-split payloads have no 'signing' entry; then
-    // this device signs with this fresh key via the getSpaceSigningKey
-    // fallback and control messages stay broken until a device holding the
-    // original promotes it (see promoteSpaceSigningKeys in configService).
+    // listen + inbox deletion), overwriting the payload's 'inbox' entry
+    // (another device's mailbox). Post-flip (Option A) this fresh key is ALSO
+    // this device's signing key: getSpaceSigningKey falls through to it, and
+    // announce-keys admits it on receivers.
     saveSpaceKey({
       spaceId,
       keyId: 'inbox',

--- a/services/space/deviceKeyStatements.ts
+++ b/services/space/deviceKeyStatements.ts
@@ -1,0 +1,183 @@
+/*
+ * Per-device space signing keys — master-signed announce/revoke statements.
+ *
+ * Multi-device breaks the single-key verified-signer model: a second device
+ * signs with its own per-space key, which no receiver's member table has seen,
+ * so its control messages are dropped. The durable fix admits MULTIPLE signing
+ * keys per member — one per device — but only inside a statement signed by the
+ * user's MASTER identity key (whose hash IS the user_address already in every
+ * member row). Mirrors desktop MessageService (PR #245 receive, #249 send).
+ *
+ * Canonical bytes + verify come from shared (deviceKeys.ts) so desktop and
+ * mobile sign/verify byte-identical. Statements never touch the member row's
+ * join binding — admissions live in their own MMKV store.
+ */
+
+import {
+  buildDeviceKeyStatementBytes,
+  deriveInboxAddress,
+  hexToBytes,
+  verifyDeviceKeyStatement,
+  type AnnounceKeysStatement,
+  type DeviceKeyStatement,
+  type RevokeDeviceStatement,
+} from '@quilibrium/quorum-shared';
+import { base64ToHex } from '../../utils/encoding';
+import { NativeCryptoProvider } from '../crypto/native-provider';
+import { NativeSigningProvider } from '../crypto/native-signing-provider';
+import { getSpaceKey, getSpaceSigningKey } from '../config/spaceStorage';
+import { getMMKVAdapter } from '../storage/mmkvAdapter';
+
+export interface MasterKeys {
+  privateKeyHex: string;
+  publicKeyHex: string;
+}
+
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  for (let i = 0; i < bytes.length; i++) binary += String.fromCharCode(bytes[i]);
+  return btoa(binary);
+}
+
+function hexToNumberArray(hex: string): number[] {
+  return Array.from(hexToBytes(hex));
+}
+
+/**
+ * Master-sign a statement over the canonical shared bytes (never the JSON
+ * envelope). Returns the hex signature.
+ */
+async function signStatement(
+  statement: DeviceKeyStatement,
+  privateKeyHex: string
+): Promise<string> {
+  const bytes = buildDeviceKeyStatementBytes(statement);
+  const messageBase64 = bytesToBase64(new TextEncoder().encode(bytes));
+  const privateKeyBase64 = bytesToBase64(Uint8Array.from(hexToBytes(privateKeyHex)));
+  const sigBase64 = await new NativeCryptoProvider().signEd448(
+    privateKeyBase64,
+    messageBase64
+  );
+  return base64ToHex(sigBase64);
+}
+
+/** Seal a control statement as a hub-log frame (mirrors sendJoinMessage). */
+async function sealControlFrame(
+  spaceId: string,
+  statement: DeviceKeyStatement
+): Promise<string | null> {
+  const hubKey = getSpaceKey(spaceId, 'hub');
+  if (!hubKey?.address || !hubKey.privateKey || !hubKey.publicKey) return null;
+  const configKey = getSpaceKey(spaceId, 'config');
+
+  const sealed = await new NativeCryptoProvider().sealHubEnvelope(
+    hubKey.address,
+    {
+      publicKey: hexToNumberArray(hubKey.publicKey),
+      privateKey: hexToNumberArray(hubKey.privateKey),
+    },
+    JSON.stringify({ type: 'control', message: statement }),
+    configKey
+      ? {
+          publicKey: hexToNumberArray(configKey.publicKey),
+          privateKey: hexToNumberArray(configKey.privateKey),
+        }
+      : undefined
+  );
+  return JSON.stringify({ type: 'log-append', ...sealed });
+}
+
+/**
+ * Build the announce-keys frame for one space: announces the key this device
+ * actually signs with (getSpaceSigningKey = signing ?? inbox). Returns the
+ * ws frame to enqueue, or null if the space has no signing key / no device tag.
+ */
+export async function buildAnnounceKeysFrame(
+  spaceId: string,
+  master: MasterKeys,
+  deviceInboxAddress: string
+): Promise<string | null> {
+  const signingKey = getSpaceSigningKey(spaceId);
+  if (!signingKey?.publicKey || !deviceInboxAddress) return null;
+
+  const statement: AnnounceKeysStatement = {
+    type: 'announce-keys',
+    userAddress: deriveInboxAddress(master.publicKeyHex),
+    userPublicKey: master.publicKeyHex,
+    spaceId,
+    deviceInboxAddress,
+    spaceKeyPublicKey: signingKey.publicKey,
+    timestamp: Date.now(),
+    signature: '',
+  };
+  statement.signature = await signStatement(statement, master.privateKeyHex);
+  return sealControlFrame(spaceId, statement);
+}
+
+/**
+ * Build revoke-device frames for each removed device across the given spaces.
+ * One master-signed tombstone per (space, device).
+ */
+export async function buildRevokeDeviceFrames(
+  spaceIds: string[],
+  deviceInboxAddresses: string[],
+  master: MasterKeys
+): Promise<string[]> {
+  const frames: string[] = [];
+  const userAddress = deriveInboxAddress(master.publicKeyHex);
+  for (const spaceId of spaceIds) {
+    for (const deviceInboxAddress of deviceInboxAddresses) {
+      const statement: RevokeDeviceStatement = {
+        type: 'revoke-device',
+        userAddress,
+        userPublicKey: master.publicKeyHex,
+        spaceId,
+        deviceInboxAddress,
+        timestamp: Date.now(),
+        signature: '',
+      };
+      statement.signature = await signStatement(statement, master.privateKeyHex);
+      const frame = await sealControlFrame(spaceId, statement);
+      if (frame) frames.push(frame);
+    }
+  }
+  return frames;
+}
+
+/**
+ * Receive an announce-keys / revoke-device statement. Verifies via shared
+ * (master-signed, self-certifying id, 30s skew, LWW) and persists the admission
+ * or a tombstone. Fails closed. Never writes the member row.
+ */
+export async function processDeviceKeyStatement(
+  statement: DeviceKeyStatement,
+  contextSpaceId: string
+): Promise<void> {
+  // Only honor a statement meant for the space whose hub delivered it.
+  if (statement.spaceId !== contextSpaceId) return;
+
+  const adapter = getMMKVAdapter();
+  const existing = await adapter.getSpaceMemberDevice(
+    statement.spaceId,
+    statement.deviceInboxAddress
+  );
+  const verdict = await verifyDeviceKeyStatement(
+    new NativeSigningProvider(),
+    statement,
+    existing ? { timestamp: existing.timestamp, revoked: !!existing.revoked } : undefined
+  );
+
+  if (verdict.action === 'admit') {
+    await adapter.saveSpaceMemberDevice(verdict.device);
+  } else if (verdict.action === 'revoke') {
+    await adapter.saveSpaceMemberDevice({
+      spaceId: verdict.spaceId,
+      userAddress: verdict.userAddress,
+      deviceInboxAddress: verdict.deviceInboxAddress,
+      inboxAddress: existing?.inboxAddress ?? '',
+      spaceKeyPublicKey: existing?.spaceKeyPublicKey ?? '',
+      timestamp: verdict.timestamp,
+      revoked: true,
+    });
+  }
+}

--- a/services/space/deviceKeyStatements.ts
+++ b/services/space/deviceKeyStatements.ts
@@ -17,6 +17,7 @@ import {
   buildDeviceKeyStatementBytes,
   deriveInboxAddress,
   hexToBytes,
+  logger,
   verifyDeviceKeyStatement,
   type AnnounceKeysStatement,
   type DeviceKeyStatement,
@@ -179,5 +180,12 @@ export async function processDeviceKeyStatement(
       timestamp: verdict.timestamp,
       revoked: true,
     });
+  } else if (verdict.reason !== 'stale') {
+    // Only surface GENUINE verification failures. `stale` is normal LWW dedup —
+    // hub-log replays every prior announce on each connect, so the same statement
+    // is re-seen constantly; logging those would drown the console.
+    logger.warn(
+      `[DeviceKeys] rejected ${statement?.type} reason=${verdict.reason} space=${contextSpaceId.slice(0, 12)}`
+    );
   }
 }

--- a/services/space/spaceMessageAuth.ts
+++ b/services/space/spaceMessageAuth.ts
@@ -33,6 +33,7 @@ import {
   deriveInboxAddress,
   hexToBytes,
   isControlMessageType,
+  logger,
   resolveVerifiedSender,
   type Channel,
   type ControlMessageContent,
@@ -137,7 +138,21 @@ export async function resolveVerifiedSpaceSender(
   const memberList = members ?? (await adapter.getSpaceMembers(spaceId));
   // Also admit per-device signing keys announced via master-signed statements.
   const deviceKeys = await adapter.getSpaceMemberDevices(spaceId);
-  return resolveVerifiedSender(publicKey, memberList, deviceKeys);
+  const resolved = resolveVerifiedSender(publicKey, memberList, deviceKeys);
+  // Diagnostic: flag when a signer resolved via a per-device key rather than the
+  // member join binding (rollout monitoring; remove at cleanup).
+  if (resolved) {
+    const signingAddr = deriveInboxAddress(publicKey);
+    const viaMember = memberList.some(
+      (m) => m.inbox_address === signingAddr && !(m as { isKicked?: boolean }).isKicked
+    );
+    if (!viaMember) {
+      logger.log(
+        `[DeviceKeys] signature accepted via per-device key signingAddr=${signingAddr.slice(0, 12)} sender=${String(resolved).slice(0, 12)}`
+      );
+    }
+  }
+  return resolved;
 }
 
 /**

--- a/services/space/spaceMessageAuth.ts
+++ b/services/space/spaceMessageAuth.ts
@@ -133,9 +133,11 @@ export async function resolveVerifiedSpaceSender(
 ): Promise<VerifiedSender | null> {
   const publicKey = await verifySpaceMessageSignature(message, spaceId);
   if (!publicKey) return null;
-  const memberList =
-    members ?? (await getMMKVAdapter().getSpaceMembers(spaceId));
-  return resolveVerifiedSender(publicKey, memberList);
+  const adapter = getMMKVAdapter();
+  const memberList = members ?? (await adapter.getSpaceMembers(spaceId));
+  // Also admit per-device signing keys announced via master-signed statements.
+  const deviceKeys = await adapter.getSpaceMemberDevices(spaceId);
+  return resolveVerifiedSender(publicKey, memberList, deviceKeys);
 }
 
 /**

--- a/services/storage/mmkvAdapter.ts
+++ b/services/storage/mmkvAdapter.ts
@@ -16,6 +16,7 @@ import type {
   Conversation,
   UserConfig,
   SpaceMember,
+  SpaceMemberDevice,
 } from '@quilibrium/quorum-shared';
 
 // Key prefixes for organized storage.
@@ -29,6 +30,7 @@ const KEYS = {
   CONVERSATION: (id: string) => `conversation:${id}`,
   USER_CONFIG: (address: string) => `userConfig:${address}`,
   SPACE_MEMBERS: (spaceId: string) => `spaceMembers:${spaceId}`,
+  SPACE_MEMBER_DEVICES: (spaceId: string) => `spaceMemberDevices:${spaceId}`,
   SYNC_TIME: (key: string) => `sync:${key}`,
 } as const;
 
@@ -240,6 +242,36 @@ export class MMKVAdapter implements StorageAdapter {
     }
     storage.set(KEYS.SPACE_MEMBERS(spaceId), JSON.stringify(members));
     this.memberIndexCache.delete(spaceId);
+  }
+
+  // Per-device signing-key admissions (mirrors desktop's space_member_devices
+  // store). Keyed by (spaceId, deviceInboxAddress); one JSON array per space.
+  // Never touches the member row's join binding.
+
+  async getSpaceMemberDevices(spaceId: string): Promise<SpaceMemberDevice[]> {
+    const data = storage.getString(KEYS.SPACE_MEMBER_DEVICES(spaceId));
+    return data ? JSON.parse(data) : [];
+  }
+
+  async getSpaceMemberDevice(
+    spaceId: string,
+    deviceInboxAddress: string
+  ): Promise<SpaceMemberDevice | undefined> {
+    const devices = await this.getSpaceMemberDevices(spaceId);
+    return devices.find((d) => d.deviceInboxAddress === deviceInboxAddress);
+  }
+
+  async saveSpaceMemberDevice(device: SpaceMemberDevice): Promise<void> {
+    const devices = await this.getSpaceMemberDevices(device.spaceId);
+    const idx = devices.findIndex(
+      (d) => d.deviceInboxAddress === device.deviceInboxAddress
+    );
+    if (idx >= 0) devices[idx] = device;
+    else devices.push(device);
+    storage.set(
+      KEYS.SPACE_MEMBER_DEVICES(device.spaceId),
+      JSON.stringify(devices)
+    );
   }
 
   // Sync Metadata


### PR DESCRIPTION
## What

Mobile side of **per-device space signing keys** — mirrors the merged desktop work (desktop #245 receive, #249 send). Multi-device control ops (delete/edit/pin/mute, @everyone, update-profile) now attribute to **per-device** keys admitted via master-signed statements, instead of a shared copied signing key.

**Do not merge/deploy yet — validate the cross-device flow via the UI first** (this is the whole point of the PR: exercise desktop↔mobile per-device attribution end to end). Behaviour-neutral for single-device users.

## How (mirrors desktop)

- **`services/space/deviceKeyStatements.ts`** (new) — master-signed `announce-keys` / `revoke-device` statements. Canonical bytes come from shared `buildDeviceKeyStatementBytes`, so mobile and desktop sign/verify **byte-identical** (a serialization drift would fail signatures silently — covered by a test). `processDeviceKeyStatement` verifies + stores an admission or a tombstone; never writes the member row.
- **`services/storage/mmkvAdapter.ts`** — new `space_member_devices` MMKV store (get / getOne / save).
- **`services/space/spaceMessageAuth.ts`** — `resolveVerifiedSpaceSender` passes stored admissions as the 3rd arg to shared `resolveVerifiedSender`, so a per-device key resolves to its member.
- **`context/WebSocketContext.tsx`** — `announce-keys` / `revoke-device` control handlers + an on-connect `announce-keys` broadcast per space (idempotent, self-healing).
- **`services/config/spaceSyncService.ts`** — **Option A**: config sync no longer adopts the shared `signing` slot (both the heal path and the new-space key-save loop). A fresh device therefore signs with its own per-device `inbox` key and announces it. `getSpaceSigningKey` read (`signing ?? inbox`) is **unchanged**, so devices that already hold a `signing` slot don't regress.
- **`components/ProfileModal.tsx`** — `handleRemoveDevice` broadcasts `revoke-device` across every space for the removed device.

## Option A rationale

The correctness bug (2nd-device control ops dropped) is already fixed by the interim shared-key approach. This is the durable security upgrade (per-device revocation, no key copying, attribution). Option A = don't disturb working setups: existing devices keep the shared key; only fresh device setups go per-device. Matches the desktop decision.

## Tests

8 new unit tests in `__tests__/deviceKeyStatements.test.ts` (frame shape, cross-platform byte-identity of the signed payload, admit / revoke / space-scope). Full suite **36/36**. `tsc` adds 0 new errors (21 pre-existing, unrelated); lint 0 errors.

## Review notes

- Independent security-focused code review (incl. an iOS pass, since the dev tests Android only): **no critical/high findings**. Signing byte-identity, Option A stability (no path re-adopts the slot), revoke wiring, and the `ProfileModal` async flow all confirmed. The one fix it raised (a stale comment in `spaceSyncService`) is applied.
- **Known, desktop-parity behaviour (not introduced here):** a `revoke-device` for a device never seen in a space leaves a hollow tombstone row, and `MAX_DEVICES_PER_MEMBER` (shared, =10) is not enforced on either platform. Both are tracked by the announce-keys flooding note in the desktop task's bug folder; worth the lead's awareness.
