### PR TITLE
fix: DM receive and session resilience

### DIFF
--- a/__tests__/confirmSenderSession.test.ts
+++ b/__tests__/confirmSenderSession.test.ts
@@ -1,0 +1,145 @@
+/**
+ * confirmSenderSession — mobile port of the SDK's
+ * ConfirmDoubleRatchetSenderSession. The crypto calls are existing primitives
+ * (mocked here); what these tests pin is the NEW logic: the guards, the SDK
+ * field validation, and the confirmed-state bookkeeping.
+ */
+
+const mockStore = new Map<string, Record<string, unknown>>();
+const mockKey = (c: string, i: string) => `${c}::${i}`;
+
+const mockSaveEncryptionState = jest.fn(
+  (s: { conversationId: string; inboxId: string }) => {
+    mockStore.set(mockKey(s.conversationId, s.inboxId), s);
+  },
+);
+const mockSaveInboxMapping = jest.fn();
+
+jest.mock('../services/crypto/encryption-state-storage', () => ({
+  encryptionStateStorage: {
+    getEncryptionState: (c: string, i: string) => mockStore.get(mockKey(c, i)) ?? null,
+    saveEncryptionState: (s: { conversationId: string; inboxId: string }) => mockSaveEncryptionState(s),
+    saveInboxMapping: (inbox: string, conv: string) => mockSaveInboxMapping(inbox, conv),
+  },
+}));
+
+jest.mock('../services/onboarding/keyService', () => ({
+  deriveAddress: jest.fn(() => 'addr'),
+}));
+
+let mockDecryptImpl: (arg: { ratchet_state: string; envelope: string }) => Promise<{
+  ratchet_state: string;
+  message: number[];
+  decryptionError?: string;
+}>;
+jest.mock('../services/crypto/native-provider', () => ({
+  NativeCryptoProvider: class {
+    doubleRatchetDecrypt(arg: { ratchet_state: string; envelope: string }) {
+      return mockDecryptImpl(arg);
+    }
+  },
+}));
+
+import { encryptionService } from '../services/crypto/encryption-service';
+
+const CONV = 'QmPeer/QmPeer';
+const INBOX = 'QmOurConversationInbox';
+
+const textEncoder = new TextEncoder();
+const okDecrypt = async () => ({
+  ratchet_state: 'advanced-state',
+  message: Array.from(textEncoder.encode('{"messageId":"m1"}')),
+});
+
+function seedUnconfirmed() {
+  mockStore.set(mockKey(CONV, INBOX), {
+    state: 'ratchet-0',
+    timestamp: 1,
+    conversationId: CONV,
+    inboxId: INBOX,
+    sentAccept: false,
+    sendingInbox: {
+      inbox_address: 'QmPeerDeviceInbox',
+      inbox_encryption_key: 'enckey',
+      inbox_public_key: '', // UNCONFIRMED
+      inbox_private_key: '',
+    },
+    tag: INBOX,
+  });
+}
+
+const fullEnvelope = {
+  user_address: 'QmPeer',
+  display_name: 'Peer',
+  return_inbox_address: 'QmPeerReturnInbox',
+  return_inbox_encryption_key: 'peer-enc-key',
+  return_inbox_public_key: 'peer-signing-pub',
+  return_inbox_private_key: 'peer-signing-priv',
+  identity_public_key: 'idpub',
+  tag: 'QmPeerReturnInbox',
+  message: 'inner-dr-envelope',
+  type: 'direct',
+} as never;
+
+beforeEach(() => {
+  mockStore.clear();
+  mockSaveEncryptionState.mockClear();
+  mockSaveInboxMapping.mockClear();
+  mockDecryptImpl = okDecrypt;
+});
+
+describe('confirmSenderSession', () => {
+  it('returns null when no state exists for the inbox', async () => {
+    const res = await encryptionService.confirmSenderSession(CONV, INBOX, fullEnvelope);
+    expect(res).toBeNull();
+    expect(mockSaveEncryptionState).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the session is already confirmed', async () => {
+    seedUnconfirmed();
+    const st = mockStore.get(mockKey(CONV, INBOX))!;
+    (st.sendingInbox as Record<string, string>).inbox_public_key = 'already-set';
+    const res = await encryptionService.confirmSenderSession(CONV, INBOX, fullEnvelope);
+    expect(res).toBeNull();
+    expect(mockSaveEncryptionState).not.toHaveBeenCalled();
+  });
+
+  it('returns null (state untouched) when the envelope is missing a required field', async () => {
+    seedUnconfirmed();
+    const partial = { ...(fullEnvelope as object), return_inbox_private_key: '' } as never;
+    const res = await encryptionService.confirmSenderSession(CONV, INBOX, partial);
+    expect(res).toBeNull();
+    expect(mockSaveEncryptionState).not.toHaveBeenCalled();
+    expect((mockStore.get(mockKey(CONV, INBOX))!.sendingInbox as Record<string, string>).inbox_public_key).toBe('');
+  });
+
+  it('returns null and keeps the session on decrypt failure (Signal rule)', async () => {
+    seedUnconfirmed();
+    mockDecryptImpl = async () => ({ ratchet_state: 'x', message: [], decryptionError: 'aead' });
+    const res = await encryptionService.confirmSenderSession(CONV, INBOX, fullEnvelope);
+    expect(res).toBeNull();
+    expect(mockSaveEncryptionState).not.toHaveBeenCalled();
+    expect(mockStore.get(mockKey(CONV, INBOX))!.state).toBe('ratchet-0');
+  });
+
+  it('confirms on success: full sendingInbox, sentAccept true, tag + mapping saved', async () => {
+    seedUnconfirmed();
+    const res = await encryptionService.confirmSenderSession(CONV, INBOX, fullEnvelope);
+    expect(res).not.toBeNull();
+    expect(res!.message).toBe('{"messageId":"m1"}');
+
+    expect(mockSaveEncryptionState).toHaveBeenCalledTimes(1);
+    const saved = mockSaveEncryptionState.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved.sentAccept).toBe(true);
+    expect(saved.state).toBe('advanced-state');
+    expect(saved.inboxId).toBe(INBOX); // keyed under OUR receiving inbox
+    expect(saved.tag).toBe('QmPeerReturnInbox');
+    expect(saved.sendingInbox).toEqual({
+      inbox_address: 'QmPeerReturnInbox',
+      inbox_encryption_key: 'peer-enc-key',
+      inbox_public_key: 'peer-signing-pub',
+      inbox_private_key: 'peer-signing-priv',
+    });
+    expect(mockSaveInboxMapping).toHaveBeenCalledWith('QmPeerReturnInbox', CONV);
+  });
+});

--- a/__tests__/initEnvelopeGuard.test.ts
+++ b/__tests__/initEnvelopeGuard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Staleness rules for Double Ratchet init envelopes (pure logic).
+ * Mirrors the desktop guard's semantics: a redelivered or zombie init
+ * envelope must be refused so it cannot replace a newer session.
+ */
+
+import {
+  isStaleInitEnvelope,
+  INIT_ENVELOPE_STALENESS_TOLERANCE_MS,
+} from '../services/crypto/initEnvelopeGuard';
+
+const T = 1_750_000_000_000; // arbitrary base timestamp
+
+describe('isStaleInitEnvelope', () => {
+  it('rule 1: no existing timestamps → not stale (first init)', () => {
+    expect(isStaleInitEnvelope(T, [])).toBe(false);
+  });
+
+  it('rule 2: exact timestamp match → stale (redelivery of a processed envelope)', () => {
+    expect(isStaleInitEnvelope(T, [T])).toBe(true);
+    expect(isStaleInitEnvelope(T, [T - 5_000, T, T + 5_000])).toBe(true);
+  });
+
+  it('rule 3: older than newest row beyond tolerance → stale (zombie)', () => {
+    const newest = T;
+    const zombie = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS - 1;
+    expect(isStaleInitEnvelope(zombie, [newest])).toBe(true);
+    // Months-old zombie (the live-observed case)
+    expect(isStaleInitEnvelope(newest - 60 * 24 * 60 * 60 * 1000, [newest])).toBe(true);
+  });
+
+  it('within skew tolerance → NOT stale (clock-domain skew absorbed)', () => {
+    const newest = T;
+    const slightlyOlder = newest - INIT_ENVELOPE_STALENESS_TOLERANCE_MS + 1;
+    expect(isStaleInitEnvelope(slightlyOlder, [newest])).toBe(false);
+  });
+
+  it('genuinely newer envelope (session reset) → NOT stale', () => {
+    expect(isStaleInitEnvelope(T + 10_000, [T - 50_000, T])).toBe(false);
+  });
+
+  it('respects a custom tolerance', () => {
+    const newest = T;
+    expect(isStaleInitEnvelope(newest - 1_500, [newest], 1_000)).toBe(true);
+    expect(isStaleInitEnvelope(newest - 500, [newest], 1_000)).toBe(false);
+  });
+});

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2722,11 +2722,31 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // Returns null if decryption fails (expected for multi-device)
             const sessionResult = await encryptionService.initializeRecipientSession(
               unsealed,
-              message.inboxAddress  // Our device inbox where we received this init
+              message.inboxAddress,  // Our device inbox where we received this init
+              message.timestamp
             );
 
+            if (sessionResult === 'stale') {
+              // Redelivered/zombie init envelope refused by the staleness
+              // guard — installing it would replace the current session with
+              // a ratchet the sender no longer holds. Delete it server-side
+              // so it cannot be redelivered (defuse the mine), keep the
+              // current session.
+              logger.warn('[stale-init] refused zombie init envelope (device inbox)', JSON.stringify({
+                inbox: message.inboxAddress?.slice(0, 10),
+                ts: message.timestamp,
+                ageSec: Math.round((Date.now() - message.timestamp) / 1000),
+              }));
+              getDeviceKeyset().then(dk => {
+                if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+              });
+              return;
+            }
             if (!sessionResult) {
-              // Decryption failed - message was likely for a different device
+              // Decryption failed - message was likely for a different device.
+              // Count toward the bounded-retry skip-list so an undecryptable
+              // init envelope can't replay through this path unbounded.
+              recordInboxAttempt(message.inboxAddress, message.timestamp);
               return;
             }
 
@@ -2899,11 +2919,30 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     // Returns null if decryption fails (expected for multi-device)
                     const sessionResult = await encryptionService.initializeRecipientSession(
                       unsealed,
-                      message.inboxAddress  // Our conversation inbox where we received this
+                      message.inboxAddress,  // Our conversation inbox where we received this
+                      message.timestamp
                     );
 
+                    if (sessionResult === 'stale') {
+                      // Redelivered/zombie init envelope refused by the
+                      // staleness guard — see the device-inbox twin above.
+                      logger.warn('[stale-init] refused zombie init envelope (conversation inbox)', JSON.stringify({
+                        inbox: message.inboxAddress?.slice(0, 10),
+                        ts: message.timestamp,
+                        ageSec: Math.round((Date.now() - message.timestamp) / 1000),
+                      }));
+                      if (conversationKeypair.signingPrivateKey && conversationKeypair.signingPublicKey) {
+                        const signingKey = {
+                          publicKey: bytesToHex(conversationKeypair.signingPublicKey),
+                          privateKey: bytesToHex(conversationKeypair.signingPrivateKey),
+                        };
+                        deleteConversationInboxMessages(message.inboxAddress, [message.timestamp], signingKey).catch(() => {});
+                      }
+                      return;
+                    }
                     if (!sessionResult) {
                       // Decryption failed - message was likely for a different device
+                      recordInboxAttempt(message.inboxAddress, message.timestamp);
                       return;
                     }
 
@@ -3595,7 +3634,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         const isDoubleRatchetEnvelope = envelopeData && 'protocol_identifier' in envelopeData;
         const isInitEnvelope = envelopeData && 'ciphertext' in envelopeData && 'initialization_vector' in envelopeData;
 
-        // Both DR and init envelopes on device inbox go through native batch
+        if (isInitEnvelope) {
+          // Init envelopes install/replace Double Ratchet sessions, so they
+          // must pass the staleness guard in initializeRecipientSession —
+          // which only the JS path runs (the native batch writes session
+          // state to MMKV directly, bypassing any JS-side check). Routing
+          // them here also keeps init-heavy hoards out of the native call,
+          // the known freeze trigger the batch watchdog guards against.
+          nonBatchMessages.push(msg);
+          continue;
+        }
+
+        // DR envelopes on device inbox go through native batch
         const groupKey = `device_inbox:${msg.inboxAddress}`;
         if (!dmGroupMap.has(groupKey)) {
           // Gather all DR states for this inbox

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -170,6 +170,10 @@ function shortAddr(address: string | undefined): string {
 // [RECEIPT-DIAG] temp, revert before PR — log each failing envelope once, not per redelivery
 const receiptDiagLogged = new Set<string>();
 
+// Envelopes already queued for server-side poison deletion this session (the
+// node may redeliver before the delete lands; don't re-request each reflood).
+const poisonDeletedKeys = new Set<string>();
+
 async function deleteInboxMessages(
   inboxAddress: string,
   timestamps: number[],
@@ -4988,11 +4992,27 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // Only DM-batch messages ever accrue attempts (see the result/timeout
       // handling below), so nothing else can ever be poisoned here.
       let poisonSkippedThisBatch = 0; // [CATCHUP-DIAG]
+      // Poisoned envelopes that are ALSO old get deleted from the server so
+      // they stop re-downloading on every connect (the reflood that makes the
+      // drain minutes-slow). Double condition: poisoned (5 failed attempts, or
+      // ≥1 failure + 7 days old) AND >7 days old — nothing recent is ever
+      // deleted, so an envelope under active investigation can't be lost.
+      const poisonDeleteByInbox = new Map<string, number[]>();
       batch = batch.filter((m) => {
         const isHubLog = !!(m as { __logSeq?: number }).__logSeq;
         if (isHubLog) return true;
         if (isInboxEnvelopePoisoned(m.inboxAddress, m.timestamp)) {
           poisonSkippedThisBatch += 1; // [CATCHUP-DIAG]
+          const deleteKey = `${m.inboxAddress}:${m.timestamp}`;
+          if (
+            Date.now() - m.timestamp > 7 * 24 * 60 * 60 * 1000 &&
+            !poisonDeletedKeys.has(deleteKey)
+          ) {
+            poisonDeletedKeys.add(deleteKey);
+            const list = poisonDeleteByInbox.get(m.inboxAddress) ?? [];
+            list.push(m.timestamp);
+            poisonDeleteByInbox.set(m.inboxAddress, list);
+          }
           return false;
         }
         return true;
@@ -5003,6 +5023,24 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           `[poison-guard] skipped ${poisonSkippedThisBatch} dead DM envelope(s) this batch ` +
             `(cumulative ${catchupDiagRef.current.poisonSkipped})`,
         );
+      }
+      if (poisonDeleteByInbox.size > 0) {
+        // Best-effort, fire-and-forget: sign with the right key per inbox type.
+        poisonDeleteByInbox.forEach((timestamps, inboxAddress) => {
+          const convKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(inboxAddress);
+          if (convKeypair?.signingPrivateKey && convKeypair.signingPublicKey) {
+            const signingKey = {
+              publicKey: bytesToHex(convKeypair.signingPublicKey),
+              privateKey: bytesToHex(convKeypair.signingPrivateKey),
+            };
+            deleteConversationInboxMessages(inboxAddress, timestamps, signingKey).catch(() => {});
+          } else {
+            getDeviceKeyset().then(dk => {
+              if (dk) deleteInboxMessages(inboxAddress, timestamps, dk).catch(() => {});
+            });
+          }
+          logger.warn(`[poison-guard] deleting ${timestamps.length} dead envelope(s) >7d old from server inbox ${inboxAddress.slice(0, 10)}…`);
+        });
       }
 
       catchupDiagRef.current.drained += batch.length; // [CATCHUP-DIAG]

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -94,6 +94,7 @@ import {
   isInboxEnvelopePoisoned,
   recordInboxAttempt,
   clearInboxAttempt,
+  getInboxAttempts,
 } from '../services/space/inboxAttemptTracker';
 import { INIT_ENVELOPE_STALENESS_TOLERANCE_MS } from '../services/crypto/initEnvelopeGuard';
 import { getMMKVAdapter, getConversationSync } from '../services/storage/mmkvAdapter';
@@ -5006,6 +5007,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           const deleteKey = `${m.inboxAddress}:${m.timestamp}`;
           if (
             Date.now() - m.timestamp > 7 * 24 * 60 * 60 * 1000 &&
+            // ≥2 independent failed decrypt attempts: a single transient
+            // failure (e.g. keys not loaded yet at startup) is retried on the
+            // next pass, never deleted.
+            getInboxAttempts(m.inboxAddress, m.timestamp) >= 2 &&
             !poisonDeletedKeys.has(deleteKey)
           ) {
             poisonDeletedKeys.add(deleteKey);

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -420,6 +420,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const isProcessingQueueRef = useRef(false);
   const MESSAGE_PROCESS_DELAY_MS = 10; // 10ms delay between non-batch messages (brief yield to UI thread)
   const MAX_MESSAGE_QUEUE_SIZE = 2000;
+  // Above this queue depth, skip the per-message sleep so a catch-up
+  // backlog drains instead of accumulating toward the cap.
+  const FAST_DRAIN_THRESHOLD = 500;
   // Gate for verbose per-message / per-batch diagnostics. These build
   // JSON.stringify(batch.map(...)) payloads that are NEVER printed
   // (logger.debug sits below the logger's "log" minLevel), yet the
@@ -4906,8 +4909,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             await handleIncomingMessage(nonBatchMessages[i]);
           } catch { /* ignore */ }
 
-          // Brief yield between messages only if more work remains
-          if (i < nonBatchMessages.length - 1 || messageQueueRef.current.length > 0) {
+          // Brief yield between messages only if more work remains. Skipped
+          // while a large backlog waits (catch-up storms) — the per-message
+          // sleep starves the drain; the every-5 InteractionManager yield
+          // above still protects the UI thread.
+          if (
+            (i < nonBatchMessages.length - 1 || messageQueueRef.current.length > 0) &&
+            messageQueueRef.current.length < FAST_DRAIN_THRESHOLD
+          ) {
             await new Promise(resolve => setTimeout(resolve, MESSAGE_PROCESS_DELAY_MS));
           }
         }
@@ -5403,20 +5412,49 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     if (connectionState !== 'connected') return;
 
     let cancelled = false;
-    const inflight = new Set<string>(); // hubAddress with an in-flight log-since
+    const inflight = new Map<string, number>(); // hubAddress → request ts
+    const deferTimers = new Map<string, ReturnType<typeof setTimeout>>();
+    const LOG_SINCE_PAGE_SIZE = 200;
+    const INFLIGHT_TIMEOUT_MS = 30000;
+    const DEFER_RETRY_MS = 250;
 
     const requestLogSince = async (hubAddress: string, since: number) => {
-      if (cancelled || inflight.has(hubAddress)) return;
+      if (cancelled) return;
+      // Expire in-flight requests whose result never came back so they
+      // don't block this hub (or the depth budget below) forever.
+      const now = Date.now();
+      inflight.forEach((ts, hub) => {
+        if (now - ts > INFLIGHT_TIMEOUT_MS) inflight.delete(hub);
+      });
+      if (inflight.has(hubAddress)) return;
+      // Flow-control: if the queue plus every page already in flight could
+      // overflow the cap, defer — an overflow drop punches a seq gap that
+      // wedges the hub cursor into a refetch storm.
+      const projected =
+        messageQueueRef.current.length +
+        (inflight.size + 1) * LOG_SINCE_PAGE_SIZE;
+      if (projected > MAX_MESSAGE_QUEUE_SIZE) {
+        if (!deferTimers.has(hubAddress)) {
+          deferTimers.set(
+            hubAddress,
+            setTimeout(() => {
+              deferTimers.delete(hubAddress);
+              requestLogSince(hubAddress, since);
+            }, DEFER_RETRY_MS),
+          );
+        }
+        return;
+      }
       const space = getSpaceByHubAddress(hubAddress);
       if (!space) return;
       const hubKey = getSpaceKey(space.spaceId, 'hub');
       if (!hubKey?.address || !hubKey.privateKey || !hubKey.publicKey) return;
-      inflight.add(hubAddress);
+      inflight.set(hubAddress, Date.now());
       try {
         const frame = await buildLogSinceFrame(
           { address: hubKey.address, publicKey: hubKey.publicKey, privateKey: hubKey.privateKey },
           since,
-          200,
+          LOG_SINCE_PAGE_SIZE,
         );
         enqueueOutbound(async () => [frame]);
       } catch {
@@ -5427,15 +5465,26 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     const ingestEntries = (
       hubAddress: string,
       entries: Array<{ seq: number; ts: number; payload: { ts: number; data: any } }>,
-    ) => {
+    ): { lastVisited: number | null; truncated: boolean } => {
       // Find which space this hub belongs to and its inbox address — the
       // existing decrypt path indexes by inbox address.
+      let lastVisited: number | null = null;
+      let truncated = false;
       const space = getSpaceByHubAddress(hubAddress);
-      if (!space) return;
+      if (!space) return { lastVisited, truncated };
       const inboxKey = getSpaceKey(space.spaceId, 'inbox');
-      if (!inboxKey?.address) return;
+      if (!inboxKey?.address) return { lastVisited, truncated };
 
       for (const entry of entries) {
+        if (messageQueueRef.current.length >= MAX_MESSAGE_QUEUE_SIZE) {
+          // Full: stop enqueuing this page instead of dropping older queued
+          // items. The contiguous head we did enqueue still advances the
+          // cursor; the caller refetches from lastVisited. Dropping oldest
+          // here punched the seq gap that wedged the cursor.
+          truncated = true;
+          break;
+        }
+        lastVisited = entry.seq;
         const sealedEnvelope = entry.payload?.data;
         if (!sealedEnvelope) continue;
         // Tag with __logSeq / __logHub so processMessageQueue can advance the
@@ -5450,17 +5499,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           __logHub: hubAddress,
         } as EncryptedWebSocketMessage & { __logSeq: number; __logHub: string };
 
-        if (messageQueueRef.current.length >= MAX_MESSAGE_QUEUE_SIZE) {
-          messageQueueRef.current.splice(
-            0,
-            messageQueueRef.current.length - MAX_MESSAGE_QUEUE_SIZE + 1,
-          );
-        }
         messageQueueRef.current.push(synthetic);
       }
       if (entries.length > 0) {
         processMessageQueue();
       }
+      return { lastVisited, truncated };
     };
 
     const unsubscribe = registerLogFrameHandler((frame) => {
@@ -5468,8 +5512,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       if (!hubAddress) return;
       if (frame.type === 'log-since-result') {
         inflight.delete(hubAddress);
-        ingestEntries(hubAddress, frame.entries);
-        if (frame.has_more && frame.entries.length > 0) {
+        const { lastVisited, truncated } = ingestEntries(hubAddress, frame.entries);
+        if (truncated) {
+          // Queue filled mid-page: refetch the tail we didn't enqueue.
+          // The flow-control gate defers this until the queue drains.
+          requestLogSince(hubAddress, lastVisited ?? getHubLastSeq(hubAddress));
+        } else if (frame.has_more && frame.entries.length > 0) {
           const last = frame.entries[frame.entries.length - 1].seq;
           requestLogSince(hubAddress, last);
         }
@@ -5548,6 +5596,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     return () => {
       cancelled = true;
       clearTimeout(setupTimeout);
+      deferTimers.forEach((t) => clearTimeout(t));
+      deferTimers.clear();
       unsubscribe();
     };
   }, [connectionState, registerLogFrameHandler, enqueueOutbound, processMessageQueue]);

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -175,6 +175,27 @@ const receiptDiagLogged = new Set<string>();
 // node may redeliver before the delete lands; don't re-request each reflood).
 const poisonDeletedKeys = new Set<string>();
 
+/**
+ * Best-effort ack-by-delete that signs with the key matching the inbox type.
+ * A conversation-inbox envelope deleted with the DEVICE key fails signature
+ * verification server-side and the envelope redelivers forever — observed as
+ * an endless storm of the same delivery/read acks starving fresh ones.
+ */
+function deleteProcessedEnvelope(inboxAddress: string, timestamp: number): void {
+  const convKeypair = encryptionStateStorage.getConversationInboxKeypairByAddress(inboxAddress);
+  if (convKeypair?.signingPrivateKey && convKeypair.signingPublicKey) {
+    const signingKey = {
+      publicKey: bytesToHex(convKeypair.signingPublicKey),
+      privateKey: bytesToHex(convKeypair.signingPrivateKey),
+    };
+    deleteConversationInboxMessages(inboxAddress, [timestamp], signingKey).catch(() => {});
+  } else {
+    getDeviceKeyset().then(dk => {
+      if (dk) deleteInboxMessages(inboxAddress, [timestamp], dk).catch(() => {});
+    });
+  }
+}
+
 async function deleteInboxMessages(
   inboxAddress: string,
   timestamps: number[],
@@ -581,17 +602,21 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
     if (raw.type === 'delivery-ack' || raw.type === 'read-ack') {
-      // [RECEIPT-DIAG] temp, revert before PR
-      logger.warn('[RECEIPT-DIAG] ack ARRIVED on mobile', JSON.stringify({
-        type: raw.type,
-        from: raw.senderId?.slice(0, 10),
-        self: self?.slice(0, 10),
-        partner: partner?.slice(0, 10),
-        selfEcho: raw.senderId === self,
-        gateDelivery: isReceiptEnabled('delivery', partner),
-        gateRead: isReceiptEnabled('read', partner),
-        hasSvc: !!svc,
-      }));
+      // [RECEIPT-DIAG] temp, revert before PR — once per unique ack (redeliveries silent)
+      const ackKey = `${raw.type}:${raw.senderId}:${raw.upToMessageId ?? (raw.messageIds ?? []).join(',')}`;
+      if (!receiptDiagLogged.has(ackKey)) {
+        receiptDiagLogged.add(ackKey);
+        logger.warn('[RECEIPT-DIAG] ack ARRIVED on mobile', JSON.stringify({
+          type: raw.type,
+          from: raw.senderId?.slice(0, 10),
+          self: self?.slice(0, 10),
+          partner: partner?.slice(0, 10),
+          selfEcho: raw.senderId === self,
+          gateDelivery: isReceiptEnabled('delivery', partner),
+          gateRead: isReceiptEnabled('read', partner),
+          hasSvc: !!svc,
+        }));
+      }
     }
     if (raw.type === 'delivery-ack') {
       if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
@@ -2773,9 +2798,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // this check they fell through toward persistence and receipts
             // never rendered on this path.
             if (handleDmReceipt(decryptedMessage, conversationId.split('/')[0])) {
-              getDeviceKeyset().then(dk => {
-                if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
-              });
+              deleteProcessedEnvelope(message.inboxAddress, message.timestamp);
               return;
             }
 
@@ -3102,9 +3125,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // DM receipts (before the self-echo guard): flat delivery/read-ack are
           // consumed here and never saved; normal messages buffer + strip acks.
           if (handleDmReceipt(decryptedMessage, conversationId.split('/')[0])) {
-            getDeviceKeyset().then(dk => {
-              if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
-            });
+            deleteProcessedEnvelope(message.inboxAddress, message.timestamp);
             return;
           }
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -423,6 +423,17 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // Above this queue depth, skip the per-message sleep so a catch-up
   // backlog drains instead of accumulating toward the cap.
   const FAST_DRAIN_THRESHOLD = 500;
+  // [CATCHUP-DIAG] temp counters, written to files/catchup-diag.json by the
+  // diag effect below so drain progress is readable over adb — revert before PR.
+  const catchupDiagRef = useRef({
+    liveIn: 0,
+    liveDropped: 0,
+    ingested: 0,
+    truncated: 0,
+    drained: 0,
+    inflight: 0,
+    defers: 0,
+  });
   // Gate for verbose per-message / per-batch diagnostics. These build
   // JSON.stringify(batch.map(...)) payloads that are NEVER printed
   // (logger.debug sits below the logger's "log" minLevel), yet the
@@ -4835,6 +4846,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // empty; see MAX_BATCH_DRAIN_SIZE for why this matters on small
       // devices.
       const batch = messageQueueRef.current.splice(0, MAX_BATCH_DRAIN_SIZE);
+      catchupDiagRef.current.drained += batch.length; // [CATCHUP-DIAG]
 
       try {
         // Classify messages and gather crypto state
@@ -5008,8 +5020,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     );
     // Backpressure: drop oldest messages if queue is overloaded
     if (messageQueueRef.current.length >= MAX_MESSAGE_QUEUE_SIZE) {
-      messageQueueRef.current.splice(0, messageQueueRef.current.length - MAX_MESSAGE_QUEUE_SIZE + 1);
+      const excess = messageQueueRef.current.length - MAX_MESSAGE_QUEUE_SIZE + 1;
+      messageQueueRef.current.splice(0, excess);
+      catchupDiagRef.current.liveDropped += excess; // [CATCHUP-DIAG]
     }
+    catchupDiagRef.current.liveIn += 1; // [CATCHUP-DIAG]
     messageQueueRef.current.push(message);
     // Start processing if not already in progress
     processMessageQueue();
@@ -5418,6 +5433,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     const INFLIGHT_TIMEOUT_MS = 30000;
     const DEFER_RETRY_MS = 250;
 
+    // [CATCHUP-DIAG]
+    const syncDiag = () => {
+      catchupDiagRef.current.inflight = inflight.size;
+      catchupDiagRef.current.defers = deferTimers.size;
+    };
+
     const requestLogSince = async (hubAddress: string, since: number) => {
       if (cancelled) return;
       // Expire in-flight requests whose result never came back so they
@@ -5443,6 +5464,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }, DEFER_RETRY_MS),
           );
         }
+        syncDiag(); // [CATCHUP-DIAG]
         return;
       }
       const space = getSpaceByHubAddress(hubAddress);
@@ -5460,6 +5482,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       } catch {
         inflight.delete(hubAddress);
       }
+      syncDiag(); // [CATCHUP-DIAG]
     };
 
     const ingestEntries = (
@@ -5482,11 +5505,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // cursor; the caller refetches from lastVisited. Dropping oldest
           // here punched the seq gap that wedged the cursor.
           truncated = true;
+          catchupDiagRef.current.truncated += 1; // [CATCHUP-DIAG]
           break;
         }
         lastVisited = entry.seq;
         const sealedEnvelope = entry.payload?.data;
         if (!sealedEnvelope) continue;
+        catchupDiagRef.current.ingested += 1; // [CATCHUP-DIAG]
         // Tag with __logSeq / __logHub so processMessageQueue can advance the
         // hub cursor only after persistence — see post-batch hook there.
         const synthetic = {
@@ -5512,6 +5537,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       if (!hubAddress) return;
       if (frame.type === 'log-since-result') {
         inflight.delete(hubAddress);
+        syncDiag(); // [CATCHUP-DIAG]
         const { lastVisited, truncated } = ingestEntries(hubAddress, frame.entries);
         if (truncated) {
           // Queue filled mid-page: refetch the tail we didn't enqueue.
@@ -5601,6 +5627,31 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       unsubscribe();
     };
   }, [connectionState, registerLogFrameHandler, enqueueOutbound, processMessageQueue]);
+
+  // [CATCHUP-DIAG] Write catch-up state to files/catchup-diag.json every 5s so
+  // drain progress is readable over adb (read-catchup-diag.ps1) — revert before PR.
+  useEffect(() => {
+    const id = setInterval(async () => {
+      try {
+        const { File, Paths } = await import('expo-file-system');
+        const cursors: Record<string, number> = {};
+        for (const spaceId of getSpaceIds()) {
+          const hub = getSpaceKey(spaceId, 'hub');
+          if (hub?.address) {
+            cursors[hub.address.slice(0, 8)] = getHubLastSeq(hub.address);
+          }
+        }
+        const payload = JSON.stringify({
+          updated: Date.now(),
+          queue: messageQueueRef.current.length,
+          ...catchupDiagRef.current,
+          cursors,
+        });
+        new File(Paths.document, 'catchup-diag.json').write(payload);
+      } catch { /* diag only */ }
+    }, 5000);
+    return () => clearInterval(id);
+  }, []);
 
   // On-connect catch-up is handled exclusively by the per-hub log effect
   // above — listen-hub + log-since fetches everything since the stored

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2877,7 +2877,26 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   const existingStates = encryptionStateStorage.getEncryptionStates(conversationId);
                   const hasExistingSession = existingStates.length > 0;
 
-                  if (hasExistingSession) {
+                  // === Session CONFIRMATION (SDK/desktop parity) ===
+                  // If this inbox holds an UNCONFIRMED sender session (we
+                  // initiated; sendingInbox pub key still ''), the peer's
+                  // first init-wrapped reply confirms it: fills the peer's
+                  // real return inbox + sets sentAccept, ending the
+                  // init-wrapping churn on both sides. Falls through to the
+                  // pre-existing paths whenever this isn't a confirm case.
+                  const confirmResult = await encryptionService.confirmSenderSession(
+                    conversationId,
+                    message.inboxAddress,
+                    unsealed
+                  );
+                  if (confirmResult) {
+                    logger.warn('[session-confirm] sender session CONFIRMED', JSON.stringify({
+                      conv: conversationId?.slice(0, 10),
+                      inbox: message.inboxAddress?.slice(0, 10),
+                    }));
+                    decryptedText = confirmResult.message;
+                    userProfileFromEnvelope = confirmResult.userProfile;
+                  } else if (hasExistingSession) {
                     // === Use existing session to decrypt ===
                     // The message is wrapped in InitEnvelope but we already have a session
                     // Try to decrypt with existing states (trial decryption)
@@ -2908,18 +2927,29 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
                     // IMPORTANT: Update sendingInbox from the InitEnvelope
                     // This tells us where to send future replies (the sender's return inbox)
-                    if (unsealed.return_inbox_address && unsealed.return_inbox_encryption_key) {
+                    // SDK-parity: only patch the sendingInbox when the envelope
+                    // carries the FULL field set (a partial envelope must not
+                    // half-confirm the session), store the private key too, and
+                    // mark sentAccept — semantically identical to
+                    // confirmSenderSession's save.
+                    if (
+                      unsealed.return_inbox_address &&
+                      unsealed.return_inbox_encryption_key &&
+                      unsealed.return_inbox_public_key &&
+                      unsealed.return_inbox_private_key
+                    ) {
                       const currentState = encryptionStateStorage.getEncryptionState(conversationId, successInboxId);
                       if (currentState) {
                         const updatedSendingInbox = {
                           inbox_address: unsealed.return_inbox_address,
                           inbox_encryption_key: unsealed.return_inbox_encryption_key,
-                          inbox_public_key: unsealed.return_inbox_public_key || '',
-                          inbox_private_key: '',
+                          inbox_public_key: unsealed.return_inbox_public_key,
+                          inbox_private_key: unsealed.return_inbox_private_key,
                         };
                         encryptionStateStorage.saveEncryptionState({
                           ...currentState,
                           sendingInbox: updatedSendingInbox,
+                          sentAccept: true,
                         }, false);
                         ratchetStateCacheRef.current.clear();
                       }

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2767,6 +2767,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // The message should now be properly decrypted plaintext JSON
             decryptedMessage = JSON.parse(sessionResult.message) as Message;
 
+            // Receipt interception — parity with Path 2 and the native batch
+            // path (applyDMGroupResults): flat delivery/read acks arrive
+            // init-wrapped whenever the peer's session is unconfirmed. Without
+            // this check they fell through toward persistence and receipts
+            // never rendered on this path.
+            if (handleDmReceipt(decryptedMessage, conversationId.split('/')[0])) {
+              getDeviceKeyset().then(dk => {
+                if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
+              });
+              return;
+            }
+
             // Self-echo init guard: if the sender is our own address and the
             // message carries no channelId, we cannot determine the real partner.
             // Drop it to prevent a phantom selfAddress/selfAddress conversation row.

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -3017,9 +3017,15 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             const diagKey = `${message.inboxAddress}:${message.timestamp}`;
             if (Date.now() - message.timestamp < 600_000 && !receiptDiagLogged.has(diagKey)) {
               receiptDiagLogged.add(diagKey);
+              const diagState = encryptionStateStorage.getEncryptionState(conversationId, message.inboxAddress);
               logger.warn('[RECEIPT-DIAG] fresh DM decrypt EMPTY/FAILED', JSON.stringify({
                 inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
                 reason: decryptedText ? decryptedText.slice(0, 120) : 'empty',
+                conv: conversationId?.slice(0, 10),
+                state: diagState
+                  ? { inboxId: diagState.inboxId?.slice(0, 10), tag: diagState.tag?.slice(0, 10), ts: diagState.timestamp, sentAccept: diagState.sentAccept }
+                  : 'NONE',
+                allStatesForConv: encryptionStateStorage.getEncryptionStates(conversationId).map(s => s.inboxId?.slice(0, 10)),
               }));
             }
             return;

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -95,6 +95,7 @@ import {
   recordInboxAttempt,
   clearInboxAttempt,
 } from '../services/space/inboxAttemptTracker';
+import { INIT_ENVELOPE_STALENESS_TOLERANCE_MS } from '../services/crypto/initEnvelopeGuard';
 import { getMMKVAdapter, getConversationSync } from '../services/storage/mmkvAdapter';
 import { useAuth } from './AuthContext';
 import { useStorageAdapter } from './StorageContext';
@@ -166,6 +167,9 @@ function shortAddr(address: string | undefined): string {
  * Delete messages from inbox after successful decryption
  * This prevents the same messages from being re-delivered on reconnect
  */
+// [RECEIPT-DIAG] temp, revert before PR — log each failing envelope once, not per redelivery
+const receiptDiagLogged = new Set<string>();
+
 async function deleteInboxMessages(
   inboxAddress: string,
   timestamps: number[],
@@ -2736,6 +2740,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 inbox: message.inboxAddress?.slice(0, 10),
                 ts: message.timestamp,
                 ageSec: Math.round((Date.now() - message.timestamp) / 1000),
+                tolMin: INIT_ENVELOPE_STALENESS_TOLERANCE_MS / 60000,
               }));
               getDeviceKeyset().then(dk => {
                 if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
@@ -2982,11 +2987,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   sealedMessage.envelope
                 );
               } catch (decryptError) {
-                // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only (skip hoard reflood noise)
-                if (Date.now() - message.timestamp < 600_000) {
+                // Bound the redelivery loop: an undecryptable envelope replays
+                // forever otherwise (JS path had no attempt counting).
+                recordInboxAttempt(message.inboxAddress, message.timestamp);
+                // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only, once per envelope
+                const diagKey = `${message.inboxAddress}:${message.timestamp}`;
+                if (Date.now() - message.timestamp < 600_000 && !receiptDiagLogged.has(diagKey)) {
+                  receiptDiagLogged.add(diagKey);
                   logger.warn('[RECEIPT-DIAG] fresh DM decrypt FAILED', JSON.stringify({
                     inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
-                    err: decryptError instanceof Error ? decryptError.message.slice(0, 80) : 'unknown',
+                    err: decryptError instanceof Error ? decryptError.message.slice(0, 120) : 'unknown',
                   }));
                 }
                 // If this is a "no state" error, it's likely stale data - skip gracefully
@@ -3000,10 +3010,16 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
 
           if (!decryptedText || decryptedText.length === 0 || decryptedText.startsWith('Decryption failed')) {
-            // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only
-            if (Date.now() - message.timestamp < 600_000) {
+            // Bound the redelivery loop: an undecryptable envelope replays
+            // forever otherwise (JS path had no attempt counting).
+            recordInboxAttempt(message.inboxAddress, message.timestamp);
+            // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only, once per envelope
+            const diagKey = `${message.inboxAddress}:${message.timestamp}`;
+            if (Date.now() - message.timestamp < 600_000 && !receiptDiagLogged.has(diagKey)) {
+              receiptDiagLogged.add(diagKey);
               logger.warn('[RECEIPT-DIAG] fresh DM decrypt EMPTY/FAILED', JSON.stringify({
                 inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
+                reason: decryptedText ? decryptedText.slice(0, 120) : 'empty',
               }));
             }
             return;

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -423,6 +423,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // Above this queue depth, skip the per-message sleep so a catch-up
   // backlog drains instead of accumulating toward the cap.
   const FAST_DRAIN_THRESHOLD = 500;
+  // Watchdog for the native batch call. A poison message can hang the
+  // native side forever (observed: a DM group never resolving), which
+  // freezes the entire drain loop — nothing lands after that. On timeout
+  // we throw into the individual-processing fallback (which completes)
+  // and stop native-batching DMs for the rest of the session.
+  const NATIVE_BATCH_TIMEOUT_MS = 30000;
+  const dmBatchDisabledRef = useRef(false);
   // [CATCHUP-DIAG] temp counters, written to files/catchup-diag.json by the
   // diag effect below so drain progress is readable over adb — revert before PR.
   const catchupDiagRef = useRef({
@@ -433,7 +440,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     drained: 0,
     inflight: 0,
     defers: 0,
+    stage: 'init',
+    stageTs: 0,
   });
+  // [CATCHUP-DIAG] mark the drain loop's current await so a hang is visible.
+  const setDrainStage = useCallback((s: string) => {
+    catchupDiagRef.current.stage = s;
+    catchupDiagRef.current.stageTs = Date.now();
+  }, []);
   // Gate for verbose per-message / per-batch diagnostics. These build
   // JSON.stringify(batch.map(...)) payloads that are NEVER printed
   // (logger.debug sits below the logger's "log" minLevel), yet the
@@ -3438,6 +3452,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       const isSpaceInbox = spaceInboxSet.has(msg.inboxAddress);
       const isOnDeviceInbox = msg.inboxAddress === ownInboxAddressRef.current;
 
+      // DM native batching hung this session (poison watchdog tripped) —
+      // route all non-space messages through the individual JS path.
+      if (dmBatchDisabledRef.current && !isSpaceInbox) {
+        nonBatchMessages.push(msg);
+        continue;
+      }
+
       if (isSpaceInbox) {
         // Space message - add to space group
         const spaceId = inboxToSpaceMap.get(msg.inboxAddress);
@@ -4847,6 +4868,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // devices.
       const batch = messageQueueRef.current.splice(0, MAX_BATCH_DRAIN_SIZE);
       catchupDiagRef.current.drained += batch.length; // [CATCHUP-DIAG]
+      setDrainStage(`preclassify(batch=${batch.length})`); // [CATCHUP-DIAG]
 
       try {
         // Classify messages and gather crypto state
@@ -4881,7 +4903,45 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // Process batch natively if there are batchable messages
         if (batchInput.space_groups.length > 0 || batchInput.dm_groups.length > 0) {
           const cryptoProvider = new NativeCryptoProvider();
-          const batchOutput = await cryptoProvider.batchProcessMessages(batchInput);
+          setDrainStage(`native-batch(sp=${batchInput.space_groups.length},dm=${batchInput.dm_groups.length})`); // [CATCHUP-DIAG]
+          // Watchdog: a hung native call must not freeze the drain forever.
+          let batchTimeoutId: ReturnType<typeof setTimeout> | undefined;
+          const batchTimeout = new Promise<never>((_, reject) => {
+            batchTimeoutId = setTimeout(
+              () => reject(new Error('native batchProcessMessages timeout')),
+              NATIVE_BATCH_TIMEOUT_MS,
+            );
+          });
+          let batchOutput: BatchProcessOutput;
+          try {
+            batchOutput = await Promise.race([
+              cryptoProvider.batchProcessMessages(batchInput),
+              batchTimeout,
+            ]);
+          } catch (raceErr) {
+            if (batchInput.dm_groups.length > 0) {
+              dmBatchDisabledRef.current = true;
+              const summary = batchInput.dm_groups.map((gp) => ({
+                conv: gp.conversation_id?.slice(0, 12),
+                type: gp.message_type,
+                states: gp.dr_states.length,
+                msgs: gp.messages.map((mm) => ({
+                  ts: mm.timestamp,
+                  init: mm.is_init_envelope,
+                  dr: mm.is_double_ratchet_envelope,
+                  len: mm.encrypted_content?.length,
+                })),
+              }));
+              logger.warn(
+                '[poison-guard] native batch timed out — DM batching disabled for this session',
+                JSON.stringify(summary),
+              );
+              (catchupDiagRef.current as Record<string, unknown>).poison = summary; // [CATCHUP-DIAG]
+            }
+            throw raceErr; // outer catch routes the batch to individual processing
+          } finally {
+            clearTimeout(batchTimeoutId);
+          }
 
           if (WS_TRACE && batchOutput.dm_results.length > 0) {
             logger.debug(
@@ -4901,9 +4961,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
           // Apply results
           if (batchOutput.space_results.length > 0) {
+            setDrainStage('apply-space'); // [CATCHUP-DIAG]
             await applySpaceGroupResults(batchOutput.space_results, batch);
           }
           if (batchOutput.dm_results.length > 0) {
+            setDrainStage('apply-dm'); // [CATCHUP-DIAG]
             await applyDMGroupResults(batchOutput.dm_results, batch);
           }
         }
@@ -4912,12 +4974,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         for (let i = 0; i < nonBatchMessages.length; i++) {
           // Yield to UI thread every 5 messages to prevent jank
           if (i % 5 === 0) {
+            setDrainStage(`nb-im(${i}/${nonBatchMessages.length})`); // [CATCHUP-DIAG]
             await new Promise<void>(resolve => {
               InteractionManager.runAfterInteractions(() => resolve());
             });
           }
 
           try {
+            setDrainStage(`nb-msg(${i}/${nonBatchMessages.length})`); // [CATCHUP-DIAG]
             await handleIncomingMessage(nonBatchMessages[i]);
           } catch { /* ignore */ }
 
@@ -4934,14 +4998,19 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         }
       } catch (batchError) {
         // Fallback: if batch processing fails entirely, process all individually
+        setDrainStage('fallback-preunseal'); // [CATCHUP-DIAG]
         await batchPreUnsealSpaceMessages(batch);
+        let fbIdx = 0; // [CATCHUP-DIAG]
         for (const message of batch) {
+          setDrainStage(`fallback-im(${fbIdx}/${batch.length})`); // [CATCHUP-DIAG]
           await new Promise<void>(resolve => {
             InteractionManager.runAfterInteractions(() => resolve());
           });
           try {
+            setDrainStage(`fallback-msg(${fbIdx}/${batch.length})`); // [CATCHUP-DIAG]
             await handleIncomingMessage(message);
           } catch { /* ignore */ }
+          fbIdx += 1; // [CATCHUP-DIAG]
         }
       }
 
@@ -4975,10 +5044,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // allocations are reclaimed before the next slice builds — keeps
       // peak RSS flat across a large catch-up instead of stacking.
       if (messageQueueRef.current.length > 0) {
+        setDrainStage('drain-yield'); // [CATCHUP-DIAG]
         await new Promise(resolve => setTimeout(resolve, 0));
       }
     }
 
+    setDrainStage('idle'); // [CATCHUP-DIAG]
     isProcessingQueueRef.current = false;
   }, [handleIncomingMessage, batchPreUnsealSpaceMessages, preclassifyAndGatherState, applySpaceGroupResults, applyDMGroupResults]);
 

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -96,7 +96,6 @@ import {
   clearInboxAttempt,
   getInboxAttempts,
 } from '../services/space/inboxAttemptTracker';
-import { INIT_ENVELOPE_STALENESS_TOLERANCE_MS } from '../services/crypto/initEnvelopeGuard';
 import { getMMKVAdapter, getConversationSync } from '../services/storage/mmkvAdapter';
 import { useAuth } from './AuthContext';
 import { useStorageAdapter } from './StorageContext';
@@ -168,9 +167,6 @@ function shortAddr(address: string | undefined): string {
  * Delete messages from inbox after successful decryption
  * This prevents the same messages from being re-delivered on reconnect
  */
-// [RECEIPT-DIAG] temp, revert before PR — log each failing envelope once, not per redelivery
-const receiptDiagLogged = new Set<string>();
-
 // Envelopes already queued for server-side poison deletion this session (the
 // node may redeliver before the delete lands; don't re-request each reflood).
 const poisonDeletedKeys = new Set<string>();
@@ -465,25 +461,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // and stop native-batching DMs for the rest of the session.
   const NATIVE_BATCH_TIMEOUT_MS = 30000;
   const dmBatchDisabledRef = useRef(false);
-  // [CATCHUP-DIAG] temp counters, written to files/catchup-diag.json by the
-  // diag effect below so drain progress is readable over adb — revert before PR.
-  const catchupDiagRef = useRef({
-    liveIn: 0,
-    liveDropped: 0,
-    ingested: 0,
-    truncated: 0,
-    drained: 0,
-    inflight: 0,
-    defers: 0,
-    poisonSkipped: 0, // [CATCHUP-DIAG] cumulative DM envelopes dropped by the poison gate
-    stage: 'init',
-    stageTs: 0,
-  });
-  // [CATCHUP-DIAG] mark the drain loop's current await so a hang is visible.
-  const setDrainStage = useCallback((s: string) => {
-    catchupDiagRef.current.stage = s;
-    catchupDiagRef.current.stageTs = Date.now();
-  }, []);
   // Gate for verbose per-message / per-batch diagnostics. These build
   // JSON.stringify(batch.map(...)) payloads that are NEVER printed
   // (logger.debug sits below the logger's "log" minLevel), yet the
@@ -601,23 +578,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // Only acks the PARTNER sent (about OUR messages) are actionable. Our own
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
-    if (raw.type === 'delivery-ack' || raw.type === 'read-ack') {
-      // [RECEIPT-DIAG] temp, revert before PR — once per unique ack (redeliveries silent)
-      const ackKey = `${raw.type}:${raw.senderId}:${raw.upToMessageId ?? (raw.messageIds ?? []).join(',')}`;
-      if (!receiptDiagLogged.has(ackKey)) {
-        receiptDiagLogged.add(ackKey);
-        logger.warn('[RECEIPT-DIAG] ack ARRIVED on mobile', JSON.stringify({
-          type: raw.type,
-          from: raw.senderId?.slice(0, 10),
-          self: self?.slice(0, 10),
-          partner: partner?.slice(0, 10),
-          selfEcho: raw.senderId === self,
-          gateDelivery: isReceiptEnabled('delivery', partner),
-          gateRead: isReceiptEnabled('read', partner),
-          hasSvc: !!svc,
-        }));
-      }
-    }
     if (raw.type === 'delivery-ack') {
       if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
       return true;
@@ -2770,7 +2730,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 inbox: message.inboxAddress?.slice(0, 10),
                 ts: message.timestamp,
                 ageSec: Math.round((Date.now() - message.timestamp) / 1000),
-                tolMin: INIT_ENVELOPE_STALENESS_TOLERANCE_MS / 60000,
               }));
               getDeviceKeyset().then(dk => {
                 if (dk) deleteInboxMessages(message.inboxAddress, [message.timestamp], dk).catch(() => {});
@@ -3060,15 +3019,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                 // Bound the redelivery loop: an undecryptable envelope replays
                 // forever otherwise (JS path had no attempt counting).
                 recordInboxAttempt(message.inboxAddress, message.timestamp);
-                // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only, once per envelope
-                const diagKey = `${message.inboxAddress}:${message.timestamp}`;
-                if (Date.now() - message.timestamp < 600_000 && !receiptDiagLogged.has(diagKey)) {
-                  receiptDiagLogged.add(diagKey);
-                  logger.warn('[RECEIPT-DIAG] fresh DM decrypt FAILED', JSON.stringify({
-                    inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
-                    err: decryptError instanceof Error ? decryptError.message.slice(0, 120) : 'unknown',
-                  }));
-                }
                 // If this is a "no state" error, it's likely stale data - skip gracefully
                 if (decryptError instanceof Error && decryptError.message.includes('No encryption state')) {
                   return;
@@ -3083,33 +3033,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // Bound the redelivery loop: an undecryptable envelope replays
             // forever otherwise (JS path had no attempt counting).
             recordInboxAttempt(message.inboxAddress, message.timestamp);
-            // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only, once per envelope
-            const diagKey = `${message.inboxAddress}:${message.timestamp}`;
-            if (Date.now() - message.timestamp < 600_000 && !receiptDiagLogged.has(diagKey)) {
-              receiptDiagLogged.add(diagKey);
-              const diagState = encryptionStateStorage.getEncryptionState(conversationId, message.inboxAddress);
-              logger.warn('[RECEIPT-DIAG] fresh DM decrypt EMPTY/FAILED', JSON.stringify({
-                inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
-                reason: decryptedText ? decryptedText.slice(0, 120) : 'empty',
-                conv: conversationId?.slice(0, 10),
-                state: diagState
-                  ? { inboxId: diagState.inboxId?.slice(0, 10), tag: diagState.tag?.slice(0, 10), ts: diagState.timestamp, sentAccept: diagState.sentAccept }
-                  : 'NONE',
-                allStatesForConv: encryptionStateStorage.getEncryptionStates(conversationId).map(s => s.inboxId?.slice(0, 10)),
-              }));
-            }
             return;
           }
 
           decryptedMessage = JSON.parse(decryptedText) as Message;
-          // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only
-          if (Date.now() - message.timestamp < 600_000) {
-            logger.warn('[RECEIPT-DIAG] fresh DM decrypted OK', JSON.stringify({
-              inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
-              type: (decryptedMessage as unknown as { type?: string }).type ?? decryptedMessage.content?.type,
-              conv: conversationId?.slice(0, 10),
-            }));
-          }
 
           // Intercept call signaling messages — forward to CallContext, don't display in chat.
           // call-event is the exception: it renders in chat history as a system message.
@@ -5055,7 +4982,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // skipping one would gap the contiguous cursor advance later in this loop.
       // Only DM-batch messages ever accrue attempts (see the result/timeout
       // handling below), so nothing else can ever be poisoned here.
-      let poisonSkippedThisBatch = 0; // [CATCHUP-DIAG]
+      let poisonSkippedThisBatch = 0;
       // Poisoned envelopes that are ALSO old get deleted from the server so
       // they stop re-downloading on every connect (the reflood that makes the
       // drain minutes-slow). Double condition: poisoned (5 failed attempts, or
@@ -5066,7 +4993,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         const isHubLog = !!(m as { __logSeq?: number }).__logSeq;
         if (isHubLog) return true;
         if (isInboxEnvelopePoisoned(m.inboxAddress, m.timestamp)) {
-          poisonSkippedThisBatch += 1; // [CATCHUP-DIAG]
+          poisonSkippedThisBatch += 1;
           const deleteKey = `${m.inboxAddress}:${m.timestamp}`;
           if (
             Date.now() - m.timestamp > 7 * 24 * 60 * 60 * 1000 &&
@@ -5086,10 +5013,8 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         return true;
       });
       if (poisonSkippedThisBatch > 0) {
-        catchupDiagRef.current.poisonSkipped += poisonSkippedThisBatch; // [CATCHUP-DIAG]
-        logger.warn( // [CATCHUP-DIAG]
-          `[poison-guard] skipped ${poisonSkippedThisBatch} dead DM envelope(s) this batch ` +
-            `(cumulative ${catchupDiagRef.current.poisonSkipped})`,
+        logger.warn(
+          `[poison-guard] skipped ${poisonSkippedThisBatch} undecryptable DM envelope(s) this batch`,
         );
       }
       if (poisonDeleteByInbox.size > 0) {
@@ -5111,8 +5036,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         });
       }
 
-      catchupDiagRef.current.drained += batch.length; // [CATCHUP-DIAG]
-      setDrainStage(`preclassify(batch=${batch.length})`); // [CATCHUP-DIAG]
 
       try {
         // Classify messages and gather crypto state
@@ -5147,7 +5070,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // Process batch natively if there are batchable messages
         if (batchInput.space_groups.length > 0 || batchInput.dm_groups.length > 0) {
           const cryptoProvider = new NativeCryptoProvider();
-          setDrainStage(`native-batch(sp=${batchInput.space_groups.length},dm=${batchInput.dm_groups.length})`); // [CATCHUP-DIAG]
           // Map each DM envelope's timestamp to its inbox so the bounded-retry
           // tracker can be updated from the native result (or a timeout) below.
           const dmInboxByTs = new Map<number, string>();
@@ -5178,22 +5100,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
               // of the hoard, so it converges over as many connects as the hoard
               // spans batches, then no longer stalls.
               dmInboxByTs.forEach((inbox, ts) => recordInboxAttempt(inbox, ts));
-              const summary = batchInput.dm_groups.map((gp) => ({
-                conv: gp.conversation_id?.slice(0, 12),
-                type: gp.message_type,
-                states: gp.dr_states.length,
-                msgs: gp.messages.map((mm) => ({
-                  ts: mm.timestamp,
-                  init: mm.is_init_envelope,
-                  dr: mm.is_double_ratchet_envelope,
-                  len: mm.encrypted_content?.length,
-                })),
-              }));
               logger.warn(
                 '[poison-guard] native batch timed out — DM batching disabled for this session',
-                JSON.stringify(summary),
               );
-              (catchupDiagRef.current as Record<string, unknown>).poison = summary; // [CATCHUP-DIAG]
             }
             throw raceErr; // outer catch routes the batch to individual processing
           } finally {
@@ -5218,11 +5127,9 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
           // Apply results
           if (batchOutput.space_results.length > 0) {
-            setDrainStage('apply-space'); // [CATCHUP-DIAG]
             await applySpaceGroupResults(batchOutput.space_results, batch);
           }
           if (batchOutput.dm_results.length > 0) {
-            setDrainStage('apply-dm'); // [CATCHUP-DIAG]
             await applyDMGroupResults(batchOutput.dm_results, batch);
             // Update the bounded-retry tracker from authoritative native statuses:
             // clear on success (resets a recovered transient failure); count on a
@@ -5248,14 +5155,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         for (let i = 0; i < nonBatchMessages.length; i++) {
           // Yield to UI thread every 5 messages to prevent jank
           if (i % 5 === 0) {
-            setDrainStage(`nb-im(${i}/${nonBatchMessages.length})`); // [CATCHUP-DIAG]
             await new Promise<void>(resolve => {
               InteractionManager.runAfterInteractions(() => resolve());
             });
           }
 
           try {
-            setDrainStage(`nb-msg(${i}/${nonBatchMessages.length})`); // [CATCHUP-DIAG]
             await handleIncomingMessage(nonBatchMessages[i]);
           } catch { /* ignore */ }
 
@@ -5272,19 +5177,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         }
       } catch (batchError) {
         // Fallback: if batch processing fails entirely, process all individually
-        setDrainStage('fallback-preunseal'); // [CATCHUP-DIAG]
         await batchPreUnsealSpaceMessages(batch);
-        let fbIdx = 0; // [CATCHUP-DIAG]
         for (const message of batch) {
-          setDrainStage(`fallback-im(${fbIdx}/${batch.length})`); // [CATCHUP-DIAG]
           await new Promise<void>(resolve => {
             InteractionManager.runAfterInteractions(() => resolve());
           });
           try {
-            setDrainStage(`fallback-msg(${fbIdx}/${batch.length})`); // [CATCHUP-DIAG]
             await handleIncomingMessage(message);
           } catch { /* ignore */ }
-          fbIdx += 1; // [CATCHUP-DIAG]
         }
       }
 
@@ -5318,12 +5218,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // allocations are reclaimed before the next slice builds — keeps
       // peak RSS flat across a large catch-up instead of stacking.
       if (messageQueueRef.current.length > 0) {
-        setDrainStage('drain-yield'); // [CATCHUP-DIAG]
         await new Promise(resolve => setTimeout(resolve, 0));
       }
     }
 
-    setDrainStage('idle'); // [CATCHUP-DIAG]
     isProcessingQueueRef.current = false;
   }, [handleIncomingMessage, batchPreUnsealSpaceMessages, preclassifyAndGatherState, applySpaceGroupResults, applyDMGroupResults]);
 
@@ -5367,9 +5265,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     if (messageQueueRef.current.length >= MAX_MESSAGE_QUEUE_SIZE) {
       const excess = messageQueueRef.current.length - MAX_MESSAGE_QUEUE_SIZE + 1;
       messageQueueRef.current.splice(0, excess);
-      catchupDiagRef.current.liveDropped += excess; // [CATCHUP-DIAG]
     }
-    catchupDiagRef.current.liveIn += 1; // [CATCHUP-DIAG]
     messageQueueRef.current.push(message);
     // Start processing if not already in progress
     processMessageQueue();
@@ -5778,12 +5674,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     const INFLIGHT_TIMEOUT_MS = 30000;
     const DEFER_RETRY_MS = 250;
 
-    // [CATCHUP-DIAG]
-    const syncDiag = () => {
-      catchupDiagRef.current.inflight = inflight.size;
-      catchupDiagRef.current.defers = deferTimers.size;
-    };
-
     const requestLogSince = async (hubAddress: string, since: number) => {
       if (cancelled) return;
       // Expire in-flight requests whose result never came back so they
@@ -5809,7 +5699,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             }, DEFER_RETRY_MS),
           );
         }
-        syncDiag(); // [CATCHUP-DIAG]
         return;
       }
       const space = getSpaceByHubAddress(hubAddress);
@@ -5827,7 +5716,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       } catch {
         inflight.delete(hubAddress);
       }
-      syncDiag(); // [CATCHUP-DIAG]
     };
 
     const ingestEntries = (
@@ -5850,13 +5738,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // cursor; the caller refetches from lastVisited. Dropping oldest
           // here punched the seq gap that wedged the cursor.
           truncated = true;
-          catchupDiagRef.current.truncated += 1; // [CATCHUP-DIAG]
           break;
         }
         lastVisited = entry.seq;
         const sealedEnvelope = entry.payload?.data;
         if (!sealedEnvelope) continue;
-        catchupDiagRef.current.ingested += 1; // [CATCHUP-DIAG]
         // Tag with __logSeq / __logHub so processMessageQueue can advance the
         // hub cursor only after persistence — see post-batch hook there.
         const synthetic = {
@@ -5882,7 +5768,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       if (!hubAddress) return;
       if (frame.type === 'log-since-result') {
         inflight.delete(hubAddress);
-        syncDiag(); // [CATCHUP-DIAG]
         const { lastVisited, truncated } = ingestEntries(hubAddress, frame.entries);
         if (truncated) {
           // Queue filled mid-page: refetch the tail we didn't enqueue.
@@ -5972,31 +5857,6 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       unsubscribe();
     };
   }, [connectionState, registerLogFrameHandler, enqueueOutbound, processMessageQueue]);
-
-  // [CATCHUP-DIAG] Write catch-up state to files/catchup-diag.json every 5s so
-  // drain progress is readable over adb (read-catchup-diag.ps1) — revert before PR.
-  useEffect(() => {
-    const id = setInterval(async () => {
-      try {
-        const { File, Paths } = await import('expo-file-system');
-        const cursors: Record<string, number> = {};
-        for (const spaceId of getSpaceIds()) {
-          const hub = getSpaceKey(spaceId, 'hub');
-          if (hub?.address) {
-            cursors[hub.address.slice(0, 8)] = getHubLastSeq(hub.address);
-          }
-        }
-        const payload = JSON.stringify({
-          updated: Date.now(),
-          queue: messageQueueRef.current.length,
-          ...catchupDiagRef.current,
-          cursors,
-        });
-        new File(Paths.document, 'catchup-diag.json').write(payload);
-      } catch { /* diag only */ }
-    }, 5000);
-    return () => clearInterval(id);
-  }, []);
 
   // On-connect catch-up is handled exclusively by the per-hub log effect
   // above — listen-hub + log-since fetches everything since the stored

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -90,6 +90,11 @@ import {
 } from '../services/space/modMuteStorage';
 import { buildListenHubFrame, buildLogSinceFrame } from '../services/space/hubLogSync';
 import { getHubLastSeq, setHubLastSeq } from '../services/space/hubLogCursor';
+import {
+  isInboxEnvelopePoisoned,
+  recordInboxAttempt,
+  clearInboxAttempt,
+} from '../services/space/inboxAttemptTracker';
 import { getMMKVAdapter, getConversationSync } from '../services/storage/mmkvAdapter';
 import { useAuth } from './AuthContext';
 import { useStorageAdapter } from './StorageContext';
@@ -440,6 +445,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     drained: 0,
     inflight: 0,
     defers: 0,
+    poisonSkipped: 0, // [CATCHUP-DIAG] cumulative DM envelopes dropped by the poison gate
     stage: 'init',
     stageTs: 0,
   });
@@ -565,6 +571,19 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
     // Only acks the PARTNER sent (about OUR messages) are actionable. Our own
     // acks (about the partner's messages) fan out to our other devices too — a
     // self-echoed read-ack would otherwise mark our own sent messages read.
+    if (raw.type === 'delivery-ack' || raw.type === 'read-ack') {
+      // [RECEIPT-DIAG] temp, revert before PR
+      logger.warn('[RECEIPT-DIAG] ack ARRIVED on mobile', JSON.stringify({
+        type: raw.type,
+        from: raw.senderId?.slice(0, 10),
+        self: self?.slice(0, 10),
+        partner: partner?.slice(0, 10),
+        selfEcho: raw.senderId === self,
+        gateDelivery: isReceiptEnabled('delivery', partner),
+        gateRead: isReceiptEnabled('read', partner),
+        hasSvc: !!svc,
+      }));
+    }
     if (raw.type === 'delivery-ack') {
       if (svc && raw.senderId !== self && isReceiptEnabled('delivery', partner)) svc.onAckReceived(raw.messageIds ?? []);
       return true;
@@ -2924,6 +2943,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                   sealedMessage.envelope
                 );
               } catch (decryptError) {
+                // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only (skip hoard reflood noise)
+                if (Date.now() - message.timestamp < 600_000) {
+                  logger.warn('[RECEIPT-DIAG] fresh DM decrypt FAILED', JSON.stringify({
+                    inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
+                    err: decryptError instanceof Error ? decryptError.message.slice(0, 80) : 'unknown',
+                  }));
+                }
                 // If this is a "no state" error, it's likely stale data - skip gracefully
                 if (decryptError instanceof Error && decryptError.message.includes('No encryption state')) {
                   return;
@@ -2935,10 +2961,24 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
 
           if (!decryptedText || decryptedText.length === 0 || decryptedText.startsWith('Decryption failed')) {
+            // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only
+            if (Date.now() - message.timestamp < 600_000) {
+              logger.warn('[RECEIPT-DIAG] fresh DM decrypt EMPTY/FAILED', JSON.stringify({
+                inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
+              }));
+            }
             return;
           }
 
           decryptedMessage = JSON.parse(decryptedText) as Message;
+          // [RECEIPT-DIAG] temp, revert before PR — fresh envelopes only
+          if (Date.now() - message.timestamp < 600_000) {
+            logger.warn('[RECEIPT-DIAG] fresh DM decrypted OK', JSON.stringify({
+              inbox: message.inboxAddress?.slice(0, 10), ts: message.timestamp,
+              type: (decryptedMessage as unknown as { type?: string }).type ?? decryptedMessage.content?.type,
+              conv: conversationId?.slice(0, 10),
+            }));
+          }
 
           // Intercept call signaling messages — forward to CallContext, don't display in chat.
           // call-event is the exception: it renders in chat history as a system message.
@@ -4866,7 +4906,33 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       // results — stays flat. The loop keeps going until the queue is
       // empty; see MAX_BATCH_DRAIN_SIZE for why this matters on small
       // devices.
-      const batch = messageQueueRef.current.splice(0, MAX_BATCH_DRAIN_SIZE);
+      let batch = messageQueueRef.current.splice(0, MAX_BATCH_DRAIN_SIZE);
+
+      // Bounded-retry poison guard (DM / device-inbox only). Drop envelopes that
+      // have already failed too many times, or are old and still failing, so a
+      // permanently-undecryptable hoard can't re-enter — and re-freeze — the
+      // native batch. Channel (hub-log) entries carry __logSeq and are exempt:
+      // skipping one would gap the contiguous cursor advance later in this loop.
+      // Only DM-batch messages ever accrue attempts (see the result/timeout
+      // handling below), so nothing else can ever be poisoned here.
+      let poisonSkippedThisBatch = 0; // [CATCHUP-DIAG]
+      batch = batch.filter((m) => {
+        const isHubLog = !!(m as { __logSeq?: number }).__logSeq;
+        if (isHubLog) return true;
+        if (isInboxEnvelopePoisoned(m.inboxAddress, m.timestamp)) {
+          poisonSkippedThisBatch += 1; // [CATCHUP-DIAG]
+          return false;
+        }
+        return true;
+      });
+      if (poisonSkippedThisBatch > 0) {
+        catchupDiagRef.current.poisonSkipped += poisonSkippedThisBatch; // [CATCHUP-DIAG]
+        logger.warn( // [CATCHUP-DIAG]
+          `[poison-guard] skipped ${poisonSkippedThisBatch} dead DM envelope(s) this batch ` +
+            `(cumulative ${catchupDiagRef.current.poisonSkipped})`,
+        );
+      }
+
       catchupDiagRef.current.drained += batch.length; // [CATCHUP-DIAG]
       setDrainStage(`preclassify(batch=${batch.length})`); // [CATCHUP-DIAG]
 
@@ -4904,6 +4970,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         if (batchInput.space_groups.length > 0 || batchInput.dm_groups.length > 0) {
           const cryptoProvider = new NativeCryptoProvider();
           setDrainStage(`native-batch(sp=${batchInput.space_groups.length},dm=${batchInput.dm_groups.length})`); // [CATCHUP-DIAG]
+          // Map each DM envelope's timestamp to its inbox so the bounded-retry
+          // tracker can be updated from the native result (or a timeout) below.
+          const dmInboxByTs = new Map<number, string>();
+          for (const gp of batchInput.dm_groups) {
+            for (const mm of gp.messages) dmInboxByTs.set(mm.timestamp, mm.inbox_address);
+          }
           // Watchdog: a hung native call must not freeze the drain forever.
           let batchTimeoutId: ReturnType<typeof setTimeout> | undefined;
           const batchTimeout = new Promise<never>((_, reject) => {
@@ -4921,6 +4993,13 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           } catch (raceErr) {
             if (batchInput.dm_groups.length > 0) {
               dmBatchDisabledRef.current = true;
+              // Count a failed attempt for every DM envelope in the hung batch so
+              // a permanently-freezing envelope accrues toward the skip threshold
+              // and stops re-entering (and re-freezing) the batch on later
+              // connects. Each connect tags one batch (up to MAX_BATCH_DRAIN_SIZE)
+              // of the hoard, so it converges over as many connects as the hoard
+              // spans batches, then no longer stalls.
+              dmInboxByTs.forEach((inbox, ts) => recordInboxAttempt(inbox, ts));
               const summary = batchInput.dm_groups.map((gp) => ({
                 conv: gp.conversation_id?.slice(0, 12),
                 type: gp.message_type,
@@ -4967,6 +5046,23 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           if (batchOutput.dm_results.length > 0) {
             setDrainStage('apply-dm'); // [CATCHUP-DIAG]
             await applyDMGroupResults(batchOutput.dm_results, batch);
+            // Update the bounded-retry tracker from authoritative native statuses:
+            // clear on success (resets a recovered transient failure); count on a
+            // hard failure. 'unseal_failed' is intentionally NOT counted — those
+            // route to the JS init-envelope fallback and usually succeed there, so
+            // counting them would penalise legitimate DMs.
+            for (const gr of batchOutput.dm_results) {
+              for (const mr of gr.messages) {
+                if (mr.timestamp == null) continue;
+                const inbox = dmInboxByTs.get(mr.timestamp);
+                if (!inbox) continue;
+                if (mr.status === 'decrypted' || mr.status === 'init_decrypted') {
+                  clearInboxAttempt(inbox, mr.timestamp);
+                } else if (mr.status === 'decrypt_failed' || mr.status === 'no_state') {
+                  recordInboxAttempt(inbox, mr.timestamp);
+                }
+              }
+            }
           }
         }
 

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -506,6 +506,94 @@ class EncryptionService {
   }
 
   /**
+   * Confirm an unconfirmed Double Ratchet SENDER session from the peer's
+   * first reply — mobile port of the SDK's ConfirmDoubleRatchetSenderSession
+   * (quilibrium-js-sdk-channels channel.ts) as used by desktop
+   * (MessageService.ts Confirm branch).
+   *
+   * The initiator's state starts with sendingInbox.inbox_public_key === ''
+   * ("unconfirmed"); while unconfirmed, every send is wrapped in an
+   * InitializationEnvelope. The peer's first reply (itself init-wrapped)
+   * carries the peer's full return_inbox_* — processing it here fills the
+   * sendingInbox, sets sentAccept, and ends the init-wrapping on both sides.
+   *
+   * Composed entirely from existing primitives (DR decrypt + state
+   * bookkeeping); no new cryptography. Returns null whenever this is not a
+   * confirmable case, so callers fall back to the pre-existing behavior.
+   */
+  async confirmSenderSession(
+    conversationId: string,
+    receivedOnInboxAddress: string,
+    unsealed: UnsealedEnvelope
+  ): Promise<{ message: string; userProfile?: { displayName?: string; userIcon?: string } } | null> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
+      const state = encryptionStateStorage.getEncryptionState(conversationId, receivedOnInboxAddress);
+      // Only an UNCONFIRMED sender session is a confirm case (SDK throws
+      // 'inbox key already set' otherwise; we return null and let the
+      // normal DR/init paths handle it).
+      if (!state) return null;
+      if (state.sendingInbox?.inbox_public_key) return null;
+
+      // SDK validation: ALL initialization fields must be present — a
+      // partial envelope must not half-confirm the session.
+      if (
+        !unsealed.return_inbox_address ||
+        !unsealed.return_inbox_encryption_key ||
+        !unsealed.return_inbox_private_key ||
+        !unsealed.return_inbox_public_key ||
+        !unsealed.tag ||
+        !unsealed.message ||
+        !unsealed.user_address
+      ) {
+        return null;
+      }
+
+      // Decrypt the inner DR envelope with the sender session's ratchet.
+      let envelopeStr = unsealed.message;
+      if (envelopeStr.includes('\\')) {
+        envelopeStr = envelopeStr.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+      }
+      const decryptResult = await this.cryptoProvider.doubleRatchetDecrypt({
+        ratchet_state: state.state,
+        envelope: envelopeStr,
+      });
+      const resultWithError = decryptResult as typeof decryptResult & { decryptionError?: string };
+      if (resultWithError.decryptionError || decryptResult.message.length === 0) {
+        // Signal rule: a bad frame never destroys the session — leave the
+        // state untouched and let the caller fall back.
+        return null;
+      }
+      const decryptedMessage = textDecoder.decode(new Uint8Array(decryptResult.message));
+
+      // Persist the CONFIRMED state immediately, inside the lock (desktop
+      // parity: accept plaintext + store state changes is one atomic step).
+      const confirmedState: EncryptionState = {
+        state: decryptResult.ratchet_state,
+        timestamp: Date.now(),
+        conversationId,
+        inboxId: state.inboxId,
+        sentAccept: true,
+        sendingInbox: {
+          inbox_address: unsealed.return_inbox_address,
+          inbox_encryption_key: unsealed.return_inbox_encryption_key,
+          inbox_public_key: unsealed.return_inbox_public_key,
+          inbox_private_key: unsealed.return_inbox_private_key,
+        },
+        tag: unsealed.tag,
+      };
+      encryptionStateStorage.saveEncryptionState(confirmedState, true);
+      // Route future received replies on the peer's return inbox to this
+      // conversation.
+      encryptionStateStorage.saveInboxMapping(unsealed.return_inbox_address, conversationId);
+
+      const userProfile = (unsealed.display_name || unsealed.user_icon)
+        ? { displayName: unsealed.display_name, userIcon: unsealed.user_icon }
+        : undefined;
+      return { message: decryptedMessage, userProfile };
+    });
+  }
+
+  /**
    * Check if a session exists for a conversation
    */
   hasSession(conversationId: string): boolean {

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -832,6 +832,15 @@ class EncryptionService {
         ...getInstalledInitEnvelopeTs(conversationId),
       ];
       if (isStaleInitEnvelope(envelopeTimestamp, knownTimestamps)) {
+        // [RECEIPT-DIAG] temp, revert before PR — show WHICH rule refused it
+        console.warn('[stale-init-detail]', JSON.stringify({
+          envTs: envelopeTimestamp,
+          exactMatch: knownTimestamps.includes(envelopeTimestamp),
+          newestKnown: Math.max(...knownTimestamps),
+          newestMinusEnvSec: Math.round((Math.max(...knownTimestamps) - envelopeTimestamp) / 1000),
+          stateRows: allStates.length,
+          recordedInitTs: getInstalledInitEnvelopeTs(conversationId),
+        }));
         return 'stale';
       }
     }

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -920,15 +920,6 @@ class EncryptionService {
         ...getInstalledInitEnvelopeTs(conversationId),
       ];
       if (isStaleInitEnvelope(envelopeTimestamp, knownTimestamps)) {
-        // [RECEIPT-DIAG] temp, revert before PR — show WHICH rule refused it
-        console.warn('[stale-init-detail]', JSON.stringify({
-          envTs: envelopeTimestamp,
-          exactMatch: knownTimestamps.includes(envelopeTimestamp),
-          newestKnown: Math.max(...knownTimestamps),
-          newestMinusEnvSec: Math.round((Math.max(...knownTimestamps) - envelopeTimestamp) / 1000),
-          stateRows: allStates.length,
-          recordedInitTs: getInstalledInitEnvelopeTs(conversationId),
-        }));
         return 'stale';
       }
     }

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -17,6 +17,11 @@ import {
   type ConversationInboxKeypair,
 } from './encryption-state-storage';
 import { ratchetMutex } from './ratchet-mutex';
+import {
+  isStaleInitEnvelope,
+  getInstalledInitEnvelopeTs,
+  recordInstalledInitEnvelopeTs,
+} from './initEnvelopeGuard';
 import { deriveAddress } from '../onboarding/keyService';
 
 import type {
@@ -626,8 +631,12 @@ class EncryptionService {
    */
   async initializeRecipientSession(
     unsealed: UnsealedEnvelope,
-    receivedOnInboxAddress: string  // The inbox where we received this init message
-  ): Promise<{
+    receivedOnInboxAddress: string,  // The inbox where we received this init message
+    // Server-assigned envelope timestamp; when provided, the staleness guard
+    // refuses redelivered/zombie init envelopes (returns 'stale') instead of
+    // letting them re-run X3DH over a newer session.
+    envelopeTimestamp?: number
+  ): Promise<'stale' | {
     conversationId: string;
     message: string;
     senderAddress: string;
@@ -809,7 +818,23 @@ class EncryptionService {
       }
     }
 
-    // No existing session - perform full X3DH initialization
+    // No existing session usable (or existing-session decrypt failed) — the
+    // code below runs full X3DH, which INSTALLS session state and repoints
+    // latestState for this conversation. Staleness guard (desktop parity,
+    // see initEnvelopeGuard.ts): a redelivered or zombie init envelope must
+    // never re-run X3DH over a newer session — that resurrects a ratchet the
+    // sender no longer holds and forks the pair. Refuse anything not strictly
+    // newer than what we already hold; the caller deletes the refused
+    // envelope from the server so it cannot be redelivered (mine defused).
+    if (envelopeTimestamp !== undefined) {
+      const knownTimestamps = [
+        ...allStates.map((s) => s.timestamp),
+        ...getInstalledInitEnvelopeTs(conversationId),
+      ];
+      if (isStaleInitEnvelope(envelopeTimestamp, knownTimestamps)) {
+        return 'stale';
+      }
+    }
 
     // Parse keys from hex strings to byte arrays
     const senderIdentityKey = this.hexToBytes(unsealed.identity_public_key);
@@ -918,6 +943,13 @@ class EncryptionService {
     // Save encryption state - this is the PRIMARY state for this conversation
     // The sendingInbox field tells us where to send, so we don't need a separate "latest" state
     encryptionStateStorage.saveEncryptionState(encryptionState, true);
+
+    // Remember this envelope's server timestamp so an exact redelivery is
+    // recognized as stale even inside the skew tolerance window (state rows
+    // carry local Date.now, not the envelope timestamp desktop keys off).
+    if (envelopeTimestamp !== undefined) {
+      recordInstalledInitEnvelopeTs(conversationId, envelopeTimestamp);
+    }
 
     // IMPORTANT: Also save to ephemeral key cache so subsequent messages with same
     // ephemeral key can use this advanced ratchet state instead of re-doing X3DH

--- a/services/crypto/initEnvelopeGuard.ts
+++ b/services/crypto/initEnvelopeGuard.ts
@@ -30,7 +30,14 @@
 
 import type { MMKV } from 'react-native-mmkv';
 
-export const INIT_ENVELOPE_STALENESS_TOLERANCE_MS = 120_000;
+// Desktop uses 120s. Mobile needs a much wider window: state rows are
+// re-stamped with local Date.now() on every save, and the receive drain can
+// delay an envelope by several minutes (catch-up refloods; dev throttling) —
+// observed live 2026-07-23: a legitimately fresh ack-as-init envelope surfaced
+// ~2 minutes after send and was falsely refused under the 120s tolerance.
+// The zombies this guard exists for are DAYS to WEEKS old, so 30 minutes
+// keeps the full protection margin while absorbing worst-case drain latency.
+export const INIT_ENVELOPE_STALENESS_TOLERANCE_MS = 30 * 60 * 1000;
 
 export function isStaleInitEnvelope(
   envelopeTimestamp: number,

--- a/services/crypto/initEnvelopeGuard.ts
+++ b/services/crypto/initEnvelopeGuard.ts
@@ -1,0 +1,93 @@
+/**
+ * Staleness guard for Double Ratchet init envelopes — port of desktop's
+ * quorum-desktop/src/utils/initEnvelopeGuard.ts (mechanism 3 of its solved
+ * DM master report, shipped 2026-07-17).
+ *
+ * An init envelope replaces the receiver's session for its conversation,
+ * unconditionally. The server redelivers any frame whose ack-by-delete
+ * failed (502s observed live), so stale init envelopes act as mines: on a
+ * reconnect they are replayed and each one silently replaces the CURRENT
+ * healthy session with a resurrected zombie the sender no longer holds.
+ * Confirmed live on mobile 2026-07-23: both of a desktop peer's sessions
+ * toward this device were forked, killing all DM receipts (master report
+ * §7b), with months of stale init envelopes replaying every connect.
+ *
+ * Rules (pure, unit-tested, same as desktop):
+ * 1. No existing timestamps for the conversation → not stale (first init).
+ * 2. Envelope timestamp EXACTLY equals a known timestamp → stale. Desktop
+ *    keys its session rows by the envelope's own timestamp; mobile rows
+ *    carry local Date.now, so the exact-match rule is fed by the separate
+ *    installed-init record below instead.
+ * 3. Envelope older than the newest known timestamp by more than the
+ *    tolerance → stale. The tolerance absorbs clock-domain skew (rows
+ *    updated by sends/receives carry local Date.now; envelope timestamps
+ *    are server-assigned) without weakening the guard — observed zombies
+ *    are hours to weeks older, far beyond any plausible skew.
+ *
+ * A genuine session reset always produces an envelope NEWER than every
+ * row it replaces, so legitimate re-inits pass rules 2 and 3 untouched.
+ */
+
+import type { MMKV } from 'react-native-mmkv';
+
+export const INIT_ENVELOPE_STALENESS_TOLERANCE_MS = 120_000;
+
+export function isStaleInitEnvelope(
+  envelopeTimestamp: number,
+  existingTimestamps: number[],
+  toleranceMs: number = INIT_ENVELOPE_STALENESS_TOLERANCE_MS
+): boolean {
+  if (existingTimestamps.length === 0) return false;
+  if (existingTimestamps.includes(envelopeTimestamp)) return true;
+  const newest = Math.max(...existingTimestamps);
+  return envelopeTimestamp < newest - toleranceMs;
+}
+
+// ---------------------------------------------------------------------------
+// Record of installed init-envelope timestamps, per conversation.
+//
+// Mobile's EncryptionState rows are stamped with local Date.now() (and are
+// re-stamped on every ratchet advance), so rule 2's exact-match redelivery
+// detection cannot key off them the way desktop's rows (stamped with the
+// envelope timestamp) allow. This small MMKV record keeps the last few
+// installed init-envelope timestamps per conversation so a redelivered
+// envelope is recognized as stale even inside the skew tolerance window.
+// Lazy-initialized so importing the pure function above doesn't touch MMKV
+// (keeps it unit-testable under jest without a native module).
+// ---------------------------------------------------------------------------
+
+const MAX_RECORDED_INIT_TS = 20;
+
+let storage: MMKV | null = null;
+function getStorage(): MMKV {
+  if (!storage) {
+    // Lazy require: a static `import { createMMKV }` pulls in the native
+    // nitro-modules chain, which breaks any jest suite that (transitively)
+    // imports this module for the pure isStaleInitEnvelope function.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { createMMKV } = require('react-native-mmkv') as typeof import('react-native-mmkv');
+    storage = createMMKV({ id: 'quorum-init-envelope-guard' });
+  }
+  return storage;
+}
+
+const key = (conversationId: string) => `installed/${conversationId}`;
+
+export function getInstalledInitEnvelopeTs(conversationId: string): number[] {
+  const raw = getStorage().getString(key(conversationId));
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    return Array.isArray(parsed) ? parsed.filter((n): n is number => typeof n === 'number') : [];
+  } catch {
+    return [];
+  }
+}
+
+export function recordInstalledInitEnvelopeTs(conversationId: string, timestamp: number): void {
+  const list = getInstalledInitEnvelopeTs(conversationId);
+  if (list.includes(timestamp)) return;
+  list.push(timestamp);
+  list.sort((a, b) => a - b);
+  getStorage().set(key(conversationId), JSON.stringify(list.slice(-MAX_RECORDED_INIT_TS)));
+}

--- a/services/space/inboxAttemptTracker.ts
+++ b/services/space/inboxAttemptTracker.ts
@@ -1,0 +1,67 @@
+/**
+ * Bounded-retry tracker for undecryptable DM / device-inbox envelopes.
+ *
+ * Background: mobile never deletes an inbox envelope that fails to decrypt, so
+ * a failed envelope replays on every connect forever — a monotonically growing
+ * "hoard". When the hoard includes large init envelopes, the native
+ * batchProcessMessages call hangs and freezes the whole receive drain until
+ * restart.
+ *
+ * This tracker bounds the retry: an envelope that keeps failing is eventually
+ * skipped from the native batch so it can neither re-freeze it nor grow the
+ * hoard, WHILE still giving genuinely-transient failures several chances to
+ * recover across reconnects. It is the middle ground between mobile's current
+ * infinite retry (hoards) and desktop's delete-on-first-failure (black-holes
+ * transient failures).
+ *
+ * Scope: DM / device-inbox envelopes only. Channel (hub-log) entries are NOT
+ * tracked here — skipping one would gap the contiguous hub-log cursor advance.
+ * See [[2026-07-23-bounded-retry-inbox-poison-skiplist]].
+ */
+
+import { createMMKV } from 'react-native-mmkv';
+
+const storage = createMMKV({ id: 'quorum-inbox-attempts' });
+
+/** Give up feeding an envelope to the decryptor after this many failed attempts. */
+const MAX_DECRYPT_ATTEMPTS = 5;
+/** An envelope still failing this long after it was sent is treated as dead. */
+const MAX_ENVELOPE_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+const key = (inboxAddress: string, timestamp: number) => `${inboxAddress}/${timestamp}`;
+
+export function getInboxAttempts(inboxAddress: string, timestamp: number): number {
+  return storage.getNumber(key(inboxAddress, timestamp)) ?? 0;
+}
+
+/** Record one more failed decrypt attempt; returns the new count. */
+export function recordInboxAttempt(inboxAddress: string, timestamp: number): number {
+  const next = getInboxAttempts(inboxAddress, timestamp) + 1;
+  storage.set(key(inboxAddress, timestamp), next);
+  return next;
+}
+
+/**
+ * Clear tracking on a successful decrypt. Keeps the tracker from becoming a
+ * second hoard (only currently-failing envelopes ever hold a key) and resets a
+ * transient failure that later recovered so it can never accrue toward the cap.
+ */
+export function clearInboxAttempt(inboxAddress: string, timestamp: number): void {
+  storage.remove(key(inboxAddress, timestamp));
+}
+
+/**
+ * Whether this envelope should be skipped from the native batch.
+ *
+ * SAFETY RULE: a never-attempted envelope is NEVER poison, regardless of age —
+ * it always gets its first try. This protects a legitimate old DM waiting for a
+ * user who was offline for a while: it arrives old but is still tried, decrypts,
+ * and is delivered. The age cap only applies once we have already attempted the
+ * envelope and seen it fail at least once.
+ */
+export function isInboxEnvelopePoisoned(inboxAddress: string, timestamp: number): boolean {
+  const attempts = getInboxAttempts(inboxAddress, timestamp);
+  if (attempts >= MAX_DECRYPT_ATTEMPTS) return true;
+  if (attempts >= 1 && Date.now() - timestamp > MAX_ENVELOPE_AGE_MS) return true;
+  return false;
+}

--- a/services/space/messageRecovery.ts
+++ b/services/space/messageRecovery.ts
@@ -11,7 +11,7 @@ import {
   hasAttemptedRecovery as hasAttemptedRecoveryDb,
   markRecoveryAttempted as markRecoveryAttemptedDb,
 } from '@/services/storage/messagesDb';
-import { setHubLastSeq } from './hubLogCursor';
+import { clearHubCursor } from './hubLogCursor';
 import { buildLogSinceFrame, type HubKey } from './hubLogSync';
 import { logger } from '@quilibrium/quorum-shared';
 const RECOVERY_FETCH_LIMIT = 1000;
@@ -35,7 +35,9 @@ export async function attemptHubLogRecovery(
   // Mark first so concurrent channel-opens in the same space coalesce.
   markRecoveryAttemptedDb(spaceId);
 
-  setHubLastSeq(hubKey.address, 0);
+  // clearHubCursor, not setHubLastSeq(addr, 0) — the setter only advances,
+  // so a "reset to 0" was a silent no-op.
+  clearHubCursor(hubKey.address);
 
   const key: HubKey = {
     address: hubKey.address,


### PR DESCRIPTION
## Problem

Direct messages between mobile and desktop have been unreliable for months: messages delayed or lost, delivery/read receipts never rendering, and conversations occasionally needing a manual session reset. Live instrumentation traced this to a chain of cooperating defects in the DM receive path:

1. **Native batch freeze.** A batch containing certain init envelopes could hang the native batchProcessMessages call forever, freezing the entire receive drain (spaces and DMs) until app restart.
2. **Unbounded envelope hoard.** An envelope that fails to decrypt was never deleted from the server inbox, so it redelivered on every connect forever. One test inbox had accumulated hundreds of undecryptable init envelopes spanning two months, re-downloaded and re-processed on every connect (multi-minute drains).
3. **Zombie session replacement.** An init envelope unconditionally installs/replaces the Double Ratchet session for its conversation, and the server redelivers envelopes whose ack-by-delete failed — so stale envelopes replayed on reconnect silently replaced healthy sessions with ratchets the sender no longer holds. Desktop shipped a staleness guard for this in July; mobile never got it.
4. **Sessions never confirmed.** Mobile lacked the ConfirmDoubleRatchetSenderSession step entirely (sessions stayed unconfirmed forever, both sides re-initialized on every message — one conversation was observed with 8,000+ accumulated state rows). Receipts, which ride only stored session states, failed 100% in one direction.
5. **Receipts missing on the init path.** Flat delivery/read acks arriving wrapped in init envelopes (the normal case for unconfirmed sessions) were decrypted but never routed through the receipt handler.
6. **Ack deletion signed with the wrong key.** Consumed acks arriving on conversation inboxes were deleted with the device key; the server rejected the delete and redelivered the same acks endlessly, starving fresh receipts.

## Fixes

- **30s watchdog + circuit breaker** around the native batch: on timeout, reprocess via the individual path and disable DM native-batching for the session.
- **Bounded retry** for undecryptable DM envelopes (MMKV per-envelope attempt counter): after 5 failed attempts, or 7 days of age with at least one failure, stop feeding the envelope to the processor. Never-attempted envelopes always get their first try; success clears the counter, so transient failures recover.
- **Server-side cleanup of provably dead envelopes**: an envelope that is poisoned AND older than 7 days AND failed at least twice is deleted from the server inbox (batched per inbox, correctly signed), permanently ending the reflood.
- **Init-envelope staleness guard** (port of the desktop/SDK logic): refuse init envelopes not strictly newer than the sessions they would replace; refused envelopes are deleted server-side so they cannot be redelivered. Init envelopes are routed through the JS path so the guard applies (the native path writes session state directly), which also keeps init-heavy batches away from the native freeze trigger.
- **Session confirmation** (port of the SDK's ConfirmDoubleRatchetSenderSession): process the peer's first reply on an unconfirmed sender session — validate the full return-inbox field set, decrypt under the ratchet mutex, store the peer's complete sending inbox and mark the session accepted. Ends the perpetual re-initialization churn.
- **Receipt interception on the init path**, matching the established-session and native-batch paths.
- **Ack-by-delete signed with the key matching the inbox type** (conversation signing key vs device key).

## Validation

Each fix was verified live on device against a desktop peer: the native freeze no longer occurs (watchdog + init routing), the hoard drained and stopped redelivering, sessions survive reconnects, the ack redelivery storm ended, and delivery/read receipts now arrive, decrypt, and render — including for freshly sent messages. Unit tests cover the staleness rules (6 tests) and the session-confirmation guards and bookkeeping (5 tests); full suite 47/47.

Includes shared applyEdit-adjacent regions only via the receive path; no changes to sending, message storage, or channel/space logic beyond the receive drain.