### PR TITLE
fix: inline DM read/delivery receipts on mobile

### DIFF
--- a/components/Chat/MentionableText.tsx
+++ b/components/Chat/MentionableText.tsx
@@ -43,6 +43,12 @@ interface MentionableTextProps {
   theme?: AppTheme;
   /** Show an on-device "See translation" toggle for non-target-language text. */
   enableTranslate?: boolean;
+  /**
+   * Inline trailing node (e.g. a DM receipt) rendered as the last child inside
+   * the terminal <Text> so it flows on the same line as the message text and
+   * wraps with it. Sits before the translation toggle when both are present.
+   */
+  receipt?: React.ReactNode;
 }
 
 // Regex patterns for @mentions, URLs, and :emoji:
@@ -118,6 +124,7 @@ function MentionableTextBase({
   onLinkPress,
   theme,
   enableTranslate = false,
+  receipt,
 }: MentionableTextProps) {
   // On-device translation. `text` below is the displayed copy (original or
   // translated), so all parsing/rendering downstream is unchanged.
@@ -452,10 +459,18 @@ function MentionableTextBase({
       // gets an oversized line box on Android (extra emoji-font ascent/descent),
       // which showed as a big empty gap below emoji-only messages.
       return renderWithToggle(
-        <Text style={[style, { fontSize: size, lineHeight: size }]}>{text}</Text>
+        <Text style={[style, { fontSize: size, lineHeight: size }]}>
+          {text}
+          {receipt}
+        </Text>
       );
     }
-    return renderWithToggle(<Text style={style}>{text}</Text>);
+    return renderWithToggle(
+      <Text style={style}>
+        {text}
+        {receipt}
+      </Text>
+    );
   }
 
   // Check if message is emoji-only
@@ -605,6 +620,7 @@ function MentionableTextBase({
 
         return <Text key={`text-${index}`}>{part.content}</Text>;
       })}
+      {receipt}
     </Text>
   );
 }

--- a/components/Chat/MessageMarkdownRenderer.native.tsx
+++ b/components/Chat/MessageMarkdownRenderer.native.tsx
@@ -43,6 +43,13 @@ export interface MessageMarkdownRendererProps {
   onMentionPress?: (userId: string) => void;
   onChannelPress?: (channelId: string) => void;
   onLinkPress?: (url: string) => void;
+  /**
+   * Inline trailing node (e.g. a DM receipt). Appended after the last inline run
+   * when the final block is text (paragraph/heading/list) so it flows on the
+   * same line and wraps with it; otherwise (code/quote/hr) it drops to a compact
+   * trailing row beneath the content.
+   */
+  receipt?: React.ReactNode;
 }
 
 // ---------------------------------------------------------------------------
@@ -285,6 +292,7 @@ function MessageMarkdownRendererBase({
   onMentionPress,
   onChannelPress,
   onLinkPress,
+  receipt,
 }: MessageMarkdownRendererProps) {
   const styles = useMemo(() => createStyles(theme), [theme]);
 
@@ -438,21 +446,33 @@ function MessageMarkdownRendererBase({
     [emojiMap, memberByAddress, onMentionPress, onChannelPress, onLinkPress, styles, theme, mentionStyle, channelStyle, linkStyle]
   );
 
+  // Inline the receipt after the last block's text so it trails the last word
+  // and wraps with it — but only when that block IS text (paragraph/heading/
+  // list). If the message ends in a code block / quote / hr there's no trailing
+  // inline run, so the receipt drops to a compact row beneath (below).
+  const lastIdx = blocks.length - 1;
+  const lastType = lastIdx >= 0 ? blocks[lastIdx].type : undefined;
+  const receiptInlineable =
+    lastType === 'paragraph' || lastType === 'heading' || lastType === 'list';
+
   return (
     <View style={styles.container}>
       {blocks.map((block, bi) => {
         const key = `block-${bi}`;
+        const isLast = bi === lastIdx;
         switch (block.type) {
           case 'heading':
             return (
               <Text key={key} style={[baseTextStyle, styles.heading]}>
                 {renderInline(block.text, key)}
+                {isLast ? receipt : null}
               </Text>
             );
           case 'paragraph':
             return (
               <Text key={key} style={baseTextStyle}>
                 {renderInline(block.text, key)}
+                {isLast ? receipt : null}
               </Text>
             );
           case 'blockquote':
@@ -469,6 +489,7 @@ function MessageMarkdownRendererBase({
                     <Text style={[baseTextStyle, styles.listMarker]}>{item.marker}</Text>
                     <Text style={[baseTextStyle, styles.listText]}>
                       {renderInline(item.text, `${key}-${ii}`)}
+                      {isLast && ii === block.items.length - 1 ? receipt : null}
                     </Text>
                   </View>
                 ))}
@@ -489,6 +510,9 @@ function MessageMarkdownRendererBase({
             return null;
         }
       })}
+      {receipt && !receiptInlineable ? (
+        <View style={styles.receiptRow}>{receipt}</View>
+      ) : null}
     </View>
   );
 }
@@ -649,6 +673,13 @@ const createStyles = (theme: AppTheme) =>
     customEmoji: {
       width: 20,
       height: 20,
+    },
+    // Fallback row for the receipt when the last block isn't inline text
+    // (code/quote/hr) — a compact row beneath the content, left-aligned with it.
+    receiptRow: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      marginTop: Skin.space(2),
     },
   });
 

--- a/components/Chat/MessageRenderer.tsx
+++ b/components/Chat/MessageRenderer.tsx
@@ -40,6 +40,12 @@ interface MessageRendererProps {
   onLinkPress?: (url: string) => void;
   /** Show an on-device "See translation" toggle (MentionableText path only). */
   enableTranslate?: boolean;
+  /**
+   * Inline trailing node (e.g. a DM read/delivery receipt) appended after the
+   * last text run so it flows on the same line as the end of the message and
+   * wraps with it. Threaded into the terminal <Text> by the underlying renderer.
+   */
+  receipt?: React.ReactNode;
 }
 
 function MessageRendererBase({
@@ -56,6 +62,7 @@ function MessageRendererBase({
   onChannelPress,
   onLinkPress,
   enableTranslate = false,
+  receipt,
 }: MessageRendererProps) {
   const isMarkdown = useMemo(() => hasMarkdown(text), [text]);
 
@@ -83,6 +90,7 @@ function MessageRendererBase({
         onMentionPress={onMentionPress}
         onChannelPress={onChannelPress}
         onLinkPress={onLinkPress}
+        receipt={receipt}
       />
     );
   }
@@ -104,6 +112,7 @@ function MessageRendererBase({
         onMentionPress={onMentionPress}
         onChannelPress={onChannelPress}
         onLinkPress={onLinkPress}
+        receipt={receipt}
       />
     );
   }
@@ -118,6 +127,7 @@ function MessageRendererBase({
       onMentionPress={onMentionPress}
       onChannelPress={onChannelPress}
       onLinkPress={onLinkPress}
+      receipt={receipt}
     />
   );
 }

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -20,6 +20,7 @@ import { FarcasterCastCard, containsFarcasterLink, extractFarcasterLink, stripFa
 import { EmojiPicker } from './EmojiPicker';
 import { MessageActionSheet } from './MessageActionSheet';
 import { MessageRenderer } from './MessageRenderer';
+import { ReceiptTicks } from './ReceiptTicks';
 import { EditHistoryModal } from './EditHistoryModal';
 import { ReactionDetailsModal } from './ReactionDetailsModal';
 import { SpaceCallBubble } from './SpaceCallBubble';
@@ -790,26 +791,19 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     [styles, theme, renderUnsignedWarning]
   );
 
-  // DM delivery/read receipt tick on own messages (✓ delivered / ✓✓ read). A
-  // text glyph so it flows inline natively (IconSymbol SVGs can't sit in a
-  // <Text>). Display is unconditional — the master switch gates persistence.
+  // DM delivery/read receipt on own messages (one check delivered / two read).
+  // Returns a <ReceiptTicks> node meant to be threaded into the message text as
+  // an inline trailing element (via MessageRenderer's `receipt` prop) so it
+  // flows on the same line and wraps with the text — matching desktop. Muted
+  // color for both states (not accent); delivered vs read differ only by one vs
+  // two checks. Display is unconditional — the master switch gates persistence.
   const renderReceipt = useCallback(
-    (item: DisplayMessage) => {
+    (item: DisplayMessage): React.ReactNode => {
       if (!isDM || item.userId !== currentUserId) return null;
       if (!item.deliveredAt && !item.readAt) return null;
-      const read = !!item.readAt;
-      // U+FE0E forces text (not emoji) presentation of the check glyph on iOS.
-      const tick = read ? '✓︎✓︎' : '✓︎';
-      return (
-        <Text
-          style={[styles.receiptIndicator, read && styles.receiptIndicatorRead]}
-          accessibilityLabel={read ? 'Read' : 'Delivered'}
-        >
-          {tick}
-        </Text>
-      );
+      return <ReceiptTicks read={!!item.readAt} color={theme.colors.textMuted} />;
     },
-    [isDM, currentUserId, styles]
+    [isDM, currentUserId, theme]
   );
 
   const renderReactions = useCallback(
@@ -1127,6 +1121,12 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
 
       const isCompact = compactMessageIds.has(item.id);
 
+      // DM receipt. Inlined into the plain-text branch (trails the last word);
+      // for the link-card branch (ends in a BrowserLink) or a bodyless message,
+      // it falls back to a compact row beneath the content.
+      const receiptNode = renderReceipt(item);
+      const receiptInlined = !(item.hasLink && item.link) && !!messageTextWithoutLink;
+
       return (
         <Pressable
           onLongPress={handleLongPress}
@@ -1202,9 +1202,12 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                   onMentionPress={onUserPress ? handleMentionPress : undefined}
                   onChannelPress={onChannelLinkPress}
                   onLinkPress={onLinkPress}
+                  receipt={receiptNode}
                 />
               ) : null}
-              {renderReceipt(item)}
+              {!receiptInlined && receiptNode ? (
+                <View style={styles.receiptRow}>{receiptNode}</View>
+              ) : null}
               {/* Per-message indicators on grouped continuation rows (header hidden) */}
               {isCompact && renderCompactIndicators(item, { isSending })}
               {/* Render invite link card if detected */}
@@ -1652,16 +1655,12 @@ const createStyles = (theme: AppTheme) => StyleSheet.create({
     fontFamily: theme.fonts.regular.fontFamily,
     marginLeft: Skin.space(6),
   },
-  // DM receipt tick — trailing, bottom-right of own message content.
-  receiptIndicator: {
-    alignSelf: 'flex-end',
-    color: theme.colors.textSubtle,
-    fontSize: Skin.font(11),
-    fontFamily: theme.fonts.regular.fontFamily,
+  // DM receipt fallback row — used when the tick can't inline into the message
+  // text (link card / bodyless message). Left-aligned beneath the content.
+  receiptRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
     marginTop: Skin.space(2),
-  },
-  receiptIndicatorRead: {
-    color: theme.colors.primary,
   },
   // Row below a compact continuation message holding its per-message indicators
   // ((edited) + unsigned + sending), since the header is hidden when grouped.

--- a/components/Chat/ReceiptTicks.tsx
+++ b/components/Chat/ReceiptTicks.tsx
@@ -1,0 +1,66 @@
+/**
+ * ReceiptTicks — the DM delivery/read receipt glyph.
+ *
+ * Renders a single inline <Image> (one check = delivered, double check = read)
+ * that is meant to sit INSIDE a <Text> so it flows on the same line as the end
+ * of the message and wraps with it — the only way to get Telegram-style inline
+ * receipts in React Native (Yoga has no `display:inline`/float; an element joins
+ * a text line only as a child of the same <Text>, and <Image> is one of the two
+ * elements that legally do so).
+ *
+ * Colour is applied via `tintColor` (the source assets are flat #000 templates),
+ * so it follows the theme. Both states use the same muted colour — delivered and
+ * read differ only by one vs two checks, matching desktop.
+ */
+
+import React from 'react';
+import { Text, Image, StyleSheet } from 'react-native';
+import {
+  RECEIPT_CHECK_SINGLE_URI,
+  RECEIPT_CHECK_DOUBLE_URI,
+  RECEIPT_CHECK_SINGLE_ASPECT,
+  RECEIPT_CHECK_DOUBLE_ASPECT,
+} from './receiptCheckAssets';
+
+interface ReceiptTicksProps {
+  /** true → double check (read); false → single check (delivered). */
+  read: boolean;
+  /** Tint colour — pass the muted theme token. */
+  color: string;
+  /** Rendered height in dp. Width is derived from the asset aspect. Default 9. */
+  size?: number;
+}
+
+// Wrapped in a <Text> with a leading space for two reasons:
+//  1. margins on an inline <Image> inside <Text> are ignored on Android, so a
+//     real space character is the reliable way to gap the tick from the last
+//     word. It scales with the text font, which looks natural.
+//  2. a <Text> wrapper is valid both inside a parent <Text> (inline flow) and
+//     inside a <View> (the fallback row) — so one component fits both call sites.
+function ReceiptTicksBase({ read, color, size = 9 }: ReceiptTicksProps) {
+  const aspect = read ? RECEIPT_CHECK_DOUBLE_ASPECT : RECEIPT_CHECK_SINGLE_ASPECT;
+  return (
+    <Text>
+      {' '}
+      <Image
+        source={{ uri: read ? RECEIPT_CHECK_DOUBLE_URI : RECEIPT_CHECK_SINGLE_URI }}
+        // width from aspect so the check glyph is never stretched; both states
+        // share the same glyph size, so delivered→read doesn't appear to resize.
+        style={[styles.tick, { width: size * aspect, height: size, tintColor: color }]}
+        accessibilityLabel={read ? 'Read' : 'Delivered'}
+      />
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  tick: {
+    // Baseline nudge so the glyph sits level with the text rather than on the
+    // descender line (inline <Image> in <Text> rides slightly low). Tune on device.
+    transform: [{ translateY: 1 }],
+  },
+});
+
+export const ReceiptTicks = React.memo(ReceiptTicksBase);
+
+export default ReceiptTicks;

--- a/components/Chat/receiptCheckAssets.ts
+++ b/components/Chat/receiptCheckAssets.ts
@@ -1,0 +1,26 @@
+/**
+ * Read/delivery receipt check glyphs, embedded as base64 data-URIs.
+ *
+ * WHY data-URI and not a file under `assets/`: a data-URI source lives in the
+ * JS bundle (a string), so it never passes through expo-updates asset-embedding
+ * (`createReleaseUpdatesResources` / `app.manifest`). That sidesteps the
+ * stale-manifest bug that blanked `apex-metallic` in local release builds
+ * (see .agents/tasks/2026-07-23-inline-dm-receipts-mobile.md, apex lesson).
+ *
+ * Both are flat black (#000) shapes on transparent bg — templates. Color is
+ * applied at render time via the <Image> `tintColor` style, so they follow the
+ * theme. Rendered inline inside <Text> so the tick flows with the message text.
+ *
+ * Intrinsic pixel sizes (left-anchored, same check glyph size in both):
+ *   single: 89 x 64   double: 120 x 64
+ */
+
+export const RECEIPT_CHECK_SINGLE_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAFkAAABACAYAAABx0tv8AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAOdEVYdFNvZnR3YXJlAEZpZ21hnrGWYwAAAYpJREFUeAHt3NFNw0AQhOEpgRJcAiWkFDqADnAHoQNPJ5RACZRACWCLrECQRD77drNnzyfts29/OXmxZUBq6E4jDh7HeR/n8zQf4wxQ8Gqe8RP370zhO8gq1wLbvEIWmxPY5g5SrCTwNAdIkdLAilxoSWD9XRRYGniAzLI08Bt0F8+iwM4U2JkCO1NgZwrsTIGdKbAzBXamwM4U2JkCO1NgZwrsTIGdKbCzlIEP+H5hYxinR9vPqFIGPl646ID2fjZNBQ65eGUpA3cZDlFJysCTp0yHWSFt4EmPhIcqlDrwpOROzhg6feDJPRo45AVNBDYvaC90U4EN0c6hmwxsiPyHbzqwIfIusYnAhsi3zKYCGyLPUpsMbIjbL7fpwIa43ZK7CGyI+GV3FdgQcUvvMrAh/JffdWBD+EVQ4F+I+jEU+AyiXhQFvoJYH0eBZyCWRzpCgWcjlsVS4EKEAocgFDgEocAhCAUOQShwCEKBQxAKHIJQ4BCEAocgFDjEA/5/37KHArvooO9ZSi1fGbSY8Lt2I/cAAAAASUVORK5CYII=';
+
+export const RECEIPT_CHECK_DOUBLE_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHgAAABACAYAAADRTbMSAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAOdEVYdFNvZnR3YXJlAEZpZ21hnrGWYwAAAlpJREFUeAHt3eGR0kAYh/HHDujAlHAdeCXQgW8H2sFRgh2AFWgHaAXaQexAO9DshMwwyJFks+9uWP7PzPuBmRuW29/BkZlAQFXdG9SSNt287+bpdPtbN9+7+UWerq3/GZWksKm/u/l7MW03W/z7cGP9J9SiXsM9n2f8ehlZOzy2BhXVFNwwR3wawx3mE2p2U3GH2ZC2qbjDs1jNaC5umIZ0zcEdRk0sBjflMzgGt0VNKhb3SJpicMPsUaPF4qZ6FxuL26J30aMtwU1xHCpcx4RbccKtOOFWnHArTrgVJ9yKE27FCbfihFtxwq044VaccCtOuBUn3IoT7pU21PGXI9yLnulPMzlfbM99Ygv3ou3Iovd0prxwL2oY35BUv7x3wr3SR/JuglfCfaUv5N+M1An3RgfKbEqqhDvSjnKbszThTigc95bcpNiEOyMj7sGWQhZuRMZ9IAt3Qca6kYWbIGOdyMJNmLEuZOE6ZKwDWbiOGWWRhZshowyycDNm5EUWboGMPMjCLZjhiyzcFWT4IAt3RRlpkYW7wow0yJ64G/pvZd3Tn9iw438Q4d7IWIbsiXvrvl9OPyPcCRnxyF64zYT7PkY+7pYH/MSBEbdZHrihg9P6LQ/8cRJjHbgQ98og3AkZ5XFxWF+4ZxllcUNtwvWFeyWjHG5ol2h94d7IKIMbCse/LcJ1z8iPO9QQjyzcGRn5cYeabn4gXPeM/LhD4eX6gHDdM/LjnrdDuO5tuf5/Mdd51TseDLfExSkb+q+LeHe6/ZP+gop/yFND/2ry9nQ7XEzya8b1lUrXP3TIA69oT6/4AAAAAElFTkSuQmCC';
+
+/** width / height of each source asset — multiply by render height for width. */
+export const RECEIPT_CHECK_SINGLE_ASPECT = 89 / 64;
+export const RECEIPT_CHECK_DOUBLE_ASPECT = 120 / 64;


### PR DESCRIPTION
Replaces the mobile DM read/delivery receipt glyphs (unicode checks on their own line, accent-colored) with proper inline check icons that trail the last word of the message and wrap with it, matching desktop.

Highlights:
- Receipt now flows inline inside the message text (Telegram-style) instead of a separate line, removing the empty gap between grouped messages.
- Renders the check as an inline tintable Image (one check = delivered, two = read), muted color for both states — no longer the accent color.
- Icons are embedded as base64 data-URIs (bundled in JS, not expo-asset files) to avoid the stale-manifest blank-image issue that affected other new assets in local release builds.
- Threaded through the plain text path (MentionableText) and the markdown path (last text block inline, compact row fallback for code/quote/hr endings); link-card and bodyless posts use a fallback row.

Media (embed/sticker) receipts are intentionally not included here (they show no receipt today, so no regression).