### PR TITLE
fix: inline unsigned-message indicator on mobile

### DIFF
--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -21,6 +21,7 @@ import { EmojiPicker } from './EmojiPicker';
 import { MessageActionSheet } from './MessageActionSheet';
 import { MessageRenderer } from './MessageRenderer';
 import { ReceiptTicks } from './ReceiptTicks';
+import { UnsignedIndicator } from './UnsignedIndicator';
 import { EditHistoryModal } from './EditHistoryModal';
 import { ReactionDetailsModal } from './ReactionDetailsModal';
 import { SpaceCallBubble } from './SpaceCallBubble';
@@ -758,15 +759,46 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     [showToast, styles, theme]
   );
 
+  // Inline variant of the unsigned warning — trails the last word of the message
+  // text (before the receipt) instead of sitting in the header. Same gate as
+  // renderUnsignedWarning; tappable to surface the same explanation toast.
+  const showUnsignedToast = useCallback(
+    () =>
+      showToast({
+        type: 'info',
+        title: 'Unsigned message',
+        message: 'Message does not have a valid signature, this may not be from the sender.',
+      }),
+    [showToast]
+  );
+  const renderUnsignedInline = useCallback(
+    (item: DisplayMessage): React.ReactNode => {
+      if (item.renderType === 'system' || item.renderType === 'error') return null;
+      if (item.originalMessage?.signature) return null;
+      if (item.sendStatus === 'sending' || item.sendStatus === 'failed') return null;
+      return (
+        // Yellow tint for the inline warning. (Header/media unsigned still uses
+        // theme.colors.warning; see renderUnsignedWarning.)
+        <UnsignedIndicator color="#EAB308" onPress={showUnsignedToast} size={13} />
+      );
+    },
+    [showUnsignedToast]
+  );
+
   // On compact continuation rows the whole header is hidden, dropping the
   // per-message indicators. Reproduce the two that matter — (edited) + unsigned —
   // on one small row below the content. Pinned/bookmark are deliberately omitted
   // (they have dedicated surfaces). The sending spinner is included since it's
   // also dropped on compact rows today. Returns null when there's nothing to show.
   const renderCompactIndicators = useCallback(
-    (item: DisplayMessage, opts?: { isSending?: boolean }) => {
+    (item: DisplayMessage, opts?: { isSending?: boolean; showUnsigned?: boolean }) => {
       const isEdited = item.isEdited;
+      // Text posts render the unsigned warning inline in the message text, so
+      // they opt out here (showUnsigned:false). Media rows have no inline text,
+      // so they keep it in this compact row (default true).
+      const allowUnsigned = opts?.showUnsigned !== false;
       const showUnsigned =
+        allowUnsigned &&
         item.renderType !== 'system' &&
         item.renderType !== 'error' &&
         !item.originalMessage?.signature &&
@@ -777,7 +809,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
       return (
         <View style={styles.compactIndicatorRow}>
           {isEdited && <Text style={styles.editedIndicator}>(edited)</Text>}
-          {renderUnsignedWarning(item)}
+          {showUnsigned && renderUnsignedWarning(item)}
           {isSending && (
             <ActivityIndicator
               size="small"
@@ -1165,7 +1197,17 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
       // for the link-card branch (ends in a BrowserLink) or a bodyless message,
       // it falls back to a compact row beneath the content.
       const receiptNode = renderReceipt(item);
-      const receiptInlined = !(item.hasLink && item.link) && !!messageTextWithoutLink;
+      // Trailing inline group: unsigned warning first, then the receipt. Both
+      // trail the last word of the message text (and wrap with it). Composed
+      // here so ordering is guaranteed regardless of the underlying renderer.
+      const unsignedNode = renderUnsignedInline(item);
+      const trailingInline = unsignedNode || receiptNode ? (
+        <>
+          {unsignedNode}
+          {receiptNode}
+        </>
+      ) : null;
+      const trailingInlined = !(item.hasLink && item.link) && !!messageTextWithoutLink;
 
       return (
         <Pressable
@@ -1185,7 +1227,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                 {item.isEdited && (
                   <Text style={styles.editedIndicator}>(edited)</Text>
                 )}
-                {renderUnsignedWarning(item)}
+                {/* Unsigned warning moved inline (trails the message text). */}
                 {isSending && (
                   <ActivityIndicator
                     size="small"
@@ -1242,14 +1284,15 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                   onMentionPress={onUserPress ? handleMentionPress : undefined}
                   onChannelPress={onChannelLinkPress}
                   onLinkPress={onLinkPress}
-                  receipt={receiptNode}
+                  receipt={trailingInline}
                 />
               ) : null}
-              {!receiptInlined && receiptNode ? (
-                <View style={styles.receiptRow}>{receiptNode}</View>
+              {!trailingInlined && trailingInline ? (
+                <View style={styles.receiptRow}>{trailingInline}</View>
               ) : null}
-              {/* Per-message indicators on grouped continuation rows (header hidden) */}
-              {isCompact && renderCompactIndicators(item, { isSending })}
+              {/* Per-message indicators on grouped continuation rows (header hidden).
+                  Unsigned is inline in the text, so opt out of it here. */}
+              {isCompact && renderCompactIndicators(item, { isSending, showUnsigned: false })}
               {/* Render invite link card if detected */}
               {inviteLink && (
                 <InviteLinkCard
@@ -1288,7 +1331,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
         </Pressable>
       );
     },
-    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, renderUnsignedWarning, renderCompactIndicators, renderReceipt, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress, compactMessageIds]
+    [styles, theme, onRetryMessage, onJoinSpace, onOpenFarcasterCast, renderReactions, renderAvatar, renderUnsignedInline, renderCompactIndicators, renderReceipt, scrollToMessageWithHighlight, customEmojis, members, channels, roles, isEveryoneAuthorized, currentUserId, onUserPress, handleMentionPress, onChannelLinkPress, onLinkPress, highlightedMessageId, highlightAnimStyle, getReplyPreview, handleMessageLongPress, compactMessageIds]
   );
 
   const renderCast = useCallback(

--- a/components/Chat/UnsignedIndicator.tsx
+++ b/components/Chat/UnsignedIndicator.tsx
@@ -1,0 +1,55 @@
+/**
+ * UnsignedIndicator — the "unsigned message" warning glyph, inline.
+ *
+ * Like ReceiptTicks, this is an inline <Image> wrapped in a <Text> so it flows
+ * on the same line as the end of the message and wraps with it. Unlike the
+ * receipt, it is tappable: the <Text> carries an onPress that surfaces the
+ * "unsigned message" explanation (the mobile equivalent of desktop's tooltip).
+ *
+ * The <Text> wrapper (with a leading space) is valid both inside a parent <Text>
+ * (inline flow) and inside a <View> (the fallback row), so one component fits
+ * both call sites. Color is applied via `tintColor` (the source is a flat #000
+ * template), so callers pass the amber `theme.colors.warning`.
+ */
+
+import React from 'react';
+import { Text, Image, StyleSheet } from 'react-native';
+import { UNSIGNED_ICON_URI, UNSIGNED_ICON_ASPECT } from './unsignedIconAsset';
+
+interface UnsignedIndicatorProps {
+  /** Tint colour — pass the amber warning theme token. */
+  color: string;
+  /** Fired on tap — surface the "unsigned message" explanation. */
+  onPress: () => void;
+  /** Rendered height in dp. Width is derived from the asset aspect. Default 11. */
+  size?: number;
+}
+
+function UnsignedIndicatorBase({ color, onPress, size = 11 }: UnsignedIndicatorProps) {
+  return (
+    <Text
+      onPress={onPress}
+      suppressHighlighting
+      accessibilityRole="button"
+      accessibilityLabel="Unsigned message"
+    >
+      {' '}
+      <Image
+        source={{ uri: UNSIGNED_ICON_URI }}
+        style={[styles.icon, { width: size * UNSIGNED_ICON_ASPECT, height: size, tintColor: color }]}
+      />
+    </Text>
+  );
+}
+
+const styles = StyleSheet.create({
+  icon: {
+    // Inline <Image> in <Text> rides high (top-aligned) on Android; push it down
+    // so its bottom sits on the text baseline. Tune on device.
+    transform: [{ translateY: 4 }],
+  },
+});
+
+export const UnsignedIndicator = React.memo(UnsignedIndicatorBase);
+
+export default UnsignedIndicator;

--- a/components/Chat/unsignedIconAsset.ts
+++ b/components/Chat/unsignedIconAsset.ts
@@ -1,0 +1,20 @@
+/**
+ * Unsigned-message warning glyph, embedded as a base64 data-URI.
+ *
+ * Same rationale as receiptCheckAssets: a data-URI lives in the JS bundle, so it
+ * never passes through expo-updates asset-embedding and can't be blanked by a
+ * stale manifest in local release builds (see the apex lesson).
+ *
+ * Flat black (#000) template on a transparent bg. Color is applied at render
+ * time via the <Image> `tintColor` style, so it follows whatever colour the
+ * caller passes. Source: unsigned-indicator-filled.png (64x64).
+ *
+ * NOTE: currently the FILLED variant. An OUTLINE variant also exists (swap the
+ * base64 to test); both are 64x64 so UNSIGNED_ICON_ASPECT stays 1.
+ */
+
+export const UNSIGNED_ICON_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAOdEVYdFNvZnR3YXJlAEZpZ21hnrGWYwAAAl9JREFUeAHtmo1tnDAYhp9WHSDd4NugGcEbtBuEDZoNmg06QugE7Qa0E7Qb0A2STHDBOixd0HH5DP7BxI/0Spy4O15/xi8GDJVK5S3zjjzIoM+DPo6f+0F/Bv1n58igbtBhRj/H7+ySm0EPzDfeyX7nCztDeL3h0yJcsyPsGD946i874Sv+jXe6pXCEZb1/OhSuKJiW5Y13uqdQbIgdAslQID3hClBcIDaEa3xxgSiE7f3iArFF36gev2Lds3EEfcPN5HfaQhg2jLYR56a5Rvnbjo3SoB/Lc2huljYZiIK+9/sL/6P9j80FYotf8M2hLYDVdzaCoDcdsgCbCURf0yEL0JGZBj/DoQuQNRCFZYZDFyBbILb4m41RAKvkgSgsMxqrAFaGhKwxGqsAHYloWG4yZgGsogeiBDAZswDegfgeP+7Y9psb2/hvREJY1zspzgAngxKfM6CjHNRngbYADWW9tDQEDEQh7DO+S0NA+zwgSiDO0QY05XTuiZBEOM7qGaJEMOXOApkcp490LMMKYply6ji+9Ih9jEU0kY2llHcgCvF7P6W8A7EFcpsOLXUgCmQ3G0sGBX0iM3djse0l8TbRMTteoUlk5FwopSrCDRfoExgI8WZojV6sNTi9FxDSzPcfF+4LhR1y4j5MC5ACYX4qLKThk9vIUQDLdEms3e7IwIeT7X+kQzjmzW+OExQh7bP9J7dxulr8ajRV9Lo8BTZn3Cr1F0PA7vjB/vl1aaeQ5lKUSz2KrDPkNxpL6mX41+zrbrBn4fL7huPlqcRh8TB6t6vV9x7slUqlUqlUFvAMReNWB+c3R2cAAAAASUVORK5CYII=';
+
+/** width / height of the source asset — multiply by render height for width. */
+export const UNSIGNED_ICON_ASPECT = 64 / 64;


### PR DESCRIPTION
Moves the unsigned-message warning inline: it now trails the last word of the message text (before the read receipt) instead of sitting in the header, matching the treatment of the read/delivery receipts.

- Inline warning icon (filled triangle) rendered as a tintable Image inside the message text, so it flows and wraps with the text; still tappable to surface the same 'unsigned message' explanation.
- Composes a trailing group per message (unsigned first, then receipt) threaded through the text renderers.
- Removed from the text-post header and the compact-row fallback; media (image/sticker) messages keep the warning in their header for now.
- Icon embedded as a base64 data-URI (bundled in JS, not an expo-asset file) to avoid the stale-manifest blank-image issue in local release builds.