### PR TITLE
fix: honest, resilient DM/space send (queue on disconnect, sent-on-transmit)

### DIFF
--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -294,6 +294,28 @@ const RetryButton = React.memo(function RetryButton({
   );
 });
 
+// Sending spinner that only appears after a short delay, so a fast send
+// (which completes in well under a second) never flashes a spinner. Mirrors
+// desktop's 1s-delayed "Sending..." indicator. It unmounts the moment the
+// message leaves 'sending' state, so a quick send shows no spinner at all;
+// only a genuinely slow or offline send reveals it.
+const SENDING_INDICATOR_DELAY_MS = 1000;
+const DelayedSendingIndicator = React.memo(function DelayedSendingIndicator({
+  color,
+  style,
+}: {
+  color: string;
+  style?: React.ComponentProps<typeof ActivityIndicator>['style'];
+}) {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const timer = setTimeout(() => setVisible(true), SENDING_INDICATOR_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, []);
+  if (!visible) return null;
+  return <ActivityIndicator size="small" color={color} style={style} />;
+});
+
 export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(function MessagesList({
   messages,
   theme,
@@ -811,8 +833,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
           {isEdited && <Text style={styles.editedIndicator}>(edited)</Text>}
           {showUnsigned && renderUnsignedWarning(item)}
           {isSending && (
-            <ActivityIndicator
-              size="small"
+            <DelayedSendingIndicator
               color={theme.colors.textMuted}
               style={styles.sendingIndicator}
             />
@@ -1229,8 +1250,7 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                 )}
                 {/* Unsigned warning moved inline (trails the message text). */}
                 {isSending && (
-                  <ActivityIndicator
-                    size="small"
+                  <DelayedSendingIndicator
                     color={theme.colors.textMuted}
                     style={styles.sendingIndicator}
                   />

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -294,28 +294,6 @@ const RetryButton = React.memo(function RetryButton({
   );
 });
 
-// Sending spinner that only appears after a short delay, so a fast send
-// (which completes in well under a second) never flashes a spinner. Mirrors
-// desktop's 1s-delayed "Sending..." indicator. It unmounts the moment the
-// message leaves 'sending' state, so a quick send shows no spinner at all;
-// only a genuinely slow or offline send reveals it.
-const SENDING_INDICATOR_DELAY_MS = 1000;
-const DelayedSendingIndicator = React.memo(function DelayedSendingIndicator({
-  color,
-  style,
-}: {
-  color: string;
-  style?: React.ComponentProps<typeof ActivityIndicator>['style'];
-}) {
-  const [visible, setVisible] = useState(false);
-  useEffect(() => {
-    const timer = setTimeout(() => setVisible(true), SENDING_INDICATOR_DELAY_MS);
-    return () => clearTimeout(timer);
-  }, []);
-  if (!visible) return null;
-  return <ActivityIndicator size="small" color={color} style={style} />;
-});
-
 export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(function MessagesList({
   messages,
   theme,
@@ -833,7 +811,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
           {isEdited && <Text style={styles.editedIndicator}>(edited)</Text>}
           {showUnsigned && renderUnsignedWarning(item)}
           {isSending && (
-            <DelayedSendingIndicator
+            <ActivityIndicator
+              size="small"
               color={theme.colors.textMuted}
               style={styles.sendingIndicator}
             />
@@ -1250,7 +1229,8 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
                 )}
                 {/* Unsigned warning moved inline (trails the message text). */}
                 {isSending && (
-                  <DelayedSendingIndicator
+                  <ActivityIndicator
+                    size="small"
                     color={theme.colors.textMuted}
                     style={styles.sendingIndicator}
                   />

--- a/hooks/chat/useDeleteSpaceMessage.ts
+++ b/hooks/chat/useDeleteSpaceMessage.ts
@@ -21,7 +21,7 @@ export interface UseDeleteSpaceMessageParams {
 export function useDeleteSpaceMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseDeleteSpaceMessageParams) => {
@@ -29,9 +29,9 @@ export function useDeleteSpaceMessage() {
         throw new Error('User must be logged in to delete messages');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server. Please wait for connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await sendDeleteMessage({
         spaceId: params.spaceId,

--- a/hooks/chat/useEditSpaceMessage.ts
+++ b/hooks/chat/useEditSpaceMessage.ts
@@ -41,7 +41,7 @@ export function canEditMessage(message: { userId: string; timestamp: number }, c
 export function useEditSpaceMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseEditSpaceMessageParams) => {
@@ -49,9 +49,9 @@ export function useEditSpaceMessage() {
         throw new Error('User must be logged in to edit messages');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server. Please wait for connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       // Enforce edit window
       const elapsed = Date.now() - params.originalCreatedDate;

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -72,7 +72,7 @@ export function useSendDirectEmbedMessage() {
   const storage = useStorageAdapter();
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected, subscribe } = useWebSocket();
+  const { enqueueOutbound, subscribe } = useWebSocket();
   const apiClient = getQuorumClient();
 
   return useMutation({
@@ -144,9 +144,9 @@ export function useSendDirectEmbedMessage() {
         throw new Error('Device encryption keys not initialized. Please restart the app.');
       }
 
-      if (!isConnected) {
-        throw new Error('WebSocket not connected. Please check your connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       // If no session and no recipientInfo provided, try to fetch the registration
       let finalRecipientInfo = recipientInfo;

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -234,7 +234,7 @@ export function useSendDirectMessage() {
           message.publicKey = signatureData.publicKey;
         }
       }
-      logger.debug(`[SEND-TIMING] sign=${Date.now() - _tStart}ms`); // temp
+      logger.warn(`[SEND-TIMING] sign=${Date.now() - _tStart}ms`); // temp
 
       // E2E encryption is required for direct messages
       const hasDeviceKeys = encryptionService.hasDeviceKeys();
@@ -323,7 +323,7 @@ export function useSendDirectMessage() {
       );
 
       const _tPrep = Date.now(); // [SEND-TIMING] temp
-      logger.debug(`[SEND-TIMING] devices=${allTargetDevices.length} prep=${_tPrep - _tStart}ms`); // temp
+      logger.warn(`[SEND-TIMING] devices=${allTargetDevices.length} prep=${_tPrep - _tStart}ms`); // temp
 
       // Send to all target device inboxes (multi-device support)
       await sendEncryptedMessageToAllDevices(
@@ -344,7 +344,7 @@ export function useSendDirectMessage() {
         // (fires inside the socket-OPEN drain). Until then it stays 'sending',
         // so an offline/queued message is never shown as sent.
         () => {
-          logger.debug(`[SEND-TIMING] flush total=${Date.now() - _tStart}ms fromPrep=${Date.now() - _tPrep}ms`); // temp
+          logger.warn(`[SEND-TIMING] flush total=${Date.now() - _tStart}ms fromPrep=${Date.now() - _tPrep}ms`); // temp
           markDmMessageSent(recipientAddress, message.messageId);
         }
       );

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -177,7 +177,6 @@ export function useSendDirectMessage() {
       skipSigning,
     }: SendDirectMessageParams): Promise<Message> => {
       const senderId = user?.address ?? 'unknown';
-      const _tStart = Date.now(); // [SEND-TIMING] temp instrumentation
 
       // Use pre-generated values from onMutate, or generate new ones
       const nonce = _nonce ?? 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
@@ -234,7 +233,6 @@ export function useSendDirectMessage() {
           message.publicKey = signatureData.publicKey;
         }
       }
-      logger.warn(`[SEND-TIMING] sign=${Date.now() - _tStart}ms`); // temp
 
       // E2E encryption is required for direct messages
       const hasDeviceKeys = encryptionService.hasDeviceKeys();
@@ -295,7 +293,6 @@ export function useSendDirectMessage() {
           const recipientReg = await apiClient.fetchUserRegistration(recipientAddress);
           if (recipientReg) {
             const recipientDevices = toAllDeviceInfos(recipientReg);
-            logger.warn(`[SEND-TIMING] recipientDevices=${recipientDevices.length} self=${recipientAddress === senderId}`); // temp
             allTargetDevices = [...recipientDevices];
           }
 
@@ -303,7 +300,6 @@ export function useSendDirectMessage() {
           const senderReg = await apiClient.fetchUserRegistration(senderId);
           if (senderReg) {
             const senderDevices = toAllDeviceInfos(senderReg);
-            logger.warn(`[SEND-TIMING] senderDevices=${senderDevices.length}`); // temp
             const otherSenderDevices = senderDevices.filter(
               (d) => d.inboxAddress !== deviceKeyset.inboxAddress
             );
@@ -324,9 +320,6 @@ export function useSendDirectMessage() {
         allTargetDevices.map((d) => d.inboxAddress.slice(0, 12)),
       );
 
-      const _tPrep = Date.now(); // [SEND-TIMING] temp
-      logger.warn(`[SEND-TIMING] devices=${allTargetDevices.length} prep=${_tPrep - _tStart}ms`); // temp
-
       // Send to all target device inboxes (multi-device support)
       await sendEncryptedMessageToAllDevices(
         conversationId,
@@ -345,10 +338,7 @@ export function useSendDirectMessage() {
         // Flip the bubble to 'sent' only when the message actually transmits
         // (fires inside the socket-OPEN drain). Until then it stays 'sending',
         // so an offline/queued message is never shown as sent.
-        () => {
-          logger.warn(`[SEND-TIMING] flush total=${Date.now() - _tStart}ms fromPrep=${Date.now() - _tPrep}ms`); // temp
-          markDmMessageSent(recipientAddress, message.messageId);
-        }
+        () => markDmMessageSent(recipientAddress, message.messageId)
       );
 
       // Return the signed message but keep it in its optimistic 'sending' state:

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -318,13 +318,14 @@ export function useSendDirectMessage() {
       return { ...message, sendStatus: 'sent' };
     },
 
-    onMutate: async ({
-      conversationId,
-      recipientAddress,
-      text,
-      repliesToMessageId,
-      replyToAuthorAddress,
-    }) => {
+    onMutate: async (variables) => {
+      const {
+        conversationId,
+        recipientAddress,
+        text,
+        repliesToMessageId,
+        replyToAuthorAddress,
+      } = variables;
       // Use the same query key format as useMessages hook (spaceId, channelId = recipientAddress)
       const key = queryKeys.messages.infinite(recipientAddress, recipientAddress);
       const senderId = user?.address ?? 'unknown';
@@ -345,6 +346,15 @@ export function useSendDirectMessage() {
 
       // Generate messageId using SHA-256 hash (matching desktop implementation)
       const { messageId } = generateMessageIdHash(nonce, senderId, text);
+
+      // Reuse these EXACT values in mutationFn so the optimistic bubble and the
+      // message we actually send share ONE id/nonce/date. Without this they
+      // diverge (mutationFn generates its own), which is confusing and can make
+      // edits/deletes/replies reference a different id than the recipient has.
+      // mutationFn reads these via its `_messageId`/`_nonce`/`_createdDate` params.
+      variables._nonce = nonce;
+      variables._messageId = messageId;
+      variables._createdDate = createdDate;
 
       const optimisticMessage: Message = {
         messageId,

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -295,6 +295,7 @@ export function useSendDirectMessage() {
           const recipientReg = await apiClient.fetchUserRegistration(recipientAddress);
           if (recipientReg) {
             const recipientDevices = toAllDeviceInfos(recipientReg);
+            logger.warn(`[SEND-TIMING] recipientDevices=${recipientDevices.length} self=${recipientAddress === senderId}`); // temp
             allTargetDevices = [...recipientDevices];
           }
 
@@ -302,6 +303,7 @@ export function useSendDirectMessage() {
           const senderReg = await apiClient.fetchUserRegistration(senderId);
           if (senderReg) {
             const senderDevices = toAllDeviceInfos(senderReg);
+            logger.warn(`[SEND-TIMING] senderDevices=${senderDevices.length}`); // temp
             const otherSenderDevices = senderDevices.filter(
               (d) => d.inboxAddress !== deviceKeyset.inboxAddress
             );

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -177,6 +177,7 @@ export function useSendDirectMessage() {
       skipSigning,
     }: SendDirectMessageParams): Promise<Message> => {
       const senderId = user?.address ?? 'unknown';
+      const _tStart = Date.now(); // [SEND-TIMING] temp instrumentation
 
       // Use pre-generated values from onMutate, or generate new ones
       const nonce = _nonce ?? 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
@@ -233,6 +234,7 @@ export function useSendDirectMessage() {
           message.publicKey = signatureData.publicKey;
         }
       }
+      logger.debug(`[SEND-TIMING] sign=${Date.now() - _tStart}ms`); // temp
 
       // E2E encryption is required for direct messages
       const hasDeviceKeys = encryptionService.hasDeviceKeys();
@@ -320,6 +322,9 @@ export function useSendDirectMessage() {
         allTargetDevices.map((d) => d.inboxAddress.slice(0, 12)),
       );
 
+      const _tPrep = Date.now(); // [SEND-TIMING] temp
+      logger.debug(`[SEND-TIMING] devices=${allTargetDevices.length} prep=${_tPrep - _tStart}ms`); // temp
+
       // Send to all target device inboxes (multi-device support)
       await sendEncryptedMessageToAllDevices(
         conversationId,
@@ -338,7 +343,10 @@ export function useSendDirectMessage() {
         // Flip the bubble to 'sent' only when the message actually transmits
         // (fires inside the socket-OPEN drain). Until then it stays 'sending',
         // so an offline/queued message is never shown as sent.
-        () => markDmMessageSent(recipientAddress, message.messageId)
+        () => {
+          logger.debug(`[SEND-TIMING] flush total=${Date.now() - _tStart}ms fromPrep=${Date.now() - _tPrep}ms`); // temp
+          markDmMessageSent(recipientAddress, message.messageId);
+        }
       );
 
       // Return the signed message but keep it in its optimistic 'sending' state:

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -226,10 +226,9 @@ export function useSendDirectMessage() {
         throw new Error('Device encryption keys not initialized. Please restart the app.');
       }
 
-      if (!isConnected) {
-        logger.debug(`[DM-send ${me}] FAIL: not connected`);
-        throw new Error('WebSocket not connected. Please check your connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       // Get our device keyset for the InitializationEnvelope
       const deviceKeyset = await getDeviceKeyset();

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -138,6 +138,28 @@ export function useSendDirectMessage() {
   const { enqueueOutbound, isConnected, subscribe } = useWebSocket();
   const apiClient = getQuorumClient();
 
+  // Flip an optimistic DM bubble from 'sending' to 'sent' in the cache. Called
+  // when the message actually transmits (via the onFlushed hook below). Guarded
+  // on 'sending' so it no-ops if a server copy already replaced the message or
+  // it was already marked sent (race-safe).
+  const markDmMessageSent = (recipient: string, messageId: string) => {
+    const key = queryKeys.messages.infinite(recipient, recipient);
+    queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          messages: page.messages.map((m) =>
+            m.messageId === messageId && m.sendStatus === 'sending'
+              ? { ...m, sendStatus: 'sent' as const }
+              : m
+          ),
+        })),
+      };
+    });
+  };
+
   return useMutation({
     mutationFn: async ({
       conversationId,
@@ -312,15 +334,21 @@ export function useSendDirectMessage() {
           inboxEncryptionPublicKey: deviceKeyset.inboxEncryptionPublicKey,
         },
         senderId,
-        user?.displayName
+        user?.displayName,
+        // Flip the bubble to 'sent' only when the message actually transmits
+        // (fires inside the socket-OPEN drain). Until then it stays 'sending',
+        // so an offline/queued message is never shown as sent.
+        () => markDmMessageSent(recipientAddress, message.messageId)
       );
 
-      return { ...message, sendStatus: 'sent' };
+      // Return the signed message but keep it in its optimistic 'sending' state:
+      // onSuccess attaches the signature, and the onFlushed callback above flips
+      // it to 'sent' on real transmission.
+      return message;
     },
 
     onMutate: async (variables) => {
       const {
-        conversationId,
         recipientAddress,
         text,
         repliesToMessageId,
@@ -474,47 +502,48 @@ export function useSendDirectMessage() {
     onSuccess: async (message, { conversationId, recipientAddress }, context) => {
       const key = queryKeys.messages.infinite(recipientAddress, recipientAddress);
 
-      // The returned message has a different ID than the optimistic one
-      // Use the optimistic message ID but update the status. Carry the real
-      // signature/publicKey across (optimistic msg has neither) so signed
-      // messages don't render the unsigned-warning icon.
-      const sentMessage: Message = context?.optimisticMessage
-        ? {
-            ...context.optimisticMessage,
-            sendStatus: 'sent' as const,
-            signature: message.signature,
-            publicKey: message.publicKey,
-          }
-        : message;
-
-      // Update cache with sent status
-      queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
-        if (!old) return old;
-        return {
-          ...old,
-          pages: old.pages.map((page, index) => {
-            if (index === 0) {
-              return {
-                ...page,
-                messages: page.messages.map((m) =>
-                  m.messageId === context?.optimisticMessage.messageId
-                    ? sentMessage
-                    : m
-                ),
-              };
-            }
-            return page;
-          }),
-        };
-      });
+      // Attach the real signature/publicKey to the optimistic bubble (it had
+      // neither) so signed messages don't show the unsigned-warning icon. Do
+      // NOT mark it 'sent' here — at this point the message is only QUEUED; the
+      // onFlushed callback flips it to 'sent' when it actually transmits. Spread
+      // the CURRENT cached message so we never clobber a 'sent' the flush may
+      // already have applied (race-safe). With aligned ids, the sent message
+      // and the optimistic bubble share one messageId.
+      const optimisticId = context?.optimisticMessage.messageId;
+      if (optimisticId) {
+        queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
+          if (!old) return old;
+          return {
+            ...old,
+            pages: old.pages.map((page) => ({
+              ...page,
+              messages: page.messages.map((m) =>
+                m.messageId === optimisticId
+                  ? { ...m, signature: message.signature, publicKey: message.publicKey }
+                  : m
+              ),
+            })),
+          };
+        });
+      }
 
       // Defer storage writes so UI updates instantly
       queueMicrotask(async () => {
         try {
-          // Persist to local storage with 'sent' status
+          // Persist WITHOUT the ephemeral sendStatus so a reload renders the
+          // message normally instead of restoring a stale 'sending' spinner.
+          const persisted: Message = context?.optimisticMessage
+            ? {
+                ...context.optimisticMessage,
+                signature: message.signature,
+                publicKey: message.publicKey,
+              }
+            : { ...message };
+          delete (persisted as Record<string, unknown>).sendStatus;
+
           await storage.saveMessage(
-            sentMessage,
-            sentMessage.createdDate,
+            persisted,
+            persisted.createdDate,
             recipientAddress,
             'direct',
             '',
@@ -849,7 +878,8 @@ export async function sendEncryptedMessageToAllDevices(
     inboxEncryptionPublicKey: number[];
   },
   userAddress: string,
-  displayName?: string
+  displayName?: string,
+  onFlushed?: () => void
 ): Promise<void> {
   // Import the NativeCryptoProvider for encryption
   const { NativeCryptoProvider } = await import('@/services/crypto/native-provider');
@@ -1146,6 +1176,9 @@ export async function sendEncryptedMessageToAllDevices(
       }
     }
 
+    // Reached only inside the outbound-queue drain, which runs only when the
+    // socket is OPEN — the honest "actually transmitting" moment.
+    onFlushed?.();
     return outbounds;
   });
 }

--- a/hooks/chat/useSendDirectReaction.ts
+++ b/hooks/chat/useSendDirectReaction.ts
@@ -59,7 +59,7 @@ export function useSendDirectReaction() {
   const storage = useStorageAdapter();
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
   const apiClient = getQuorumClient();
 
   return useMutation({
@@ -108,9 +108,9 @@ export function useSendDirectReaction() {
         throw new Error('Device encryption keys not initialized.');
       }
 
-      if (!isConnected) {
-        throw new Error('WebSocket not connected.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       // Fetch recipient info if needed
       let finalRecipientInfo = recipientInfo;
@@ -232,7 +232,7 @@ export function useRemoveDirectReaction() {
   const storage = useStorageAdapter();
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
   const apiClient = getQuorumClient();
 
   return useMutation({
@@ -279,9 +279,9 @@ export function useRemoveDirectReaction() {
         throw new Error('Device encryption keys not initialized.');
       }
 
-      if (!isConnected) {
-        throw new Error('WebSocket not connected.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       let finalRecipientInfo = recipientInfo;
       if (!finalRecipientInfo && !hasSession) {

--- a/hooks/chat/useSendEmbedMessage.ts
+++ b/hooks/chat/useSendEmbedMessage.ts
@@ -33,7 +33,7 @@ export interface UseSendEmbedMessageParams {
 export function useSendEmbedMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseSendEmbedMessageParams) => {
@@ -41,9 +41,9 @@ export function useSendEmbedMessage() {
         throw new Error('User must be logged in to send messages');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server. Please wait for connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await sendEmbedMessage({
         spaceId: params.spaceId,

--- a/hooks/chat/useSendSpaceMessage.ts
+++ b/hooks/chat/useSendSpaceMessage.ts
@@ -36,7 +36,7 @@ export interface UseSendSpaceMessageParams {
 export function useSendSpaceMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseSendSpaceMessageParams) => {
@@ -44,9 +44,9 @@ export function useSendSpaceMessage() {
         throw new Error('User must be logged in to send messages');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server. Please wait for connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await sendSpaceMessage({
         spaceId: params.spaceId,

--- a/hooks/chat/useSendStickerMessage.ts
+++ b/hooks/chat/useSendStickerMessage.ts
@@ -17,7 +17,7 @@ export interface UseSendStickerMessageParams {
 export function useSendStickerMessage() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseSendStickerMessageParams) => {
@@ -25,9 +25,9 @@ export function useSendStickerMessage() {
         throw new Error('User must be logged in to send stickers');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server. Please wait for connection.');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await sendStickerMessage({
         spaceId: params.spaceId,

--- a/hooks/chat/useSpaceReactions.ts
+++ b/hooks/chat/useSpaceReactions.ts
@@ -47,7 +47,7 @@ export interface UseSpaceReactionParams {
 export function useAddSpaceReaction() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseSpaceReactionParams) => {
@@ -55,9 +55,9 @@ export function useAddSpaceReaction() {
         throw new Error('User must be logged in to add reactions');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await sendReaction({
         spaceId: params.spaceId,
@@ -159,7 +159,7 @@ export function useAddSpaceReaction() {
 export function useRemoveSpaceReaction() {
   const queryClient = useQueryClient();
   const { user } = useAuth();
-  const { enqueueOutbound, isConnected } = useWebSocket();
+  const { enqueueOutbound } = useWebSocket();
 
   return useMutation({
     mutationFn: async (params: UseSpaceReactionParams) => {
@@ -167,9 +167,9 @@ export function useRemoveSpaceReaction() {
         throw new Error('User must be logged in to remove reactions');
       }
 
-      if (!isConnected) {
-        throw new Error('Not connected to server');
-      }
+      // Do NOT gate on isConnected: enqueueOutbound buffers the envelope and the
+      // WS client flushes it on (re)connect, so a transient disconnect (or a
+      // stale isConnected) must not drop the send. Mirrors the DM delete/edit paths.
 
       const result = await removeReaction({
         spaceId: params.spaceId,


### PR DESCRIPTION
## Summary

Makes message **sending** more honest and resilient. Three real changes (a spinner-delay experiment and temporary timing instrumentation were added then removed, so they net out).

### 1. Enqueue sends on transient disconnect instead of aborting (DM + space)
Every message-send hook did a pre-flight `if (!isConnected) throw`, dropping the message before it was encrypted or queued — so a brief disconnect (or a stale `isConnected`) lost the message with no recovery (DM showed a red "WebSocket not connected"; space aborted silently). Removed the throw across all message-send hooks so the encrypted envelope flows into `enqueueOutbound`, which buffers while the socket is not OPEN and flushes on reconnect. Mirrors the already-established DM delete/edit paths and desktop's durable-queue send.

### 2. Share one message id between the optimistic bubble and the sent DM
`onMutate` and `mutationFn` each generated their own nonce/messageId, so the sender's bubble and the message actually sent used different ids (reconciled only by cache mapping — a latent source of edit/delete/reply id mismatches). The id is now generated once in `onMutate` and reused, matching desktop.

### 3. Mark a DM `sent` only when it actually transmits, not when queued
Previously the bubble flipped to `sent` as soon as the message was handed to the outbound queue — so a message queued while offline showed as "sent" though it had not been transmitted. The `sent` transition now fires from the real send moment (inside the socket-OPEN drain); an offline/queued message stays `sending` and flips to `sent` on reconnect. Never a false "sent". Persisted without the ephemeral status so a reload renders normally.

## Scope
- Changes 2 and 3 are DM-only for now; change 1 covers DM + space. Space-side honest status can follow once DM is proven.
- Does NOT address space append-ack silent-loss or DM send retry/failed-timeout (both tracked separately).

## Not a crypto/perf change
Multi-second DM sends in the **dev build** were investigated and found to be a dev-environment artifact — the native crypto lib is release-compiled and fast, and prod-preview sends are ~instant. Tracked as a low-priority dev-latency task. No crypto touched here.

## Verification
- Typecheck: no new errors. Lint: 0 errors on changed files.
- On-device (Android dev build): online sends work normally; offline sends correctly show `sending` (not a false "sent") and deliver on reconnect; edit/delete/reply unaffected.