### PR TITLE
fix: DM sessions reach the confirmed state; hear and sign every session inbox

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -2916,6 +2916,12 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
                     }
 
                     if (!decryptedText || decryptedText.startsWith('Decryption failed') || !successInboxId) {
+                      // Bound the redelivery loop (PR #170 parity): a frame no
+                      // stored state can decrypt replays forever otherwise —
+                      // this branch previously returned without counting the
+                      // attempt, and dead frames re-drained several times a
+                      // minute indefinitely.
+                      recordInboxAttempt(message.inboxAddress, message.timestamp);
                       return;
                     }
 

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -484,7 +484,9 @@ async function sendEncryptedEmbedMessage(
           ? bytesToHex(conversationSigningKeypair.private_key)
           : '',
         identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-        tag: conversationInboxAddress,
+        // SDK-standard tag: the SENDER'S DEVICE INBOX — the session identity
+        // the receiver files this session under (matches useSendDirectMessage).
+        tag: deviceKeyset.inboxAddress,
         message: encrypted.envelope,
         type: 'direct',
       };
@@ -576,7 +578,8 @@ async function sendEncryptedEmbedMessage(
             ? bytesToHex(ourConversationInbox.signingPrivateKey)
             : '',
           identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-          tag: ourConversationInbox?.inboxAddress || deviceKeyset.inboxAddress,
+          // SDK-standard tag: sender's device inbox (see first-send builder).
+          tag: deviceKeyset.inboxAddress,
           message: encrypted.envelope,
           type: 'direct',
         };

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -17,6 +17,7 @@ import { queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type Em
 import type { Message } from '@quilibrium/quorum-shared';
 import type { MessagePreview } from '@/utils/messagePreview';
 import { NativeSigningProvider } from '@/services/crypto/native-signing-provider';
+import { signConfirmedEnvelope } from './useSendDirectMessage';
 import { sha256 } from '@noble/hashes/sha2.js';
 
 /** SHA-256 messageId hash, matching desktop: nonce + 'post' + sender + JSON.stringify(content). */
@@ -618,13 +619,14 @@ async function sendEncryptedEmbedMessage(
           plaintext: envelopeBytes,
         });
 
+        const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
         const existingSessionMsg = {
           type: 'direct',
           inbox_address: sendingInbox.inbox_address,
           envelope: sealedEnvelope,
           ephemeral_public_key: bytesToHex(sealingEphemeralKey.public_key),
-          inbox_public_key: '',
-          inbox_signature: '',
+          inbox_public_key: inboxAuth.inbox_public_key,
+          inbox_signature: inboxAuth.inbox_signature,
         };
 
         outbounds.push(JSON.stringify(existingSessionMsg));

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -86,6 +86,8 @@ function bytesToBase64(bytes: Uint8Array): string {
   return btoa(binary);
 }
 
+import { base64ToHex, hexToBase64 } from '@/utils/encoding';
+
 /**
  * Sign a sealed envelope for a CONFIRMED session with the conversation-inbox
  * signing key the peer shared at confirmation.
@@ -112,21 +114,21 @@ export async function signConfirmedEnvelope(
   }
   try {
     const signingProvider = new NativeSigningProvider();
-    const privateKeyBase64 = bytesToBase64(
-      new Uint8Array(hexToBytes(sendingInbox.inbox_private_key))
-    );
+    const privateKeyBase64 = hexToBase64(sendingInbox.inbox_private_key);
     const messageBase64 = bytesToBase64(new TextEncoder().encode(sealedEnvelope));
     const signatureBase64 = await signingProvider.signEd448(privateKeyBase64, messageBase64);
-    const signatureHex = Array.from(atob(signatureBase64))
-      .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
-      .join('');
     return {
       inbox_public_key: sendingInbox.inbox_public_key,
-      inbox_signature: signatureHex,
+      inbox_signature: base64ToHex(signatureBase64),
     };
-  } catch {
-    // Unsigned fallback — the send may be rejected, but never block the
-    // attempt on a signing failure.
+  } catch (err) {
+    // Unsigned fallback — never block the send attempt on a signing failure,
+    // but log it: an unsigned confirmed-path message may be rejected
+    // downstream with no other trace.
+    logger.warn(
+      '[DM-send] confirmed-envelope signing failed, sending unsigned:',
+      err instanceof Error ? err.message : err,
+    );
     return { inbox_public_key: '', inbox_signature: '' };
   }
 }
@@ -954,20 +956,12 @@ export async function sendEncryptedMessageToAllDevices(
   // Get all existing encryption states for this conversation
   const existingStates = encryptionStateStorage.getEncryptionStates(conversationId);
 
-  // Ghost-session prune (SDK/desktop parity): drop TAGGED rows whose tag no
-  // longer corresponds to any registered device inbox (stale devices, plus
-  // legacy rows tagged with conversation-inbox addresses from before the
-  // SDK-standard tag fix). Tagless rows are left alone. Skipped when the
-  // device list is empty so a failed registration fetch can't wipe healthy
-  // sessions.
-  if (allTargetDevices.length > 0) {
-    const validInboxes = new Set(allTargetDevices.map((d) => d.inboxAddress));
-    for (const s of existingStates) {
-      if (s.tag && !validInboxes.has(s.tag)) {
-        encryptionStateStorage.deleteEncryptionState(conversationId, s.inboxId);
-      }
-    }
-  }
+  // NOTE: desktop also prunes session rows whose tag matches no registered
+  // device inbox here. Mobile deliberately does NOT yet: callers reach this
+  // function with device lists of varying completeness (some pass only the
+  // recipient's devices), and pruning against a partial list would delete
+  // healthy own-device sync sessions. A prune needs its own
+  // registration-sourced valid set — tracked as follow-up work.
 
   // Determine which devices need new sessions vs existing sessions
   const devicesNeedingNewSession: typeof allTargetDevices = [];

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -72,6 +72,65 @@ export function resetDMSession(conversationId: string): void {
 
 import type { MessagesPage, InfiniteMessagesData } from './queryTypes';
 
+// Chunked bytes→base64 (String.fromCharCode(...bytes) overflows the argument
+// limit on large envelopes, e.g. media embeds).
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = '';
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + CHUNK) as unknown as number[]
+    );
+  }
+  return btoa(binary);
+}
+
+/**
+ * Sign a sealed envelope for a CONFIRMED session with the conversation-inbox
+ * signing key the peer shared at confirmation.
+ *
+ * SDK parity (DoubleRatchetInboxEncrypt): when sending_inbox.inbox_public_key
+ * is set, the ciphertext is signed with sending_inbox.inbox_private_key and
+ * both fields ride on the sealed message — writes to a registered
+ * conversation inbox are verified against that key. Mobile historically sent
+ * these fields empty, which went unnoticed because sessions never reached
+ * the confirmed state; once they did, unsigned confirmed-path messages were
+ * dropped downstream (no delivery, no receipt).
+ *
+ * Returns empty fields when the session has no signing material (init sends
+ * to device inboxes are unsigned by design).
+ */
+export async function signConfirmedEnvelope(
+  sendingInbox:
+    | { inbox_public_key?: string; inbox_private_key?: string }
+    | undefined,
+  sealedEnvelope: string
+): Promise<{ inbox_public_key: string; inbox_signature: string }> {
+  if (!sendingInbox?.inbox_public_key || !sendingInbox.inbox_private_key) {
+    return { inbox_public_key: '', inbox_signature: '' };
+  }
+  try {
+    const signingProvider = new NativeSigningProvider();
+    const privateKeyBase64 = bytesToBase64(
+      new Uint8Array(hexToBytes(sendingInbox.inbox_private_key))
+    );
+    const messageBase64 = bytesToBase64(new TextEncoder().encode(sealedEnvelope));
+    const signatureBase64 = await signingProvider.signEd448(privateKeyBase64, messageBase64);
+    const signatureHex = Array.from(atob(signatureBase64))
+      .map((c) => c.charCodeAt(0).toString(16).padStart(2, '0'))
+      .join('');
+    return {
+      inbox_public_key: sendingInbox.inbox_public_key,
+      inbox_signature: signatureHex,
+    };
+  } catch {
+    // Unsigned fallback — the send may be rejected, but never block the
+    // attempt on a signing failure.
+    return { inbox_public_key: '', inbox_signature: '' };
+  }
+}
+
 /**
  * Generate a messageId using SHA-256 hash, matching desktop implementation.
  * The hash is computed from: nonce + 'post' + senderAddress + messageContent
@@ -839,13 +898,14 @@ async function sendEncryptedMessage(
           plaintext: envelopeBytes,
         });
 
+        const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
         const existingSessionMsg = {
           type: 'direct',
           inbox_address: sendingInbox.inbox_address,
           envelope: sealedEnvelope,
           ephemeral_public_key: bytesToHex(sealingEphemeralKey.public_key),
-          inbox_public_key: '',
-          inbox_signature: '',
+          inbox_public_key: inboxAuth.inbox_public_key,
+          inbox_signature: inboxAuth.inbox_signature,
         };
         outbounds.push(JSON.stringify(existingSessionMsg));
       } else {
@@ -932,14 +992,8 @@ export async function sendEncryptedMessageToAllDevices(
     const existingState =
       tagMatches.find((s) => s.sendingInbox?.inbox_public_key) ?? tagMatches[0];
     if (existingState) {
-      // TEMP-VERIFY: strip before merge
-      logger.warn(
-        `[DM-VERIFY] session for ${device.inboxAddress.slice(0, 12)}: ${existingState.sendingInbox?.inbox_public_key ? 'SEND-READY (confirmed)' : 'unconfirmed (init-wrap)'}`,
-      );
       devicesWithExistingSession.push({ device, state: existingState });
     } else {
-      // TEMP-VERIFY: strip before merge
-      logger.warn(`[DM-VERIFY] no session for ${device.inboxAddress.slice(0, 12)} — new X3DH`);
       devicesNeedingNewSession.push(device);
     }
   }
@@ -1200,13 +1254,14 @@ export async function sendEncryptedMessageToAllDevices(
           plaintext: envelopeBytes,
         });
 
+        const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
         const existingSessionMsg = {
           type: 'direct',
           inbox_address: sendingInbox.inbox_address,
           envelope: sealedEnvelope,
           ephemeral_public_key: bytesToHex(sealingEphemeralKey.public_key),
-          inbox_public_key: '',
-          inbox_signature: '',
+          inbox_public_key: inboxAuth.inbox_public_key,
+          inbox_signature: inboxAuth.inbox_signature,
         };
 
         outbounds.push(JSON.stringify(existingSessionMsg));

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -688,7 +688,12 @@ async function sendEncryptedMessage(
           ? bytesToHex(conversationSigningKeypair.private_key)
           : '',
         identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-        tag: conversationInboxAddress,
+        // SDK-standard tag: the SENDER'S DEVICE INBOX (the session identity
+        // the receiver files this session under). Previously mobile sent the
+        // return conversation inbox here, so peers filed our sessions under
+        // an address absent from every device-registration list — desktop's
+        // ghost-session prune then deleted them on every send.
+        tag: deviceKeyset.inboxAddress,
         message: encrypted.envelope,
         type: 'direct',
       };
@@ -792,7 +797,8 @@ async function sendEncryptedMessage(
             ? bytesToHex(ourConversationInbox.signingPrivateKey)
             : '',
           identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-          tag: ourConversationInbox?.inboxAddress || deviceKeyset.inboxAddress,
+          // SDK-standard tag: sender's device inbox (see first-send builder).
+          tag: deviceKeyset.inboxAddress,
           message: encrypted.envelope,
           type: 'direct',
         };
@@ -887,7 +893,21 @@ export async function sendEncryptedMessageToAllDevices(
 
   // Get all existing encryption states for this conversation
   const existingStates = encryptionStateStorage.getEncryptionStates(conversationId);
-  const existingInboxTags = new Set(existingStates.map((s) => s.tag).filter(Boolean));
+
+  // Ghost-session prune (SDK/desktop parity): drop TAGGED rows whose tag no
+  // longer corresponds to any registered device inbox (stale devices, plus
+  // legacy rows tagged with conversation-inbox addresses from before the
+  // SDK-standard tag fix). Tagless rows are left alone. Skipped when the
+  // device list is empty so a failed registration fetch can't wipe healthy
+  // sessions.
+  if (allTargetDevices.length > 0) {
+    const validInboxes = new Set(allTargetDevices.map((d) => d.inboxAddress));
+    for (const s of existingStates) {
+      if (s.tag && !validInboxes.has(s.tag)) {
+        encryptionStateStorage.deleteEncryptionState(conversationId, s.inboxId);
+      }
+    }
+  }
 
   // Determine which devices need new sessions vs existing sessions
   const devicesNeedingNewSession: typeof allTargetDevices = [];
@@ -902,11 +922,24 @@ export async function sendEncryptedMessageToAllDevices(
       continue;
     }
 
-    // Check if we have an existing session for this device's inbox (by tag)
-    const existingState = existingStates.find((s) => s.tag === device.inboxAddress);
+    // Check if we have an existing session for this device's inbox (by tag).
+    // Several rows can share a tag (e.g. a session created by RECEIVING the
+    // peer's message — born send-ready with their full return-inbox keys —
+    // alongside an older self-initiated one still waiting for confirmation).
+    // Prefer the send-ready row: it skips the init-envelope wrapping
+    // entirely.
+    const tagMatches = existingStates.filter((s) => s.tag === device.inboxAddress);
+    const existingState =
+      tagMatches.find((s) => s.sendingInbox?.inbox_public_key) ?? tagMatches[0];
     if (existingState) {
+      // TEMP-VERIFY: strip before merge
+      logger.warn(
+        `[DM-VERIFY] session for ${device.inboxAddress.slice(0, 12)}: ${existingState.sendingInbox?.inbox_public_key ? 'SEND-READY (confirmed)' : 'unconfirmed (init-wrap)'}`,
+      );
       devicesWithExistingSession.push({ device, state: existingState });
     } else {
+      // TEMP-VERIFY: strip before merge
+      logger.warn(`[DM-VERIFY] no session for ${device.inboxAddress.slice(0, 12)} — new X3DH`);
       devicesNeedingNewSession.push(device);
     }
   }
@@ -995,7 +1028,10 @@ export async function sendEncryptedMessageToAllDevices(
         return_inbox_public_key: bytesToHex(conversationSigningKeypair.public_key),
         return_inbox_private_key: bytesToHex(conversationSigningKeypair.private_key),
         identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-        tag: conversationInboxAddress,
+        // SDK-standard tag: sender's device inbox — the identity the
+        // receiver files this session under (previously the conversation
+        // inbox, which peers' device lists never contain).
+        tag: deviceKeyset.inboxAddress,
         message: encrypted.envelope,
         type: 'direct',
       };
@@ -1114,7 +1150,8 @@ export async function sendEncryptedMessageToAllDevices(
           return_inbox_public_key: bytesToHex(convSigningKeypair.public_key),
           return_inbox_private_key: bytesToHex(convSigningKeypair.private_key),
           identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-          tag: convInboxAddress,
+          // SDK-standard tag: sender's device inbox (see first-send builder).
+          tag: deviceKeyset.inboxAddress,
           message: encrypted.envelope,
           type: 'direct',
         };
@@ -1260,7 +1297,10 @@ async function encryptWithExistingSession(
     message: messageBytes,
   });
 
-  // Save updated state - preserve sendingInbox and tag
+  // Save updated state - preserve sendingInbox, tag, AND the X3DH ephemeral
+  // keys (an unconfirmed session re-wraps each message reusing them;
+  // dropping them here forced a fresh ephemeral next send and a receiver
+  // ephemeral-cache miss).
   // The inboxAddress is OUR receiving inbox (not where we send TO)
   encryptionStateStorage.saveEncryptionState({
     state: result.ratchet_state,
@@ -1270,6 +1310,8 @@ async function encryptWithExistingSession(
     sentAccept: encryptionState.sentAccept,
     sendingInbox: encryptionState.sendingInbox, // Preserve where to send
     tag: encryptionState.tag,
+    x3dhEphemeralPublicKey: encryptionState.x3dhEphemeralPublicKey,
+    x3dhEphemeralPrivateKey: encryptionState.x3dhEphemeralPrivateKey,
   }, true);
 
   return { envelope: result.envelope, ephemeralPublicKey };

--- a/hooks/chat/useSendDirectReaction.ts
+++ b/hooks/chat/useSendDirectReaction.ts
@@ -13,6 +13,7 @@ import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
 import { queryKeys, bytesToHex, hexToBytes } from '@quilibrium/quorum-shared';
+import { signConfirmedEnvelope } from './useSendDirectMessage';
 import type { Message, ReactionMessage, RemoveReactionMessage, Reaction } from '@quilibrium/quorum-shared';
 
 export interface SendDirectReactionParams {
@@ -435,13 +436,14 @@ export async function sendEncryptedControlMessage(
         plaintext: envelopeBytes,
       });
 
+      const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
       const sealedMessage = {
         type: 'direct',
         inbox_address: sendingInbox.inbox_address,
         envelope: sealedEnvelope,
         ephemeral_public_key: bytesToHex(sealingEphemeralKey.public_key),
-        inbox_public_key: '',
-        inbox_signature: '',
+        inbox_public_key: inboxAuth.inbox_public_key,
+        inbox_signature: inboxAuth.inbox_signature,
       };
 
       outbounds.push(JSON.stringify(sealedMessage));

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -1047,10 +1047,6 @@ class EncryptionService {
     // Save encryption state - this is the PRIMARY state for this conversation
     // The sendingInbox field tells us where to send, so we don't need a separate "latest" state
     encryptionStateStorage.saveEncryptionState(encryptionState, true);
-    // TEMP-VERIFY: strip before merge
-    console.warn(
-      `[DM-VERIFY] recipient session stored tag=${(unsealed.tag || '').slice(0, 12)} sendReady=${!!sendingInbox.inbox_public_key}`,
-    );
 
     // Remember this envelope's server timestamp so an exact redelivery is
     // recognized as stale even inside the skew tolerance window (state rows

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -584,7 +584,7 @@ class EncryptionService {
           inbox_public_key: unsealed.return_inbox_public_key,
           inbox_private_key: unsealed.return_inbox_private_key,
         },
-        tag: state.tag ?? unsealed.tag,
+        tag: state.tag || unsealed.tag,
       };
       encryptionStateStorage.saveEncryptionState(confirmedState, true);
       // Route future received replies on the peer's return inbox to this

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -567,6 +567,11 @@ class EncryptionService {
 
       // Persist the CONFIRMED state immediately, inside the lock (desktop
       // parity: accept plaintext + store state changes is one atomic step).
+      // Keep the row's OWN tag (the target device inbox): the send path
+      // selects sessions by tag, so overwriting it with the PEER's tag
+      // (unsealed.tag) un-linked the confirmed row from its device and the
+      // next send re-initialized from scratch — sessions could never stay
+      // confirmed. Desktop preserves the session's own tag here.
       const confirmedState: EncryptionState = {
         state: decryptResult.ratchet_state,
         timestamp: Date.now(),
@@ -579,7 +584,7 @@ class EncryptionService {
           inbox_public_key: unsealed.return_inbox_public_key,
           inbox_private_key: unsealed.return_inbox_private_key,
         },
-        tag: unsealed.tag,
+        tag: state.tag ?? unsealed.tag,
       };
       encryptionStateStorage.saveEncryptionState(confirmedState, true);
       // Route future received replies on the peer's return inbox to this
@@ -985,12 +990,17 @@ class EncryptionService {
     const decryptedMessage = textDecoder.decode(new Uint8Array(decryptResult.message));
 
     // Create sendingInbox structure for sealing future replies
-    // This is the sender's inbox info we'll use to seal messages to them
+    // This is the sender's inbox info we'll use to seal messages to them.
+    // SDK model: the init envelope carries the sender's FULL return-inbox key
+    // set (including the signing keys), so a recipient session is born
+    // send-ready — no separate confirmation round-trip is needed in this
+    // direction. Leaving the keys empty here (the previous behavior) made
+    // the send path treat this session as unconfirmed forever.
     const sendingInbox: SendingInbox = {
       inbox_address: unsealed.return_inbox_address,
       inbox_encryption_key: unsealed.return_inbox_encryption_key,
-      inbox_public_key: '', // Empty until session is confirmed (we don't know their signing key yet)
-      inbox_private_key: '', // Always empty - we never have their private key
+      inbox_public_key: unsealed.return_inbox_public_key || '',
+      inbox_private_key: unsealed.return_inbox_private_key || '',
     };
 
     // IMPORTANT: Generate conversation inbox keypairs for the receiver
@@ -1025,12 +1035,22 @@ class EncryptionService {
       inboxId: conversationInboxAddress,  // Key by OUR conversation inbox
       sentAccept: false,
       sendingInbox,  // Where we SEND replies (sender's return inbox)
-      tag: conversationInboxAddress,  // Session tag
+      // SDK model: the envelope tag is the SENDER'S DEVICE INBOX and is the
+      // session's identity — the send path selects sessions by
+      // tag === target device inbox, so storing it is what lets a reply
+      // reuse this (send-ready) session instead of spinning up a parallel
+      // sender session. The previous value (our own conversation inbox)
+      // made this row invisible to sends.
+      tag: unsealed.tag || conversationInboxAddress,
     };
 
     // Save encryption state - this is the PRIMARY state for this conversation
     // The sendingInbox field tells us where to send, so we don't need a separate "latest" state
     encryptionStateStorage.saveEncryptionState(encryptionState, true);
+    // TEMP-VERIFY: strip before merge
+    console.warn(
+      `[DM-VERIFY] recipient session stored tag=${(unsealed.tag || '').slice(0, 12)} sendReady=${!!sendingInbox.inbox_public_key}`,
+    );
 
     // Remember this envelope's server timestamp so an exact redelivery is
     // recognized as stale even inside the skew tolerance window (state rows

--- a/services/crypto/encryption-state-storage.ts
+++ b/services/crypto/encryption-state-storage.ts
@@ -382,35 +382,20 @@ class EncryptionStateStorage {
    */
   saveConversationInboxKeypair(keypair: ConversationInboxKeypair): void {
     const key = `${KEYS.CONVERSATION_INBOX_KEY}${keypair.conversationId}`;
-    // First time we've seen this conversation's inbox → make sure its push
-    // binding gets registered so the peer's messages wake this device.
-    const isNew = this.storage.getString(key) == null;
+    const addrKey = `${INBOX_KEYPAIR_BY_ADDR_PREFIX}${keypair.inboxAddress}`;
+    // First time we've seen this INBOX ADDRESS → make sure its push binding
+    // gets registered so the peer's messages wake this device. Keyed on the
+    // per-address slot: the per-conversation slot is last-writer-wins, so a
+    // second session inbox in the same conversation would look "not new"
+    // there and silently skip push registration.
+    const isNew = this.storage.getString(addrKey) == null;
     this.storage.set(key, JSON.stringify(keypair));
-    this.storage.set(
-      `${INBOX_KEYPAIR_BY_ADDR_PREFIX}${keypair.inboxAddress}`,
-      JSON.stringify(keypair)
-    );
+    this.storage.set(addrKey, JSON.stringify(keypair));
     if (isNew) {
       scheduleConversationInboxPushRegistration();
     }
   }
 
-  /**
-   * Get the keypair for a SPECIFIC conversation inbox address. Reads the
-   * per-address key first; falls back to scanning the legacy per-conversation
-   * slots (which only retain each conversation's most recent inbox).
-   */
-  getConversationInboxKeypairForInbox(inboxAddress: string): ConversationInboxKeypair | null {
-    const data = this.storage.getString(`${INBOX_KEYPAIR_BY_ADDR_PREFIX}${inboxAddress}`);
-    if (data) {
-      try {
-        return JSON.parse(data) as ConversationInboxKeypair;
-      } catch {
-        // fall through to legacy scan
-      }
-    }
-    return this.getConversationInboxKeypairByAddress(inboxAddress);
-  }
 
   /**
    * Get the inbox keypair for a conversation
@@ -427,10 +412,23 @@ class EncryptionStateStorage {
   }
 
   /**
-   * Delete conversation inbox keypair
+   * Delete conversation inbox keypair (both the per-conversation slot and
+   * the per-address copy, so a deleted conversation's inbox doesn't keep
+   * getting resubscribed and push-registered).
    */
   deleteConversationInboxKeypair(conversationId: string): void {
     const key = `${KEYS.CONVERSATION_INBOX_KEY}${conversationId}`;
+    const data = this.storage.getString(key);
+    if (data) {
+      try {
+        const kp = JSON.parse(data) as ConversationInboxKeypair;
+        if (kp.inboxAddress) {
+          this.storage.remove(`${INBOX_KEYPAIR_BY_ADDR_PREFIX}${kp.inboxAddress}`);
+        }
+      } catch {
+        // Malformed slot — still remove it below
+      }
+    }
     this.storage.remove(key);
   }
 

--- a/services/crypto/encryption-state-storage.ts
+++ b/services/crypto/encryption-state-storage.ts
@@ -28,6 +28,9 @@ export type {
   ConversationInboxKeypair,
 } from '@quilibrium/quorum-shared';
 
+// Per-inbox-address keypair copies (see saveConversationInboxKeypair).
+const INBOX_KEYPAIR_BY_ADDR_PREFIX = 'conversationInboxByAddr:';
+
 // Debounced best-effort push re-registration. A brand-new conversation
 // inbox must be registered with quorum-api so the peer's DMs can wake this
 // device — push registration otherwise only runs at startup/token-rotation
@@ -369,6 +372,13 @@ class EncryptionStateStorage {
   /**
    * Save a per-conversation inbox keypair
    * This keypair is used to receive replies for a specific conversation
+   *
+   * Also stored keyed BY INBOX ADDRESS: the per-conversation slot is
+   * last-writer-wins, so with multi-device sends (one return inbox per
+   * device session) only the last device's keypair survived there. The
+   * per-address copy lets the send path re-advertise a SESSION's own
+   * return inbox (desktop parity), which is what makes the peer's
+   * confirming reply land back on the row the send path reads.
    */
   saveConversationInboxKeypair(keypair: ConversationInboxKeypair): void {
     const key = `${KEYS.CONVERSATION_INBOX_KEY}${keypair.conversationId}`;
@@ -376,9 +386,30 @@ class EncryptionStateStorage {
     // binding gets registered so the peer's messages wake this device.
     const isNew = this.storage.getString(key) == null;
     this.storage.set(key, JSON.stringify(keypair));
+    this.storage.set(
+      `${INBOX_KEYPAIR_BY_ADDR_PREFIX}${keypair.inboxAddress}`,
+      JSON.stringify(keypair)
+    );
     if (isNew) {
       scheduleConversationInboxPushRegistration();
     }
+  }
+
+  /**
+   * Get the keypair for a SPECIFIC conversation inbox address. Reads the
+   * per-address key first; falls back to scanning the legacy per-conversation
+   * slots (which only retain each conversation's most recent inbox).
+   */
+  getConversationInboxKeypairForInbox(inboxAddress: string): ConversationInboxKeypair | null {
+    const data = this.storage.getString(`${INBOX_KEYPAIR_BY_ADDR_PREFIX}${inboxAddress}`);
+    if (data) {
+      try {
+        return JSON.parse(data) as ConversationInboxKeypair;
+      } catch {
+        // fall through to legacy scan
+      }
+    }
+    return this.getConversationInboxKeypairByAddress(inboxAddress);
   }
 
   /**

--- a/services/crypto/encryption-state-storage.ts
+++ b/services/crypto/encryption-state-storage.ts
@@ -439,6 +439,19 @@ class EncryptionStateStorage {
    * Used when we need to decrypt a message that arrived at a conversation-specific inbox
    */
   getConversationInboxKeypairByAddress(inboxAddress: string): ConversationInboxKeypair | null {
+    // Per-address store first — the legacy per-conversation slot only holds
+    // the most recently created inbox of each conversation, so scanning it
+    // alone missed every other session inbox. The receive path uses this
+    // lookup both to recognize "this is one of OUR inboxes" (a miss caused
+    // messages to be silently dropped as echoes) and to unseal envelopes.
+    const direct = this.storage.getString(`${INBOX_KEYPAIR_BY_ADDR_PREFIX}${inboxAddress}`);
+    if (direct) {
+      try {
+        return JSON.parse(direct) as ConversationInboxKeypair;
+      } catch {
+        // fall through to legacy scan
+      }
+    }
     // Get all keys and find the one with matching inbox address
     const allKeys = this.storage.getAllKeys();
     for (const key of allKeys) {
@@ -468,13 +481,28 @@ class EncryptionStateStorage {
    */
   getAllConversationInboxKeypairs(): ConversationInboxKeypair[] {
     const out: ConversationInboxKeypair[] = [];
+    const seen = new Set<string>();
     const allKeys = this.storage.getAllKeys();
     for (const key of allKeys) {
-      if (!key.startsWith(KEYS.CONVERSATION_INBOX_KEY)) continue;
+      // Sweep BOTH stores: the legacy per-conversation slot keeps only the
+      // most recently created inbox of each conversation (last-writer-wins),
+      // while every session inbox has a per-address entry. Missing the
+      // per-address entries here meant that after an app restart,
+      // subscriptions and push bindings only covered the last inbox per
+      // conversation — peers replying to any other session inbox went
+      // unheard until they fell back to the device inbox (the "messages
+      // arrive minutes later" symptom).
+      const isLegacy = key.startsWith(KEYS.CONVERSATION_INBOX_KEY);
+      const isByAddr = key.startsWith(INBOX_KEYPAIR_BY_ADDR_PREFIX);
+      if (!isLegacy && !isByAddr) continue;
       const data = this.storage.getString(key);
       if (!data) continue;
       try {
-        out.push(JSON.parse(data) as ConversationInboxKeypair);
+        const kp = JSON.parse(data) as ConversationInboxKeypair;
+        if (kp.inboxAddress && !seen.has(kp.inboxAddress)) {
+          seen.add(kp.inboxAddress);
+          out.push(kp);
+        }
       } catch {
         // Skip malformed entries
       }
@@ -487,22 +515,10 @@ class EncryptionStateStorage {
    * Used for resubscribing to all inboxes we created when initiating conversations
    */
   getAllConversationInboxAddresses(): string[] {
-    const addresses: string[] = [];
-    const allKeys = this.storage.getAllKeys();
-    for (const key of allKeys) {
-      if (key.startsWith(KEYS.CONVERSATION_INBOX_KEY)) {
-        const data = this.storage.getString(key);
-        if (data) {
-          try {
-            const keypair = JSON.parse(data) as ConversationInboxKeypair;
-            addresses.push(keypair.inboxAddress);
-          } catch {
-            // Skip malformed entries
-          }
-        }
-      }
-    }
-    return addresses;
+    // Derived from the full keypair sweep so subscriptions cover EVERY
+    // session inbox, not just the last-created one per conversation (see
+    // getAllConversationInboxKeypairs).
+    return this.getAllConversationInboxKeypairs().map((kp) => kp.inboxAddress);
   }
 
   // Utility


### PR DESCRIPTION
## Problem

DM sender sessions never reached the confirmed state, so every send re-ran full X3DH session establishment for every target device (~2-3s per send, 6 init envelopes per message, mutual session churn with desktop). Independently, desktop→mobile messages were routinely delayed for minutes or lost.

## Root causes (verified against the channels SDK, which defines the init-envelope `tag` as the sender's device inbox and the session identity)

1. **Receive discarded the SDK tag.** Recipient sessions were stored tagged with our own conversation inbox and with the peer's return-inbox signing keys blanked, so the send path (which selects sessions by tag = target device inbox) could never find or reuse them.
2. **Send emitted a non-SDK tag** (conversation-inbox address). Peers filed our sessions under an address absent from every device-registration list; desktop's ghost-session prune then deleted them on every send.
3. **The confirmed-send path was unsigned.** Dead code until now (sessions never confirmed); once reachable, unsigned confirmed-path messages were dropped downstream with no delivery and no receipt.
4. **After an app restart, mobile only listened on the most recently created mailbox per conversation** (subscriptions, push bindings, and the receive-path echo filter all read a last-writer-wins store), so peer replies to any other session inbox were silently discarded — the long-standing "messages arrive minutes later or never" symptom.

## Fixes

- Recipient sessions store the envelope tag + full sendingInbox key set (send-ready at birth, per the SDK model)
- All DM init-envelope builders emit tag = own device inbox
- Confirmed-session sends (messages, embeds, reactions) sign the sealed envelope with the conversation-inbox key (SDK parity)
- Conversation-inbox keypairs are additionally stored keyed by inbox address; subscriptions, push registration, and the receive-path lookup sweep both stores
- Send path prefers a send-ready row when several share a tag
- Trial-decrypt failures on conversation inboxes now count delivery attempts (bounded-retry parity with #170) instead of redelivering forever
- Review fixes: push registration keyed per-address, keypair deletion removes both copies, empty-string legacy tags fall back correctly, signing failures are logged

## Live verification (dev device + desktop)

- Session confirmed ~16s after first send (peer's delivery receipt closes the handshake); subsequent sends use the confirmed path — no X3DH, no init wrapping — and persist across app restarts
- Mobile resubscribes to all session inboxes after restart (observed: 26 vs 1-per-conversation before)
- Frames on non-primary session inboxes pass the echo gate instead of being dropped

## Known remaining issues (tracked, NOT fixed here)

- **Desktop→mobile is still nondeterministic on the churned test pairing:** some desktop frames are encrypted against a session state mobile doesn't hold (observed live; needs desktop-side evidence to diagnose). Receipts/ticks are blocked by the same divergence.
- The desktop-parity ghost-session prune was deliberately left out: callers pass device lists of varying completeness and pruning against a partial list could delete healthy own-device sessions. Follow-up needs a registration-sourced valid set.
- Peers on older builds still emit legacy tags; sessions with them keep the old per-send re-init cost until they upgrade (no data loss).