### PR TITLE
fix: stop DM ratchet state resurrecting or regressing in the write queue

### DIFF
--- a/__tests__/confirmSenderSession.test.ts
+++ b/__tests__/confirmSenderSession.test.ts
@@ -133,7 +133,11 @@ describe('confirmSenderSession', () => {
     expect(saved.sentAccept).toBe(true);
     expect(saved.state).toBe('advanced-state');
     expect(saved.inboxId).toBe(INBOX); // keyed under OUR receiving inbox
-    expect(saved.tag).toBe('QmPeerReturnInbox');
+    // The row keeps its OWN tag (the target device inbox), it does not adopt
+    // the peer's. The send path selects sessions by tag, so overwriting this
+    // un-links the confirmed row from its device and the next send re-runs
+    // X3DH — sessions could then never stay confirmed. Desktop does the same.
+    expect(saved.tag).toBe(INBOX);
     expect(saved.sendingInbox).toEqual({
       inbox_address: 'QmPeerReturnInbox',
       inbox_encryption_key: 'peer-enc-key',

--- a/__tests__/encryptionStateDurability.test.ts
+++ b/__tests__/encryptionStateDurability.test.ts
@@ -1,0 +1,110 @@
+/**
+ * EncryptionStateStorage write-batching invariants.
+ *
+ * Ratchet state is the one piece of DM state that must never regress or
+ * resurrect: a frame encrypted at position N is already on the wire, so a
+ * stored state that goes back to N-1 (or a deleted session that comes back)
+ * desynchronizes the pairing permanently — every later frame fails AEAD and
+ * only a manual "reset encryption session" recovers it.
+ *
+ * The storage layer batches writes (100ms / 10 updates) to keep MMKV off the
+ * hot path. These tests pin the invariants that batching must preserve.
+ */
+
+// Real MMKV replaced with an in-memory map; everything else is the real class.
+const mockBacking = new Map<string, string>();
+jest.mock('@/services/storage/mirroredMMKV', () => ({
+  createMirroredMMKV: () => ({
+    getString: (k: string) => mockBacking.get(k),
+    set: (k: string, v: string) => void mockBacking.set(k, v),
+    remove: (k: string) => void mockBacking.delete(k),
+    getAllKeys: () => [...mockBacking.keys()],
+    clearAll: () => mockBacking.clear(),
+  }),
+}));
+
+// Capture the storage module's AppState subscription so tests can drive it.
+// The listener array lives INSIDE the factory: the storage singleton is built
+// during import, which runs this factory before any module-scope const in this
+// file is initialized.
+jest.mock('react-native', () => {
+  const listeners: ((s: string) => void)[] = [];
+  return {
+    AppState: {
+      addEventListener: (_event: string, cb: (s: string) => void) => {
+        listeners.push(cb);
+        return { remove: () => {} };
+      },
+      __listeners: listeners,
+    },
+  };
+});
+
+import { encryptionStateStorage, type EncryptionState } from '../services/crypto/encryption-state-storage';
+
+/** Simulate the app going to the background. */
+const backgroundApp = () => {
+  const { AppState } = jest.requireMock('react-native') as {
+    AppState: { __listeners: ((s: string) => void)[] };
+  };
+  expect(AppState.__listeners.length).toBeGreaterThan(0); // storage must subscribe
+  AppState.__listeners.forEach((cb) => cb('background'));
+};
+
+const CONV = 'QmPeer/QmPeer';
+const INBOX = 'QmOurConversationInbox';
+const stateKey = `enc_state:${CONV}:${INBOX}`;
+
+const row = (ratchet: string): EncryptionState =>
+  ({ state: ratchet, timestamp: Date.now(), conversationId: CONV, inboxId: INBOX, sentAccept: true }) as EncryptionState;
+
+/** What is actually durable on disk right now (ignores the in-process queue). */
+const onDisk = () => {
+  const raw = mockBacking.get(stateKey);
+  return raw ? (JSON.parse(raw) as EncryptionState).state : null;
+};
+
+beforeEach(() => {
+  mockBacking.clear();
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.runOnlyPendingTimers();
+  jest.useRealTimers();
+});
+
+describe('EncryptionStateStorage batching invariants', () => {
+  it('does not resurrect a deleted session when a queued write flushes afterwards', () => {
+    encryptionStateStorage.saveEncryptionState(row('ratchet-1'), false);
+
+    // Reset the session while that write is still queued.
+    encryptionStateStorage.deleteAllEncryptionStates(CONV);
+    expect(encryptionStateStorage.getEncryptionState(CONV, INBOX)).toBeNull();
+
+    // The batch timer fires.
+    jest.advanceTimersByTime(200);
+
+    expect(onDisk()).toBeNull();
+    expect(encryptionStateStorage.getEncryptionState(CONV, INBOX)).toBeNull();
+  });
+
+  it('does not let a stale queued write overwrite a newer immediate write', () => {
+    encryptionStateStorage.saveEncryptionState(row('ratchet-1'), false); // queued
+    encryptionStateStorage.saveEncryptionState(row('ratchet-2'), false, true); // immediate
+
+    expect(onDisk()).toBe('ratchet-2');
+    jest.advanceTimersByTime(200);
+    expect(onDisk()).toBe('ratchet-2');
+  });
+
+  it('makes a queued ratchet advance durable when the app leaves the foreground', () => {
+    // Batching is deliberate, but the frame encrypted at this position is
+    // ALREADY on the wire. Backgrounding freezes JS timers on Android, so the
+    // queued flush may never run before the process is reaped.
+    encryptionStateStorage.saveEncryptionState(row('ratchet-1'), false);
+    expect(onDisk()).toBeNull(); // batched, not yet durable
+
+    backgroundApp();
+    expect(onDisk()).toBe('ratchet-1');
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,9 @@ module.exports = {
   // Watchman to speed up file discovery, so turning it off is behavior-safe.
   watchman: false,
   moduleNameMapper: {
+    // Project-root path alias (tsconfig "@/*" -> "./*"). Metro resolves this
+    // from tsconfig; jest needs it spelled out.
+    '^@/(.*)$': '<rootDir>/$1',
     // Resolve quorum-shared to its NON-native build. The native barrel
     // (index.native.js) imports RN native modules (AsyncStorage, etc.) that
     // are null under jest; the pure crypto/auth/permission functions these

--- a/services/crypto/encryption-state-storage.ts
+++ b/services/crypto/encryption-state-storage.ts
@@ -7,6 +7,7 @@
  * Uses types from @quilibrium/quorum-shared for cross-platform compatibility.
  */
 
+import { AppState } from 'react-native';
 import { type MMKV } from 'react-native-mmkv';
 import { createMirroredMMKV } from '@/services/storage/mirroredMMKV';
 import {
@@ -106,6 +107,27 @@ class EncryptionStateStorage {
   constructor() {
     // Separate MMKV instance for encryption states (encrypted at rest)
     this.storage = new MMKVStorageProvider('quorum-encryption');
+    this.flushWhenBackgrounded();
+  }
+
+  /**
+   * Flush the write queue whenever the app leaves the foreground.
+   *
+   * Batching keeps MMKV off the hot path, but a queued ratchet advance is
+   * only in memory while its frame is already on the wire. Backgrounding
+   * freezes JS timers on Android, so without this the pending flush may
+   * never run before the process is reaped — the peer has consumed the
+   * frame and this device restarts a step behind, permanently desynced.
+   */
+  private flushWhenBackgrounded(): void {
+    try {
+      AppState.addEventListener('change', (next) => {
+        if (next !== 'active') this.flushWrites();
+      });
+    } catch {
+      // No AppState (tests, non-RN contexts): batching still works, it just
+      // relies on the timer. Never let this break storage construction.
+    }
   }
 
   /**
@@ -151,6 +173,31 @@ class EncryptionStateStorage {
    */
   flushPendingWrites(): void {
     this.flushWrites();
+  }
+
+  /**
+   * Write a key immediately, superseding any queued value for it.
+   *
+   * Dropping the queued entry is the point: without it the next flush would
+   * write the OLDER value back over this one, regressing the ratchet after
+   * its frame is already on the wire.
+   */
+  private writeNow(key: string, value: string): void {
+    this.pendingWrites.delete(key);
+    this.storage.set(key, value);
+  }
+
+  /**
+   * Delete a key, including any queued write for it.
+   *
+   * Without dropping the queued entry the row comes back from the dead:
+   * reads consult the queue first (so it is still visible immediately after
+   * deletion), and the next flush writes it back to disk — silently undoing
+   * a "reset encryption session".
+   */
+  private removeNow(key: string): void {
+    this.pendingWrites.delete(key);
+    this.storage.remove(key);
   }
 
   // Encryption States
@@ -209,7 +256,7 @@ class EncryptionStateStorage {
 
     if (immediate) {
       // Immediate write for critical operations (e.g., before sending)
-      this.storage.set(key, value);
+      this.writeNow(key, value);
     } else {
       // Batched write for performance during sync
       this.queueWrite(key, value);
@@ -230,7 +277,7 @@ class EncryptionStateStorage {
    */
   deleteEncryptionState(conversationId: string, inboxId: string): void {
     const key = `${KEYS.ENCRYPTION_STATE}${conversationId}:${inboxId}`;
-    this.storage.remove(key);
+    this.removeNow(key);
 
     // Remove from conversation inbox list
     this.removeInboxFromConversation(conversationId, inboxId);
@@ -244,7 +291,15 @@ class EncryptionStateStorage {
 
     for (const inboxId of inboxIds) {
       const key = `${KEYS.ENCRYPTION_STATE}${conversationId}:${inboxId}`;
-      this.storage.remove(key);
+      this.removeNow(key);
+    }
+
+    // A queued write can name an inbox the list no longer does (the list is
+    // rebuilt on every save, the queue outlives it), so sweep the queue for
+    // this conversation too — otherwise that row survives the reset.
+    const prefix = `${KEYS.ENCRYPTION_STATE}${conversationId}:`;
+    for (const key of [...this.pendingWrites.keys()]) {
+      if (key.startsWith(prefix)) this.removeNow(key);
     }
 
     // Clear the inbox list


### PR DESCRIPTION
## The bug

Encryption state is written through a 100ms batching queue, and reads consult that queue before MMKV. Three invariant breaks around it, each of which can desync a DM pairing permanently — a frame encrypted at position N is already on the wire, so stored state that goes back to N-1 fails authentication from then on, and only a manual "reset encryption session" recovers it.

**1. Deleting a session did not drop its queued write.** The row stayed readable straight after deletion and the next flush wrote it back to disk, silently undoing a reset. `deleteAllEncryptionStates` now also sweeps the queue by conversation prefix, since a queued key can name an inbox the rebuilt inbox list no longer does.

**2. An immediate write did not supersede the queued value for the same key**, so the following flush overwrote it with the older state, regressing the ratchet. Latent today (no caller passes `immediate`) but the parameter is documented for critical sends, so the first person to follow that advice would have corrupted sessions silently.

**3. Nothing ever flushed the queue** — `flushPendingWrites` had no callers. A queued advance stayed in memory only, and backgrounding freezes JS timers on Android, so it could be lost entirely when the process was reaped. The storage now flushes itself whenever the app leaves the foreground.

## Verification

Covered by `__tests__/encryptionStateDurability.test.ts` — all three were **red** before this change.

- 50/50 tests pass (was 47 pass / 3 fail)
- Type-error count unchanged from baseline, none in the touched files
- Live: three consecutive test runs with **zero** mobile-side receive drops

## Also included

- Un-stales one assertion in `confirmSenderSession.test.ts`. A confirmed row deliberately keeps its own tag rather than adopting the peer's (overwriting it un-linked the row from its device and forced a fresh handshake on every send); the test was never updated and had been failing since.
- Adds a jest `moduleNameMapper` for the `@/` path alias. Without it, any module importing `@/…` is untestable, which is why the existing tests all avoid it.