### PR TITLE
fix: send with the NEWEST session for a device, so a peer's reset propagates

### DIFF
--- a/__tests__/selectSendState.test.ts
+++ b/__tests__/selectSendState.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Which stored session we SEND with when several share a device tag.
+ *
+ * The case that matters: the peer resets. They mint a new receiving inbox and
+ * announce it in a fresh init envelope, but they cannot delete our old row — so
+ * we hold BOTH a stale confirmed row (pointing at an inbox they have abandoned)
+ * and the new one. Picking the stale row sends every message into a black hole
+ * while theirs keep arriving, which is exactly what made a one-sided reset fail
+ * to propagate.
+ */
+import { selectSendState } from '../services/crypto/selectSendState';
+
+const ready = (timestamp: number, inbox: string) => ({
+  timestamp,
+  inboxId: inbox,
+  sendingInbox: { inbox_public_key: `pub-${inbox}`, inbox_address: inbox },
+});
+const unconfirmed = (timestamp: number, inbox: string) => ({
+  timestamp,
+  inboxId: inbox,
+  sendingInbox: { inbox_public_key: '' },
+});
+
+describe('selectSendState', () => {
+  it('returns undefined when there is no session for the tag', () => {
+    expect(selectSendState([])).toBeUndefined();
+  });
+
+  it('prefers a send-ready row over an unconfirmed one', () => {
+    const chosen = selectSendState([unconfirmed(200, 'old'), ready(100, 'ready')]);
+    expect(chosen?.inboxId).toBe('ready');
+  });
+
+  it('picks the NEWEST send-ready row after the peer resets', () => {
+    // Stale row is first in insertion order — the old code took it and kept
+    // sending to the inbox the peer had abandoned.
+    const stale = ready(1_000, 'abandoned-inbox');
+    const fresh = ready(2_000, 'peer-new-inbox');
+    expect(selectSendState([stale, fresh])?.inboxId).toBe('peer-new-inbox');
+  });
+
+  it('is independent of array order', () => {
+    const stale = ready(1_000, 'abandoned-inbox');
+    const fresh = ready(2_000, 'peer-new-inbox');
+    expect(selectSendState([fresh, stale])?.inboxId).toBe('peer-new-inbox');
+  });
+
+  it('falls back to the newest row when none are send-ready', () => {
+    const chosen = selectSendState([unconfirmed(1_000, 'a'), unconfirmed(3_000, 'b')]);
+    expect(chosen?.inboxId).toBe('b');
+  });
+
+  it('does not mutate the caller array', () => {
+    const rows = [ready(1_000, 'a'), ready(2_000, 'b')];
+    selectSendState(rows);
+    expect(rows.map((r) => r.inboxId)).toEqual(['a', 'b']);
+  });
+
+  it('tolerates rows with no timestamp by sorting them last', () => {
+    const noTs = { inboxId: 'no-ts', sendingInbox: { inbox_public_key: 'p' } };
+    expect(selectSendState([noTs, ready(500, 'has-ts')])?.inboxId).toBe('has-ts');
+  });
+});

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -14,6 +14,7 @@ import { useAuth, useWebSocket } from '@/context';
 import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
+import { selectSendState } from '@/services/crypto/selectSendState';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
@@ -977,14 +978,11 @@ export async function sendEncryptedMessageToAllDevices(
     }
 
     // Check if we have an existing session for this device's inbox (by tag).
-    // Several rows can share a tag (e.g. a session created by RECEIVING the
-    // peer's message — born send-ready with their full return-inbox keys —
-    // alongside an older self-initiated one still waiting for confirmation).
-    // Prefer the send-ready row: it skips the init-envelope wrapping
-    // entirely.
+    // Several rows can share a tag, and the NEWEST send-ready one must win —
+    // see selectSendState for why (a peer's reset is otherwise ignored and we
+    // keep sending into an inbox they have abandoned).
     const tagMatches = existingStates.filter((s) => s.tag === device.inboxAddress);
-    const existingState =
-      tagMatches.find((s) => s.sendingInbox?.inbox_public_key) ?? tagMatches[0];
+    const existingState = selectSendState(tagMatches);
     if (existingState) {
       devicesWithExistingSession.push({ device, state: existingState });
     } else {

--- a/services/crypto/selectSendState.ts
+++ b/services/crypto/selectSendState.ts
@@ -1,0 +1,41 @@
+/**
+ * Choosing which stored session to SEND with, when several share a device tag.
+ *
+ * Multiple rows legitimately share one tag: a session we created by sending
+ * first (initially unconfirmed) can coexist with one created by RECEIVING the
+ * peer's init envelope (born send-ready with their full return-inbox keys).
+ *
+ * The rule is: prefer a send-ready row, and among send-ready rows prefer the
+ * NEWEST.
+ *
+ * Recency is the part that matters and was missing. When the peer resets their
+ * session they mint a new receiving inbox and tell us about it in a fresh init
+ * envelope — but they cannot delete our old row. So we end up holding BOTH a
+ * stale confirmed row (pointing at an inbox the peer has abandoned) and the new
+ * one. Both look send-ready, so selecting by array order silently kept using the
+ * dead inbox: the peer's reset never propagated, our messages vanished into a
+ * black hole while theirs kept arriving. A reset is meant to be one-sided — one
+ * user resets, their next message carries the new session, and both converge.
+ * That only works if the newest session wins here.
+ */
+
+export type SendCandidate = {
+  timestamp?: number;
+  sendingInbox?: { inbox_public_key?: string };
+};
+
+/** Newest first; rows without a timestamp sort last. */
+function newestFirst<T extends SendCandidate>(rows: T[]): T[] {
+  return [...rows].sort((a, b) => (b.timestamp ?? 0) - (a.timestamp ?? 0));
+}
+
+/**
+ * Pick the session to send with from the rows matching a device tag.
+ * Returns undefined when there are none (caller establishes a new session).
+ */
+export function selectSendState<T extends SendCandidate>(tagMatches: T[]): T | undefined {
+  if (tagMatches.length === 0) return undefined;
+  const ordered = newestFirst(tagMatches);
+  // A send-ready row (peer's return inbox known) skips init-envelope wrapping.
+  return ordered.find((s) => s.sendingInbox?.inbox_public_key) ?? ordered[0];
+}


### PR DESCRIPTION
## The bug

A reset is meant to be **one-sided**: one user resets, their next message carries a fresh init envelope, and both sides converge on the new session. That was not happening. After the peer reset, our messages kept vanishing while theirs kept arriving — a permanently one-way conversation that no amount of resetting on their side could fix.

## Cause

Several stored rows legitimately share one device tag. The send path picked the first row that looked send-ready, with no regard for recency:

```js
tagMatches.find((s) => s.sendingInbox?.inbox_public_key) ?? tagMatches[0]
```

When the peer resets they mint a **new receiving inbox** and announce it in their init envelope — but they cannot delete our old row. So we hold **both**:

- a stale confirmed row, pointing at an inbox they have abandoned
- the fresh row installed from their init

Both look send-ready, and the stale one comes first in insertion order, so it won every time. Every message went to a dead inbox and was silently discarded by the peer as having no session for it.

## Evidence

Verified live before the change: with a desktop-only reset, mobile kept posting to the old inbox with a still-confirmed session (`acc=true`) while desktop had already moved on to a new one. Desktop→mobile kept working throughout, which is exactly the asymmetry users report.

## Change

Selection now prefers the **newest** send-ready row, extracted into a small pure helper (`selectSendState`) with the reasoning attached.

## Verification

- 57/57 tests pass (8 suites), including 7 new ones covering the exact stale-confirmed-vs-fresh case, order-independence, the unconfirmed fallback, and non-mutation of the caller's array
- Type-error count unchanged from baseline; none in the touched files