### PR TITLE
fix: DM sessions can actually confirm, and multi-device sessions stop overwriting each other

### DIFF
--- a/__tests__/perDeviceSessionInbox.test.ts
+++ b/__tests__/perDeviceSessionInbox.test.ts
@@ -1,0 +1,218 @@
+/**
+ * One conversation inbox PER SESSION (per peer device), never one per conversation.
+ *
+ * State rows are keyed `(conversationId, inboxId)`, so the inbox a session
+ * advertises IS its row key. Sharing one conversation-wide inbox made every
+ * device of a peer re-initialize into the SAME row: last writer won and the
+ * other devices' sessions were silently destroyed, losing every message to
+ * them. A phone plus a laptop is enough to trigger it.
+ *
+ * These tests drive the real resolver against the real storage class (MMKV
+ * replaced with a map). What they stand in for is `establishSession`'s row
+ * write, which needs native crypto: the harness below writes the row with the
+ * same `inboxId` production uses — the resolved return inbox address.
+ */
+
+const mockBacking = new Map<string, string>();
+jest.mock('@/services/storage/mirroredMMKV', () => ({
+  createMirroredMMKV: () => ({
+    getString: (k: string) => mockBacking.get(k),
+    set: (k: string, v: string) => void mockBacking.set(k, v),
+    remove: (k: string) => void mockBacking.delete(k),
+    getAllKeys: () => [...mockBacking.keys()],
+    clearAll: () => mockBacking.clear(),
+  }),
+}));
+
+jest.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+
+// Saving a keypair schedules a debounced push re-registration; keep it inert.
+jest.mock('../services/notifications/pushRegistration', () => ({
+  registerPushTokenWithQuorum: jest.fn(async () => {}),
+}));
+
+// Address = base58 multihash of the Ed448 key in production; here just a
+// readable function of the key so rows are easy to assert on.
+jest.mock('@/services/onboarding/keyService', () => ({
+  deriveAddress: (key: Uint8Array) => `Qm-inbox-${key[0]}`,
+}));
+
+import { encryptionStateStorage, type EncryptionState } from '../services/crypto/encryption-state-storage';
+import {
+  mintSessionReturnInbox,
+  resolveSessionReturnInbox,
+  sessionReturnInbox,
+  type InboxKeyGenerator,
+} from '../services/crypto/sessionReturnInbox';
+
+const CONV = 'QmPeer/QmPeer';
+const DEVICE_A = 'QmPeerDeviceA';
+const DEVICE_B = 'QmPeerDeviceB';
+
+/** Deterministic stand-in for NativeCryptoProvider's keygen. */
+function keyGenerator(): InboxKeyGenerator {
+  let n = 0;
+  return {
+    generateX448: async () => ({ public_key: [++n, 0], private_key: [n, 1] }),
+    generateEd448: async () => ({ public_key: [++n, 2], private_key: [n, 3] }),
+  };
+}
+let generator: InboxKeyGenerator;
+
+/** An unconfirmed session row for `device` — the state that forces a re-init. */
+const unconfirmedRow = (inboxId: string, device: string): EncryptionState => ({
+  state: `ratchet-${device}`,
+  timestamp: Date.now(),
+  conversationId: CONV,
+  inboxId,
+  sentAccept: false,
+  tag: device,
+  sendingInbox: {
+    inbox_address: `${device}-inbox`,
+    inbox_encryption_key: 'aabb',
+    inbox_public_key: '', // unconfirmed
+    inbox_private_key: '',
+  },
+});
+
+/**
+ * What a re-init does: resolve the session's return inbox, then write the row
+ * keyed by it (production does the write inside establishSession).
+ */
+async function reinit(device: string, existing?: EncryptionState) {
+  const { inbox, minted } = await resolveSessionReturnInbox(CONV, existing, generator);
+  encryptionStateStorage.saveEncryptionState(unconfirmedRow(inbox.inboxAddress, device), false, true);
+  return { inbox, minted };
+}
+
+const rowsByTag = () => {
+  const out = new Map<string, EncryptionState>();
+  for (const s of encryptionStateStorage.getEncryptionStates(CONV)) out.set(s.tag!, s);
+  return out;
+};
+
+beforeEach(() => {
+  mockBacking.clear();
+  generator = keyGenerator();
+  // Keeps the storage layer's batch timer and the debounced push
+  // re-registration off the real clock (the latter outlives the run otherwise).
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('a session advertises its OWN inbox', () => {
+  it('reuses the inbox the session row is keyed by', async () => {
+    const minted = await mintSessionReturnInbox(CONV, generator);
+    const row = unconfirmedRow(minted.inboxAddress, DEVICE_A);
+
+    expect(sessionReturnInbox(row)?.inboxAddress).toBe(minted.inboxAddress);
+  });
+
+  it('mints instead of reusing when the row has no inboxId', () => {
+    expect(sessionReturnInbox({ inboxId: undefined })).toBeNull();
+    expect(sessionReturnInbox(null)).toBeNull();
+  });
+
+  it('mints instead of reusing when we no longer hold the row inbox keys', () => {
+    // A row written before per-address keypairs existed (#177): its keypair
+    // lived only in the last-writer-wins per-conversation slot and is gone.
+    expect(sessionReturnInbox(unconfirmedRow('QmForgottenInbox', DEVICE_A))).toBeNull();
+  });
+
+  it('mints instead of reusing a keyset with no Ed448 half', async () => {
+    // Without signing keys the peer cannot confirm the session, so it would
+    // re-initialize forever.
+    encryptionStateStorage.saveConversationInboxKeypair({
+      conversationId: CONV,
+      inboxAddress: 'QmEncryptionOnly',
+      encryptionPublicKey: [1],
+      encryptionPrivateKey: [2],
+    });
+
+    expect(sessionReturnInbox(unconfirmedRow('QmEncryptionOnly', DEVICE_A))).toBeNull();
+  });
+});
+
+describe('two devices of one peer', () => {
+  it('get two distinct inboxes and two distinct rows', async () => {
+    const a = await reinit(DEVICE_A);
+    const b = await reinit(DEVICE_B);
+
+    expect(a.inbox.inboxAddress).not.toBe(b.inbox.inboxAddress);
+    expect(rowsByTag().size).toBe(2);
+    expect(rowsByTag().get(DEVICE_A)!.inboxId).toBe(a.inbox.inboxAddress);
+    expect(rowsByTag().get(DEVICE_B)!.inboxId).toBe(b.inbox.inboxAddress);
+  });
+
+  it('re-initializing device A never overwrites device B row', async () => {
+    const a = await reinit(DEVICE_A);
+    const b = await reinit(DEVICE_B);
+    const bRatchetBefore = rowsByTag().get(DEVICE_B)!.state;
+
+    // Device A re-initializes again, reusing its own inbox.
+    const again = await reinit(DEVICE_A, rowsByTag().get(DEVICE_A));
+
+    expect(again.minted).toBe(false);
+    expect(again.inbox.inboxAddress).toBe(a.inbox.inboxAddress);
+    expect(rowsByTag().size).toBe(2);
+    expect(rowsByTag().get(DEVICE_B)!.inboxId).toBe(b.inbox.inboxAddress);
+    expect(rowsByTag().get(DEVICE_B)!.state).toBe(bRatchetBefore);
+  });
+
+  it('REGRESSION: one shared inbox collapses both devices onto one row', async () => {
+    // The pre-fix behaviour, spelled out: both devices re-initializing into the
+    // same conversation-wide inbox leaves ONE row. Device A survives only
+    // because it was written last; B session is destroyed and its messages lost.
+    const shared = await mintSessionReturnInbox(CONV, generator);
+    encryptionStateStorage.saveEncryptionState(unconfirmedRow(shared.inboxAddress, DEVICE_B), false, true);
+    encryptionStateStorage.saveEncryptionState(unconfirmedRow(shared.inboxAddress, DEVICE_A), false, true);
+
+    expect(encryptionStateStorage.getEncryptionStates(CONV)).toHaveLength(1);
+    expect(rowsByTag().has(DEVICE_B)).toBe(false);
+  });
+});
+
+describe('resolution is idempotent and preserves routing', () => {
+  it('returns the same inbox on every later send', async () => {
+    const first = await reinit(DEVICE_A);
+    const second = await resolveSessionReturnInbox(CONV, rowsByTag().get(DEVICE_A), generator);
+    const third = await resolveSessionReturnInbox(CONV, rowsByTag().get(DEVICE_A), generator);
+
+    expect(second.inbox.inboxAddress).toBe(first.inbox.inboxAddress);
+    expect(third.inbox.inboxAddress).toBe(first.inbox.inboxAddress);
+    expect(second.minted).toBe(false);
+    expect(third.minted).toBe(false);
+  });
+
+  it('maps every session inbox to the conversation, and never unmaps one', async () => {
+    const a = await reinit(DEVICE_A);
+    const b = await reinit(DEVICE_B);
+
+    // A stale row whose keypair is gone re-initializes onto a fresh inbox —
+    // the migration path — without disturbing the older mappings, because the
+    // peer may still be writing to them (desktop #252).
+    const migrated = await reinit(DEVICE_A, unconfirmedRow('QmForgottenInbox', DEVICE_A));
+    expect(migrated.minted).toBe(true);
+    expect(migrated.inbox.inboxAddress).not.toBe(a.inbox.inboxAddress);
+
+    for (const addr of [a.inbox.inboxAddress, b.inbox.inboxAddress, migrated.inbox.inboxAddress]) {
+      expect(encryptionStateStorage.getInboxMapping(addr)?.conversationId).toBe(CONV);
+    }
+  });
+
+  it('exposes every per-device inbox for subscription and push registration', async () => {
+    const a = await reinit(DEVICE_A);
+    const b = await reinit(DEVICE_B);
+
+    // Both must be covered: a peer replying to the inbox we advertised is
+    // unheard if we are not subscribed and unregistered for push there.
+    expect(encryptionStateStorage.getAllConversationInboxAddresses()).toEqual(
+      expect.arrayContaining([a.inbox.inboxAddress, b.inbox.inboxAddress]),
+    );
+  });
+});

--- a/__tests__/sessionSendShape.test.ts
+++ b/__tests__/sessionSendShape.test.ts
@@ -151,6 +151,36 @@ describe('a recipient session announces once, then goes plain', () => {
   });
 });
 
+describe('an accept that never reached the wire is not recorded', () => {
+  // Three ways the accept can fail to land. Each one, if recorded anyway,
+  // strands the session on plain frames the peer rejects — permanently, until
+  // a manual reset. That is the exact deadlock this whole change exists to fix,
+  // so re-arming it through the back door is the worst available outcome.
+
+  it('stays in accept shape when the flag was never flipped', async () => {
+    // Stands in for: a sibling device threw mid-batch and the transport
+    // discarded every frame, so no accept was recorded.
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+
+    const row = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+    expect(sessionSendShape(row)).toBe('accept');
+    expect(row.sentAccept).toBe(false);
+  });
+
+  it('re-announces on the next send after an unrecorded accept', async () => {
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+
+    // First attempt produced a frame but it was not recorded (unsigned, or the
+    // batch was dropped). Second attempt must announce again.
+    expect(sessionSendShape(encryptionStateStorage.getEncryptionState(CONV, INBOX))).toBe('accept');
+    expect(sessionSendShape(encryptionStateStorage.getEncryptionState(CONV, INBOX))).toBe('accept');
+
+    // Only an explicit record moves it on.
+    await encryptionService.markAcceptSent(CONV, INBOX);
+    expect(sessionSendShape(encryptionStateStorage.getEncryptionState(CONV, INBOX))).toBe('plain');
+  });
+});
+
 describe('the two ways sentAccept gets set converge', () => {
   it('a session confirmed on RECEIVE sends plain, same as one accepted on SEND', async () => {
     // Mobile sets the flag in two unrelated places and they must mean one

--- a/__tests__/sessionSendShape.test.ts
+++ b/__tests__/sessionSendShape.test.ts
@@ -1,0 +1,188 @@
+/**
+ * The frame shape a session must send, and the bookkeeping behind it.
+ *
+ * The receiver demands a shape based on ITS session, not ours: while its
+ * `sending_inbox.inbox_public_key` is empty it takes
+ * ConfirmDoubleRatchetSenderSession, which throws on a plain frame. So until
+ * the peer has our return inbox, every plain frame we send is discarded — the
+ * "permanently one-way after a reset" failure.
+ *
+ * Mobile used to answer "do I know THEIR inbox?"; the SDK answers "have I told
+ * them MINE?" (`sent_accept`). These tests pin that question and the two ways
+ * mobile answers it — one on receive, one on send — landing on one meaning.
+ */
+
+const mockBacking = new Map<string, string>();
+jest.mock('@/services/storage/mirroredMMKV', () => ({
+  createMirroredMMKV: () => ({
+    getString: (k: string) => mockBacking.get(k),
+    set: (k: string, v: string) => void mockBacking.set(k, v),
+    remove: (k: string) => void mockBacking.delete(k),
+    getAllKeys: () => [...mockBacking.keys()],
+    clearAll: () => mockBacking.clear(),
+  }),
+}));
+jest.mock('react-native', () => ({
+  AppState: { addEventListener: () => ({ remove: () => {} }) },
+}));
+jest.mock('../services/notifications/pushRegistration', () => ({
+  registerPushTokenWithQuorum: jest.fn(async () => {}),
+}));
+jest.mock('@/services/onboarding/keyService', () => ({ deriveAddress: () => 'Qm-addr' }));
+jest.mock('../services/crypto/native-provider', () => ({ NativeCryptoProvider: class {} }));
+
+import { sessionSendShape } from '../services/crypto/sessionSendShape';
+import { encryptionService } from '../services/crypto/encryption-service';
+import { encryptionStateStorage, type EncryptionState } from '../services/crypto/encryption-state-storage';
+
+const CONV = 'QmPeer/QmPeer';
+const INBOX = 'QmOurSessionInbox';
+
+/** A session WE opened: we hold their device inbox, not their return inbox. */
+const unconfirmedSender = (over: Partial<EncryptionState> = {}): EncryptionState => ({
+  state: 'ratchet-0',
+  timestamp: 1,
+  conversationId: CONV,
+  inboxId: INBOX,
+  sentAccept: false,
+  sendingInbox: {
+    inbox_address: 'QmTheirDeviceInbox',
+    inbox_encryption_key: 'aabb',
+    inbox_public_key: '', // they have not replied yet
+    inbox_private_key: '',
+  },
+  ...over,
+});
+
+/** A session THEY opened: their init envelope gave us their full keyset. */
+const recipientSession = (over: Partial<EncryptionState> = {}): EncryptionState => ({
+  ...unconfirmedSender(),
+  sendingInbox: {
+    inbox_address: 'QmTheirConversationInbox',
+    inbox_encryption_key: 'aabb',
+    inbox_public_key: 'ccdd',
+    inbox_private_key: 'eeff',
+  },
+  ...over,
+});
+
+beforeEach(() => {
+  mockBacking.clear();
+  jest.useFakeTimers();
+});
+afterEach(() => {
+  jest.clearAllTimers();
+  jest.useRealTimers();
+});
+
+describe('which shape a session sends', () => {
+  it('keeps announcing while the peer has not replied', () => {
+    expect(sessionSendShape(unconfirmedSender())).toBe('init');
+  });
+
+  it('still announces even if sentAccept was somehow set', () => {
+    // Their inbox is unknown, so there is nowhere a plain frame could land.
+    expect(sessionSendShape(unconfirmedSender({ sentAccept: true }))).toBe('init');
+  });
+
+  it('sends the accept on a session the peer opened', () => {
+    // The regression this whole task is about: mobile used to call this 'plain'
+    // because their inbox key was known, and the peer dropped every frame.
+    expect(sessionSendShape(recipientSession())).toBe('accept');
+  });
+
+  it('sends plain once our return inbox is known to be out there', () => {
+    expect(sessionSendShape(recipientSession({ sentAccept: true }))).toBe('plain');
+  });
+
+  it('reports unsendable with nothing to seal to', () => {
+    expect(sessionSendShape(undefined)).toBe('unsendable');
+    expect(sessionSendShape({})).toBe('unsendable');
+    expect(sessionSendShape({ sendingInbox: { inbox_encryption_key: '' } })).toBe('unsendable');
+  });
+});
+
+describe('a recipient session announces once, then goes plain', () => {
+  it('first reply is the accept, second is plain', async () => {
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+
+    const first = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+    expect(sessionSendShape(first)).toBe('accept');
+
+    await encryptionService.markAcceptSent(CONV, INBOX);
+
+    const second = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+    expect(sessionSendShape(second)).toBe('plain');
+  });
+
+  it('never regresses the ratchet when flipping the flag', async () => {
+    // The flag write re-reads inside the lock; a send may have advanced the
+    // state in between, and writing back a stale snapshot would desync a
+    // ratchet whose frame is already on the wire (see #178).
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+    encryptionStateStorage.saveEncryptionState(
+      recipientSession({ state: 'ratchet-7', timestamp: 2 }),
+      false,
+      true,
+    );
+
+    await encryptionService.markAcceptSent(CONV, INBOX);
+
+    const row = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+    expect(row.state).toBe('ratchet-7');
+    expect(row.sentAccept).toBe(true);
+  });
+
+  it('is idempotent, and leaves the rest of the row alone', async () => {
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+
+    await encryptionService.markAcceptSent(CONV, INBOX);
+    await encryptionService.markAcceptSent(CONV, INBOX);
+
+    const row = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+    expect(row.sentAccept).toBe(true);
+    expect(row.sendingInbox).toEqual(recipientSession().sendingInbox);
+    expect(row.state).toBe('ratchet-0');
+  });
+
+  it('does nothing for a session that no longer exists', async () => {
+    await expect(encryptionService.markAcceptSent(CONV, 'QmGone')).resolves.toBeUndefined();
+    expect(encryptionStateStorage.getEncryptionState(CONV, 'QmGone')).toBeNull();
+  });
+});
+
+describe('the two ways sentAccept gets set converge', () => {
+  it('a session confirmed on RECEIVE sends plain, same as one accepted on SEND', async () => {
+    // Mobile sets the flag in two unrelated places and they must mean one
+    // thing: "the peer has our return inbox".
+    //
+    // 1. confirmSenderSession — the peer replied to the inbox we advertised,
+    //    which is proof they had it. It writes sentAccept: true and fills
+    //    sendingInbox from their envelope.
+    const confirmedOnReceive: EncryptionState = {
+      ...unconfirmedSender(),
+      sentAccept: true,
+      sendingInbox: {
+        inbox_address: 'QmTheirConversationInbox',
+        inbox_encryption_key: 'aabb',
+        inbox_public_key: 'ccdd',
+        inbox_private_key: 'eeff',
+      },
+    };
+
+    // 2. markAcceptSent — we just put our return inbox on the wire.
+    encryptionStateStorage.saveEncryptionState(recipientSession(), false, true);
+    await encryptionService.markAcceptSent(CONV, INBOX);
+    const acceptedOnSend = encryptionStateStorage.getEncryptionState(CONV, INBOX)!;
+
+    expect(sessionSendShape(confirmedOnReceive)).toBe('plain');
+    expect(sessionSendShape(acceptedOnSend)).toBe('plain');
+  });
+
+  it('a fresh session from either direction starts unaccepted', () => {
+    // encryptMessageForNewDevice and initializeRecipientSession both write
+    // sentAccept: false, so neither can skip its announcement.
+    expect(sessionSendShape(unconfirmedSender({ sentAccept: undefined }))).toBe('init');
+    expect(sessionSendShape(recipientSession({ sentAccept: undefined }))).toBe('accept');
+  });
+});

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -5452,7 +5452,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         try {
           envelopes = await prepareMessage();
         } catch (err) {
-          logger.debug(`[WS-send ${me}] prepareMessage threw`, err);
+          // The transport discards this whole batch without requeueing it, so
+          // one device's failure silently costs every device in the fan-out.
+          // Debug level made that invisible under a warnings-only capture.
+          logger.warn(`[WS-send ${me}] prepareMessage threw, WHOLE batch dropped`, err);
           throw err;
         }
         for (const env of envelopes) {

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -5237,9 +5237,25 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
    */
   const throttledMessageHandler = useCallback((message: EncryptedWebSocketMessage) => {
     const me = fullUserAddrRef.current?.slice(0, 8) ?? '???';
-    // Diagnostic: confirm WS messages are reaching the client at all.
+    // The server's only channel for telling us a write was refused. It was
+    // logged at debug and dropped, which made a rejected inbox write
+    // indistinguishable from a delivered one: frames left the socket, never
+    // reached the peer, and nothing anywhere said why. Warn, and keep the
+    // whole payload — the reason is the point.
     if ('error' in message && message.error) {
-      logger.debug(`[WS-in ${me}] error msg`, message.error);
+      logger.warn(`[WS-in ${me}] SERVER REJECTED`, JSON.stringify(message));
+      return;
+    }
+
+    // Anything inbound that is neither an error, nor a known frame type, nor a
+    // sealed message is by definition unhandled. Silence here hid the case
+    // above for months; if the server answers writes in some other shape, this
+    // is what surfaces it.
+    if (
+      !(message as { encryptedContent?: unknown }).encryptedContent &&
+      !(message as { type?: unknown }).type
+    ) {
+      logger.warn(`[WS-in ${me}] UNHANDLED inbound payload`, JSON.stringify(message).slice(0, 400));
       return;
     }
 

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -11,6 +11,7 @@ import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
+import { sessionReturnInbox } from '@/services/crypto/sessionReturnInbox';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
 import { queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type EmbedMessage } from '@quilibrium/quorum-shared';
@@ -543,8 +544,10 @@ async function sendEncryptedEmbedMessage(
       const needsInitEnvelope = !sendingInbox || sendingInbox.inbox_public_key === '';
 
       if (needsInitEnvelope && sendingInbox?.inbox_encryption_key) {
-        // Unconfirmed session
-        const ourConversationInbox = encryptionStateStorage.getConversationInboxKeypair(conversationId);
+        // Unconfirmed session. The return inbox is THIS session's own (the row
+        // we are advancing) — a conversation-wide one belongs to whichever
+        // device wrote it last, and the peer would confirm the wrong row.
+        const ourConversationInbox = sessionReturnInbox(encryptionState);
 
         let ephemeralPrivateKeyBytes: number[];
         let ephemeralPublicKeyHex: string;

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -12,6 +12,7 @@ import { encryptionService } from '@/services/crypto/encryption-service';
 import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { sessionReturnInbox } from '@/services/crypto/sessionReturnInbox';
+import { sessionSendShape } from '@/services/crypto/sessionSendShape';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
 import { queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type EmbedMessage } from '@quilibrium/quorum-shared';
@@ -541,7 +542,12 @@ async function sendEncryptedEmbedMessage(
       );
 
       const sendingInbox = encryptionState.sendingInbox;
-      const needsInitEnvelope = !sendingInbox || sendingInbox.inbox_public_key === '';
+      // 'accept' is the session the PEER opened: they stay unconfirmed and drop
+      // every plain frame until we announce our return inbox once. Same wire
+      // shape as 'init' — the existing ratchet, wrapped — so one branch serves
+      // both; only the bookkeeping at the end differs. See sessionSendShape.
+      const shape = sessionSendShape(encryptionState);
+      const needsInitEnvelope = shape === 'init' || shape === 'accept';
 
       if (needsInitEnvelope && sendingInbox?.inbox_encryption_key) {
         // Unconfirmed session. The return inbox is THIS session's own (the row
@@ -598,16 +604,24 @@ async function sendEncryptedEmbedMessage(
           plaintext: envelopeBytes,
         });
 
+        // An accept is written to their CONVERSATION inbox, which verifies the
+        // signature; an init goes to their device inbox and has no signing key
+        // yet. signConfirmedEnvelope returns empty fields in that case, so one
+        // call covers both.
+        const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
         const sealedMessage = {
           type: 'direct',
           inbox_address: sendingInbox.inbox_address,
           ephemeral_public_key: ephemeralPublicKeyHex,
           envelope: sealedEnvelope,
-          inbox_public_key: '',
-          inbox_signature: '',
+          inbox_public_key: inboxAuth.inbox_public_key,
+          inbox_signature: inboxAuth.inbox_signature,
         };
 
         outbounds.push(JSON.stringify(sealedMessage));
+        if (shape === 'accept') {
+          await encryptionService.markAcceptSent(conversationId, encryptionState.inboxId);
+        }
       } else if (sendingInbox?.inbox_address) {
         // Confirmed session
         const sealingEphemeralKey = await cryptoProvider.generateX448();

--- a/hooks/chat/useSendDirectEmbedMessage.ts
+++ b/hooks/chat/useSendDirectEmbedMessage.ts
@@ -15,7 +15,7 @@ import { sessionReturnInbox } from '@/services/crypto/sessionReturnInbox';
 import { sessionSendShape } from '@/services/crypto/sessionSendShape';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
-import { queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type EmbedMessage } from '@quilibrium/quorum-shared';
+import { logger, queryKeys, bytesToHex, hexToBytes, type InitializationEnvelope, type EmbedMessage } from '@quilibrium/quorum-shared';
 import type { Message } from '@quilibrium/quorum-shared';
 import type { MessagePreview } from '@/utils/messagePreview';
 import { NativeSigningProvider } from '@/services/crypto/native-signing-provider';
@@ -547,7 +547,18 @@ async function sendEncryptedEmbedMessage(
       // shape as 'init' — the existing ratchet, wrapped — so one branch serves
       // both; only the bookkeeping at the end differs. See sessionSendShape.
       const shape = sessionSendShape(encryptionState);
-      const needsInitEnvelope = shape === 'init' || shape === 'accept';
+      // An accept with no return-inbox keys of its own would advertise the
+      // DEVICE inbox and empty signing keys, which the peer's confirm step
+      // rejects outright — while we recorded the accept as sent. Fall back to
+      // the plain send instead (what this path did before) and stay honest.
+      const canAnnounce = sessionReturnInbox(encryptionState) !== null;
+      if (shape === 'accept' && !canAnnounce) {
+        logger.warn(
+          '[DM-embed] no return inbox to announce for this session, sending plain:',
+          encryptionState.inboxId?.slice(0, 12),
+        );
+      }
+      const needsInitEnvelope = shape === 'init' || (shape === 'accept' && canAnnounce);
 
       if (needsInitEnvelope && sendingInbox?.inbox_encryption_key) {
         // Unconfirmed session. The return inbox is THIS session's own (the row
@@ -619,7 +630,10 @@ async function sendEncryptedEmbedMessage(
         };
 
         outbounds.push(JSON.stringify(sealedMessage));
-        if (shape === 'accept') {
+        // Only a SIGNED accept can land — their conversation inbox rejects an
+        // unsigned write, so recording one would strand the session on plain
+        // frames they refuse.
+        if (shape === 'accept' && inboxAuth.inbox_signature) {
           await encryptionService.markAcceptSent(conversationId, encryptionState.inboxId);
         }
       } else if (sendingInbox?.inbox_address) {

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -1048,6 +1048,11 @@ async function buildInitEnvelopeSend(args: {
  *
  * Returns null when we no longer hold this session's own return inbox keys —
  * there is nothing to announce, so the caller falls back to a plain send.
+ *
+ * Does NOT record the accept: `announced` reports whether this frame can
+ * actually announce anything, and the caller flips the flag only once the whole
+ * batch exists. Recording it here would mark an accept that a sibling device's
+ * exception then discarded (see the deferred markAcceptSent in the send loop).
  */
 async function buildAcceptSend(args: {
   conversationId: string;
@@ -1064,7 +1069,7 @@ async function buildAcceptSend(args: {
       plaintext: number[];
     }): Promise<string>;
   };
-}): Promise<string | null> {
+}): Promise<{ sealed: string; announced: boolean } | null> {
   const { conversationId, message, state, deviceKeyset, userAddress, displayName, cryptoProvider } = args;
   const sendingInbox = state.sendingInbox;
   if (!sendingInbox?.inbox_address || !sendingInbox.inbox_encryption_key) return null;
@@ -1109,9 +1114,17 @@ async function buildAcceptSend(args: {
     inbox_signature: inboxAuth.inbox_signature,
   });
 
-  // Only now that the frame exists — see markAcceptSent.
-  await encryptionService.markAcceptSent(conversationId, state.inboxId);
-  return sealed;
+  // signConfirmedEnvelope degrades to unsigned rather than throwing, and their
+  // conversation inbox rejects an unsigned write — so such a frame announces
+  // nothing and must not count as our accept. Send it anyway (it costs
+  // nothing) and let the next send announce again.
+  if (!inboxAuth.inbox_signature) {
+    logger.warn(
+      '[DM-send] accept went out unsigned, not recording it:',
+      state.inboxId.slice(0, 12),
+    );
+  }
+  return { sealed, announced: !!inboxAuth.inbox_signature };
 }
 
 /**
@@ -1223,6 +1236,9 @@ export async function sendEncryptedMessageToAllDevices(
   // Enqueue all outbound messages
   enqueueOutbound(async () => {
     const outbounds: string[] = [];
+    // Sessions whose accept is in this batch. Flipped only once every frame
+    // below exists — see the loop that drains this before returning.
+    const acceptedSessions: string[] = [];
 
     // === Handle new sessions ===
     for (const { device, returnInbox } of newSessionPrepData) {
@@ -1237,7 +1253,14 @@ export async function sendEncryptedMessageToAllDevices(
         displayName,
         cryptoProvider,
       });
-      if (sealed) outbounds.push(sealed);
+      if (sealed) {
+        outbounds.push(sealed);
+      } else {
+        logger.warn(
+          '[DM-send] X3DH produced no ephemeral key, device skipped:',
+          device.inboxAddress.slice(0, 12),
+        );
+      }
     }
 
     // === Handle existing sessions ===
@@ -1257,7 +1280,7 @@ export async function sendEncryptedMessageToAllDevices(
       if (shape === 'accept') {
         // The peer opened this session and is still unconfirmed: our first
         // frame back must carry our return inbox or they reject all of them.
-        const sealed = await buildAcceptSend({
+        const accept = await buildAcceptSend({
           conversationId,
           message,
           state,
@@ -1266,8 +1289,9 @@ export async function sendEncryptedMessageToAllDevices(
           displayName,
           cryptoProvider,
         });
-        if (sealed) {
-          outbounds.push(sealed);
+        if (accept) {
+          outbounds.push(accept.sealed);
+          if (accept.announced) acceptedSessions.push(state.inboxId);
           continue;
         }
         // No return inbox to announce — fall through to the plain send below,
@@ -1300,7 +1324,14 @@ export async function sendEncryptedMessageToAllDevices(
           displayName,
           cryptoProvider,
         });
-        if (sealed) outbounds.push(sealed);
+        if (sealed) {
+          outbounds.push(sealed);
+        } else {
+          logger.warn(
+            '[DM-send] X3DH produced no ephemeral key on re-init, device skipped:',
+            device.inboxAddress.slice(0, 12),
+          );
+        }
       } else if (sendingInbox?.inbox_address && sendingInbox?.inbox_encryption_key) {
         // Confirmed session - encrypt with existing session and send directly
         const encrypted = await encryptWithExistingSession(
@@ -1340,6 +1371,19 @@ export async function sendEncryptedMessageToAllDevices(
           device.inboxAddress.slice(0, 12),
         );
       }
+    }
+
+    // Record the accepts LAST, once every frame in this batch exists.
+    //
+    // A device throwing anywhere in the loops above rejects this whole
+    // callback, and the transport discards the entire batch without requeueing
+    // it (rn-websocket's processQueues logs and moves on). Flipping the flag
+    // inside the loop would therefore mark an accept for a frame that was
+    // never queued — and the session, believing it announced, would send only
+    // plain frames the peer rejects. Permanently, until a manual reset. The
+    // ghost devices in a normal fan-out make a mid-loop throw plausible.
+    for (const inboxId of acceptedSessions) {
+      await encryptionService.markAcceptSent(conversationId, inboxId);
     }
 
     // Reached only inside the outbound-queue drain, which runs only when the

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -15,6 +15,12 @@ import { getQuorumClient } from '@/services/api/quorumClient';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { ratchetMutex } from '@/services/crypto/ratchet-mutex';
 import { selectSendState } from '@/services/crypto/selectSendState';
+import {
+  mintSessionReturnInbox,
+  resolveSessionReturnInbox,
+  sessionReturnInbox,
+  type InboxKeyGenerator,
+} from '@/services/crypto/sessionReturnInbox';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
@@ -819,7 +825,9 @@ async function sendEncryptedMessage(
 
       if (needsInitEnvelope && sendingInbox?.inbox_encryption_key) {
         // Session not yet confirmed: rewrap in an InitializationEnvelope.
-        const ourConversationInbox = encryptionStateStorage.getConversationInboxKeypair(conversationId);
+        // The return inbox is THIS session's own (the row we are advancing);
+        // the peer's confirming reply is matched to the row by that address.
+        const ourConversationInbox = sessionReturnInbox(encryptionState);
 
         // Reuse the X3DH ephemeral key from session establishment so the
         // receiver derives the matching session key. A fresh ephemeral
@@ -921,6 +929,109 @@ async function sendEncryptedMessage(
 }
 
 /**
+ * Build the sealed init-envelope send for ONE device session.
+ *
+ * Serves both a brand-new session and the re-initialization of an unconfirmed
+ * one: they differ only in where `returnInbox` came from (freshly minted vs.
+ * the session's own row), so the envelope is built in one place to stop the two
+ * from drifting apart.
+ *
+ * Returns null when X3DH yielded no ephemeral keypair — nothing sendable.
+ */
+async function buildInitEnvelopeSend(args: {
+  conversationId: string;
+  recipientAddress: string;
+  message: Message;
+  device: {
+    identityKey: number[];
+    signedPreKey: number[];
+    inboxAddress: string;
+    inboxEncryptionKey: number[];
+  };
+  returnInbox: ConversationInboxKeypair;
+  deviceKeyset: { identityPublicKey: number[]; inboxAddress: string };
+  userAddress: string;
+  displayName?: string;
+  cryptoProvider: {
+    encryptInboxMessage(request: {
+      inbox_public_key: number[];
+      ephemeral_private_key: number[];
+      plaintext: number[];
+    }): Promise<string>;
+  };
+}): Promise<string | null> {
+  const {
+    conversationId,
+    recipientAddress,
+    message,
+    device,
+    returnInbox,
+    deviceKeyset,
+    userAddress,
+    displayName,
+    cryptoProvider,
+  } = args;
+
+  // Establishes a fresh X3DH session for this device, keyed by OUR return
+  // inbox and tagged with the target device inbox.
+  const encrypted = await encryptionService.encryptMessageForNewDevice(
+    conversationId,
+    {
+      address: recipientAddress,
+      identityKey: device.identityKey,
+      signedPreKey: device.signedPreKey,
+      inboxAddress: device.inboxAddress,
+      inboxEncryptionKey: device.inboxEncryptionKey,
+    },
+    JSON.stringify(message),
+    returnInbox.inboxAddress,
+    device.inboxAddress
+  );
+
+  const x3dhEphemeralKey = encrypted.ephemeralPublicKey;
+  const ephemeralPrivateKey = encrypted.ephemeralPrivateKey;
+  if (!x3dhEphemeralKey?.length || !ephemeralPrivateKey?.length) return null;
+
+  const initEnvelope: InitializationEnvelope = {
+    user_address: userAddress,
+    display_name: displayName || userAddress,
+    return_inbox_address: returnInbox.inboxAddress,
+    return_inbox_encryption_key: bytesToHex(returnInbox.encryptionPublicKey),
+    return_inbox_public_key: returnInbox.signingPublicKey
+      ? bytesToHex(returnInbox.signingPublicKey)
+      : '',
+    return_inbox_private_key: returnInbox.signingPrivateKey
+      ? bytesToHex(returnInbox.signingPrivateKey)
+      : '',
+    identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
+    // SDK-standard tag: sender's device inbox — the identity the receiver files
+    // this session under (peers' device lists never contain conversation inboxes).
+    tag: deviceKeyset.inboxAddress,
+    message: encrypted.envelope,
+    type: 'direct',
+  };
+
+  const envelopeBytes = Array.from(new TextEncoder().encode(JSON.stringify(initEnvelope)));
+
+  const sealedEnvelope = await cryptoProvider.encryptInboxMessage({
+    inbox_public_key: device.inboxEncryptionKey,
+    ephemeral_private_key: ephemeralPrivateKey,
+    plaintext: envelopeBytes,
+  });
+
+  return JSON.stringify({
+    type: 'direct',
+    inbox_address: device.inboxAddress,
+    ephemeral_public_key: Array.isArray(x3dhEphemeralKey)
+      ? bytesToHex(x3dhEphemeralKey)
+      : x3dhEphemeralKey,
+    envelope: sealedEnvelope,
+    inbox_public_key: '',
+    inbox_signature: '',
+  });
+}
+
+/**
  * Send an encrypted message to ALL target device inboxes
  *
  * This handles multi-device support by:
@@ -968,7 +1079,7 @@ export async function sendEncryptedMessageToAllDevices(
   const devicesNeedingNewSession: typeof allTargetDevices = [];
   const devicesWithExistingSession: Array<{
     device: typeof allTargetDevices[0];
-    state: ReturnType<typeof encryptionStateStorage.getEncryptionState>;
+    state: NonNullable<ReturnType<typeof encryptionStateStorage.getEncryptionState>>;
   }> = [];
 
   for (const device of allTargetDevices) {
@@ -990,44 +1101,44 @@ export async function sendEncryptedMessageToAllDevices(
     }
   }
 
-  // For new sessions, generate conversation inbox keypairs BEFORE enqueuing
-  // so we can properly subscribe to them
-  // Generate all keypairs in parallel for better performance
+  // An unconfirmed session must re-initialize: the peer never derived our
+  // advanced ratchet, so only a fresh X3DH lands. Classified here, once, so the
+  // send loop below cannot disagree with what we prepared.
+  const needsReinit = (state: { sendingInbox?: { inbox_public_key?: string; inbox_encryption_key?: string } }) =>
+    !state.sendingInbox?.inbox_public_key && !!state.sendingInbox?.inbox_encryption_key;
+
+  // Resolve every return inbox BEFORE enqueuing, so all of them can be
+  // subscribed before anything is sent — the peer's confirming reply is lost if
+  // nothing is listening on the inbox we advertise.
+  //
+  // Each session gets its OWN inbox: a new session mints one, a re-initializing
+  // session reuses the inbox its row is keyed by (see sessionReturnInbox). One
+  // shared conversation inbox made all of a peer's devices re-initialize into
+  // ONE row, destroying every session but the last.
+  const generator: InboxKeyGenerator = cryptoProvider;
+
   const newSessionPrepData = await Promise.all(
-    devicesNeedingNewSession.map(async (device) => {
-      // Generate X448 for encryption, Ed448 for signing - in parallel
-      const [conversationInboxKeypair, conversationSigningKeypair] = await Promise.all([
-        cryptoProvider.generateX448(),
-        cryptoProvider.generateEd448(),
-      ]);
-      // Derive address from Ed448 signing key
-      const conversationInboxAddress = deriveAddress(new Uint8Array(conversationSigningKeypair.public_key));
-
-      // Store the conversation inbox keypair
-      const storedKeypair: ConversationInboxKeypair = {
-        conversationId,
-        inboxAddress: conversationInboxAddress,
-        encryptionPublicKey: conversationInboxKeypair.public_key,
-        encryptionPrivateKey: conversationInboxKeypair.private_key,
-        signingPublicKey: conversationSigningKeypair.public_key,
-        signingPrivateKey: conversationSigningKeypair.private_key,
-      };
-      encryptionStateStorage.saveConversationInboxKeypair(storedKeypair);
-
-      // Save inbox mapping
-      encryptionStateStorage.saveInboxMapping(conversationInboxAddress, conversationId);
-
-      return {
-        device,
-        conversationInboxAddress,
-        conversationInboxKeypair,
-        conversationSigningKeypair,
-      };
-    })
+    devicesNeedingNewSession.map(async (device) => ({
+      device,
+      returnInbox: await mintSessionReturnInbox(conversationId, generator),
+    }))
   );
 
-  // Subscribe to all conversation inboxes in parallel
-  const inboxAddresses = newSessionPrepData.map((p) => p.conversationInboxAddress);
+  const reinitPrepData = await Promise.all(
+    devicesWithExistingSession
+      .filter(({ state }) => state.inboxId && state.state && needsReinit(state))
+      .map(async ({ device, state }) => ({
+        device,
+        ...(await resolveSessionReturnInbox(conversationId, state, generator)),
+      }))
+  );
+  const reinitByDevice = new Map(reinitPrepData.map((p) => [p.device.inboxAddress, p.inbox]));
+
+  // Only freshly minted inboxes need a subscription; reused ones already have one.
+  const inboxAddresses = [
+    ...newSessionPrepData.map((p) => p.returnInbox.inboxAddress),
+    ...reinitPrepData.filter((p) => p.minted).map((p) => p.inbox.inboxAddress),
+  ];
   if (inboxAddresses.length > 0) {
     await subscribe(inboxAddresses);
   }
@@ -1037,76 +1148,19 @@ export async function sendEncryptedMessageToAllDevices(
     const outbounds: string[] = [];
 
     // === Handle new sessions ===
-    for (const prep of newSessionPrepData) {
-      const { device, conversationInboxAddress, conversationInboxKeypair, conversationSigningKeypair } = prep;
-
-      // Encrypt with Double Ratchet using the new device method
-      // This forces a new session to be established for this specific device
-      const encrypted = await encryptionService.encryptMessageForNewDevice(
+    for (const { device, returnInbox } of newSessionPrepData) {
+      const sealed = await buildInitEnvelopeSend({
         conversationId,
-        {
-          address: recipientAddress,
-          identityKey: device.identityKey,
-          signedPreKey: device.signedPreKey,
-          inboxAddress: device.inboxAddress,
-          inboxEncryptionKey: device.inboxEncryptionKey,
-        },
-        JSON.stringify(message),
-        conversationInboxAddress,
-        device.inboxAddress  // Use device's inbox as the tag
-      );
-
-      // Get X3DH ephemeral key
-      const x3dhEphemeralKey = encrypted.ephemeralPublicKey;
-      if (!x3dhEphemeralKey || x3dhEphemeralKey.length === 0) {
-        continue;
-      }
-
-      const x3dhEphemeralKeyBytes = Array.isArray(x3dhEphemeralKey) ? x3dhEphemeralKey : hexToBytes(x3dhEphemeralKey);
-      const x3dhEphemeralKeyHex = Array.isArray(x3dhEphemeralKey) ? bytesToHex(x3dhEphemeralKey) : x3dhEphemeralKey;
-
-      // Build InitializationEnvelope
-      const initEnvelope: InitializationEnvelope = {
-        user_address: userAddress,
-        display_name: displayName || userAddress,
-        return_inbox_address: conversationInboxAddress,
-        return_inbox_encryption_key: bytesToHex(conversationInboxKeypair.public_key),
-        return_inbox_public_key: bytesToHex(conversationSigningKeypair.public_key),
-        return_inbox_private_key: bytesToHex(conversationSigningKeypair.private_key),
-        identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-        // SDK-standard tag: sender's device inbox — the identity the
-        // receiver files this session under (previously the conversation
-        // inbox, which peers' device lists never contain).
-        tag: deviceKeyset.inboxAddress,
-        message: encrypted.envelope,
-        type: 'direct',
-      };
-
-      // Seal with recipient's inbox encryption key
-      const textEncoder = new TextEncoder();
-      const envelopeBytes = Array.from(textEncoder.encode(JSON.stringify(initEnvelope)));
-
-      const ephemeralPrivateKey = encrypted.ephemeralPrivateKey;
-      if (!ephemeralPrivateKey || ephemeralPrivateKey.length === 0) {
-        continue;
-      }
-
-      const sealedEnvelope = await cryptoProvider.encryptInboxMessage({
-        inbox_public_key: device.inboxEncryptionKey,
-        ephemeral_private_key: ephemeralPrivateKey,
-        plaintext: envelopeBytes,
+        recipientAddress,
+        message,
+        device,
+        returnInbox,
+        deviceKeyset,
+        userAddress,
+        displayName,
+        cryptoProvider,
       });
-
-      const sealedMessage = {
-        type: 'direct',
-        inbox_address: device.inboxAddress,
-        ephemeral_public_key: x3dhEphemeralKeyHex,
-        envelope: sealedEnvelope,
-        inbox_public_key: '',
-        inbox_signature: '',
-      };
-
-      outbounds.push(JSON.stringify(sealedMessage));
+      if (sealed) outbounds.push(sealed);
     }
 
     // === Handle existing sessions ===
@@ -1120,9 +1174,9 @@ export async function sendEncryptedMessageToAllDevices(
 
       // Check if session is confirmed or needs InitializationEnvelope
       const sendingInbox = state.sendingInbox;
-      const needsInitEnvelope = !sendingInbox || sendingInbox.inbox_public_key === '';
+      const reinitInbox = reinitByDevice.get(device.inboxAddress);
 
-      if (needsInitEnvelope && sendingInbox?.inbox_encryption_key) {
+      if (reinitInbox) {
         // CRITICAL: Unconfirmed session means the receiver never got our previous messages
         // or never acknowledged them. We need to send as a NEW session so the receiver
         // can do X3DH and derive the same initial ratchet state.
@@ -1130,102 +1184,21 @@ export async function sendEncryptedMessageToAllDevices(
         // If we use the existing (advanced) ratchet state, the receiver will do X3DH
         // to get the initial state, and won't be able to decrypt our message.
         //
-        // Treat this like devicesNeedingNewSession - establish a fresh X3DH session.
-
-        // Get or create conversation inbox for this device
-        let convInboxAddress: string;
-        let convInboxKeypair: { public_key: number[]; private_key: number[] };
-        let convSigningKeypair: { public_key: number[]; private_key: number[] };
-
-        const existingConvInbox = encryptionStateStorage.getConversationInboxKeypair(conversationId);
-        if (existingConvInbox) {
-          convInboxAddress = existingConvInbox.inboxAddress;
-          convInboxKeypair = {
-            public_key: existingConvInbox.encryptionPublicKey,
-            private_key: existingConvInbox.encryptionPrivateKey,
-          };
-          convSigningKeypair = {
-            public_key: existingConvInbox.signingPublicKey,
-            private_key: existingConvInbox.signingPrivateKey,
-          };
-        } else {
-          // Generate new conversation inbox
-          convInboxKeypair = await cryptoProvider.generateX448();
-          convSigningKeypair = await cryptoProvider.generateEd448();
-          convInboxAddress = deriveAddress(new Uint8Array(convSigningKeypair.public_key));
-
-          const storedKeypair: ConversationInboxKeypair = {
-            conversationId,
-            inboxAddress: convInboxAddress,
-            encryptionPublicKey: convInboxKeypair.public_key,
-            encryptionPrivateKey: convInboxKeypair.private_key,
-            signingPublicKey: convSigningKeypair.public_key,
-            signingPrivateKey: convSigningKeypair.private_key,
-          };
-          encryptionStateStorage.saveConversationInboxKeypair(storedKeypair);
-          encryptionStateStorage.saveInboxMapping(convInboxAddress, conversationId);
-        }
-
-        // Force a new X3DH session for this device
-        const encrypted = await encryptionService.encryptMessageForNewDevice(
+        // Treat this like devicesNeedingNewSession - establish a fresh X3DH session,
+        // into THIS session's own return inbox (resolved during prep) so the
+        // re-init cannot overwrite another device's row.
+        const sealed = await buildInitEnvelopeSend({
           conversationId,
-          {
-            address: recipientAddress,
-            identityKey: device.identityKey,
-            signedPreKey: device.signedPreKey,
-            inboxAddress: device.inboxAddress,
-            inboxEncryptionKey: device.inboxEncryptionKey,
-          },
-          JSON.stringify(message),
-          convInboxAddress,
-          device.inboxAddress  // Tag with device inbox
-        );
-
-        const x3dhEphemeralKey = encrypted.ephemeralPublicKey;
-        if (!x3dhEphemeralKey || x3dhEphemeralKey.length === 0) {
-          continue;
-        }
-
-        const x3dhEphemeralKeyHex = Array.isArray(x3dhEphemeralKey) ? bytesToHex(x3dhEphemeralKey) : x3dhEphemeralKey;
-
-        const initEnvelope: InitializationEnvelope = {
-          user_address: userAddress,
-          display_name: displayName || userAddress,
-          return_inbox_address: convInboxAddress,
-          return_inbox_encryption_key: bytesToHex(convInboxKeypair.public_key),
-          return_inbox_public_key: bytesToHex(convSigningKeypair.public_key),
-          return_inbox_private_key: bytesToHex(convSigningKeypair.private_key),
-          identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
-          // SDK-standard tag: sender's device inbox (see first-send builder).
-          tag: deviceKeyset.inboxAddress,
-          message: encrypted.envelope,
-          type: 'direct',
-        };
-
-        const textEncoder = new TextEncoder();
-        const envelopeBytes = Array.from(textEncoder.encode(JSON.stringify(initEnvelope)));
-
-        const ephemeralPrivateKey = encrypted.ephemeralPrivateKey;
-        if (!ephemeralPrivateKey || ephemeralPrivateKey.length === 0) {
-          continue;
-        }
-
-        const sealedEnvelope = await cryptoProvider.encryptInboxMessage({
-          inbox_public_key: device.inboxEncryptionKey,
-          ephemeral_private_key: ephemeralPrivateKey,
-          plaintext: envelopeBytes,
+          recipientAddress,
+          message,
+          device,
+          returnInbox: reinitInbox,
+          deviceKeyset,
+          userAddress,
+          displayName,
+          cryptoProvider,
         });
-
-        const sealedMessage = {
-          type: 'direct',
-          inbox_address: device.inboxAddress,
-          ephemeral_public_key: x3dhEphemeralKeyHex,
-          envelope: sealedEnvelope,
-          inbox_public_key: '',
-          inbox_signature: '',
-        };
-
-        outbounds.push(JSON.stringify(sealedMessage));
+        if (sealed) outbounds.push(sealed);
       } else if (sendingInbox?.inbox_address && sendingInbox?.inbox_encryption_key) {
         // Confirmed session - encrypt with existing session and send directly
         const encrypted = await encryptWithExistingSession(
@@ -1257,6 +1230,13 @@ export async function sendEncryptedMessageToAllDevices(
         };
 
         outbounds.push(JSON.stringify(existingSessionMsg));
+      } else {
+        // Neither sendable nor re-initializable: the row has no inbox to seal
+        // to. Nothing we can do here, but it must not be silent.
+        logger.warn(
+          '[DM-send] session has no usable sendingInbox, device skipped:',
+          device.inboxAddress.slice(0, 12),
+        );
       }
     }
 

--- a/hooks/chat/useSendDirectMessage.ts
+++ b/hooks/chat/useSendDirectMessage.ts
@@ -21,6 +21,7 @@ import {
   sessionReturnInbox,
   type InboxKeyGenerator,
 } from '@/services/crypto/sessionReturnInbox';
+import { sessionSendShape } from '@/services/crypto/sessionSendShape';
 import { encryptionStateStorage, type ConversationInboxKeypair } from '@/services/crypto/encryption-state-storage';
 import { getDeviceKeyset, getPrivateKey, getPublicKey } from '@/services/onboarding/secureStorage';
 import { deriveAddress } from '@/services/onboarding/keyService';
@@ -1032,6 +1033,88 @@ async function buildInitEnvelopeSend(args: {
 }
 
 /**
+ * Build the ACCEPT for a session the peer started: the existing ratchet's
+ * envelope wrapped in an InitializationEnvelope carrying our return inbox.
+ *
+ * Their session is unconfirmed until this lands, and while unconfirmed their
+ * receive path takes ConfirmDoubleRatchetSenderSession, which rejects a plain
+ * frame outright. That function then decrypts with `encryption_state.
+ * ratchet_state` (channel.ts L1123) — the EXISTING ratchet — so the accept must
+ * NOT re-run X3DH. A fresh X3DH here would replace the very session their
+ * frames are encrypted against.
+ *
+ * Signed like any confirmed-path frame: it is written to their conversation
+ * inbox, which verifies the signature.
+ *
+ * Returns null when we no longer hold this session's own return inbox keys —
+ * there is nothing to announce, so the caller falls back to a plain send.
+ */
+async function buildAcceptSend(args: {
+  conversationId: string;
+  message: Message;
+  state: { inboxId: string; sendingInbox?: { inbox_address?: string; inbox_encryption_key?: string; inbox_public_key?: string; inbox_private_key?: string } };
+  deviceKeyset: { identityPublicKey: number[]; inboxAddress: string };
+  userAddress: string;
+  displayName?: string;
+  cryptoProvider: {
+    generateX448(): Promise<{ public_key: number[]; private_key: number[] }>;
+    encryptInboxMessage(request: {
+      inbox_public_key: number[];
+      ephemeral_private_key: number[];
+      plaintext: number[];
+    }): Promise<string>;
+  };
+}): Promise<string | null> {
+  const { conversationId, message, state, deviceKeyset, userAddress, displayName, cryptoProvider } = args;
+  const sendingInbox = state.sendingInbox;
+  if (!sendingInbox?.inbox_address || !sendingInbox.inbox_encryption_key) return null;
+
+  const returnInbox = sessionReturnInbox(state);
+  if (!returnInbox) return null;
+
+  const encrypted = await encryptWithExistingSession(
+    conversationId,
+    state.inboxId,
+    JSON.stringify(message)
+  );
+
+  const initEnvelope: InitializationEnvelope = {
+    user_address: userAddress,
+    display_name: displayName || userAddress,
+    return_inbox_address: returnInbox.inboxAddress,
+    return_inbox_encryption_key: bytesToHex(returnInbox.encryptionPublicKey),
+    return_inbox_public_key: returnInbox.signingPublicKey ? bytesToHex(returnInbox.signingPublicKey) : '',
+    return_inbox_private_key: returnInbox.signingPrivateKey ? bytesToHex(returnInbox.signingPrivateKey) : '',
+    identity_public_key: bytesToHex(deviceKeyset.identityPublicKey),
+    tag: deviceKeyset.inboxAddress,
+    message: encrypted.envelope,
+    type: 'direct',
+  };
+
+  const envelopeBytes = Array.from(new TextEncoder().encode(JSON.stringify(initEnvelope)));
+  const sealingEphemeralKey = await cryptoProvider.generateX448();
+  const sealedEnvelope = await cryptoProvider.encryptInboxMessage({
+    inbox_public_key: hexToBytes(sendingInbox.inbox_encryption_key),
+    ephemeral_private_key: sealingEphemeralKey.private_key,
+    plaintext: envelopeBytes,
+  });
+
+  const inboxAuth = await signConfirmedEnvelope(sendingInbox, sealedEnvelope);
+  const sealed = JSON.stringify({
+    type: 'direct',
+    inbox_address: sendingInbox.inbox_address,
+    envelope: sealedEnvelope,
+    ephemeral_public_key: bytesToHex(sealingEphemeralKey.public_key),
+    inbox_public_key: inboxAuth.inbox_public_key,
+    inbox_signature: inboxAuth.inbox_signature,
+  });
+
+  // Only now that the frame exists — see markAcceptSent.
+  await encryptionService.markAcceptSent(conversationId, state.inboxId);
+  return sealed;
+}
+
+/**
  * Send an encrypted message to ALL target device inboxes
  *
  * This handles multi-device support by:
@@ -1101,12 +1184,6 @@ export async function sendEncryptedMessageToAllDevices(
     }
   }
 
-  // An unconfirmed session must re-initialize: the peer never derived our
-  // advanced ratchet, so only a fresh X3DH lands. Classified here, once, so the
-  // send loop below cannot disagree with what we prepared.
-  const needsReinit = (state: { sendingInbox?: { inbox_public_key?: string; inbox_encryption_key?: string } }) =>
-    !state.sendingInbox?.inbox_public_key && !!state.sendingInbox?.inbox_encryption_key;
-
   // Resolve every return inbox BEFORE enqueuing, so all of them can be
   // subscribed before anything is sent — the peer's confirming reply is lost if
   // nothing is listening on the inbox we advertise.
@@ -1126,7 +1203,7 @@ export async function sendEncryptedMessageToAllDevices(
 
   const reinitPrepData = await Promise.all(
     devicesWithExistingSession
-      .filter(({ state }) => state.inboxId && state.state && needsReinit(state))
+      .filter(({ state }) => state.inboxId && state.state && sessionSendShape(state) === 'init')
       .map(async ({ device, state }) => ({
         device,
         ...(await resolveSessionReturnInbox(conversationId, state, generator)),
@@ -1172,11 +1249,36 @@ export async function sendEncryptedMessageToAllDevices(
         continue;
       }
 
-      // Check if session is confirmed or needs InitializationEnvelope
+      // Which shape this frame must take on the wire — see sessionSendShape.
       const sendingInbox = state.sendingInbox;
+      const shape = sessionSendShape(state);
       const reinitInbox = reinitByDevice.get(device.inboxAddress);
 
-      if (reinitInbox) {
+      if (shape === 'accept') {
+        // The peer opened this session and is still unconfirmed: our first
+        // frame back must carry our return inbox or they reject all of them.
+        const sealed = await buildAcceptSend({
+          conversationId,
+          message,
+          state,
+          deviceKeyset,
+          userAddress,
+          displayName,
+          cryptoProvider,
+        });
+        if (sealed) {
+          outbounds.push(sealed);
+          continue;
+        }
+        // No return inbox to announce — fall through to the plain send below,
+        // which is what we did before and is no worse.
+        logger.warn(
+          '[DM-send] cannot announce a return inbox for this session, sending plain:',
+          device.inboxAddress.slice(0, 12),
+        );
+      }
+
+      if (shape === 'init' && reinitInbox) {
         // CRITICAL: Unconfirmed session means the receiver never got our previous messages
         // or never acknowledged them. We need to send as a NEW session so the receiver
         // can do X3DH and derive the same initial ratchet state.

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -797,9 +797,6 @@ class EncryptionService {
         // Also save to regular state storage
         encryptionStateStorage.saveEncryptionState(updatedState, false);
 
-        // Get our conversation inbox for the return value
-        const cachedConversationInbox = encryptionStateStorage.getConversationInboxKeypair(conversationId);
-
         return {
           conversationId,
           message: decryptedMessage,
@@ -810,7 +807,10 @@ class EncryptionService {
             publicKey: unsealed.return_inbox_public_key,
             privateKey: unsealed.return_inbox_private_key,
           },
-          ourConversationInbox: cachedConversationInbox?.inboxAddress || ephemeralCachedState.inboxId,
+          // This session's OWN receiving inbox (the row key), not a
+          // conversation-wide one — that would be another device's inbox and
+          // the caller subscribes to whatever we return here.
+          ourConversationInbox: ephemeralCachedState.inboxId,
           userProfile: {
             displayName: unsealed.display_name,
             userIcon: unsealed.user_icon,
@@ -888,9 +888,6 @@ class EncryptionService {
         };
         encryptionStateStorage.saveEncryptionState(updatedState, false); // Don't update latestState for receive
 
-        // Get our conversation inbox for the return value
-        const conversationInbox = encryptionStateStorage.getConversationInboxKeypair(conversationId);
-
         const userProfile = (unsealed.display_name || unsealed.user_icon)
           ? { displayName: unsealed.display_name, userIcon: unsealed.user_icon }
           : undefined;
@@ -905,7 +902,8 @@ class EncryptionService {
             publicKey: unsealed.return_inbox_public_key,
             privateKey: unsealed.return_inbox_private_key,
           },
-          ourConversationInbox: conversationInbox?.inboxAddress || existingState.inboxId,
+          // This session's OWN receiving inbox (see the ephemeral-cache branch).
+          ourConversationInbox: existingState.inboxId,
           userProfile,
         };
       }

--- a/services/crypto/encryption-service.ts
+++ b/services/crypto/encryption-service.ts
@@ -645,6 +645,27 @@ class EncryptionService {
   }
 
   /**
+   * Record that this session's accept is on the wire — the init-wrapped frame
+   * carrying OUR return inbox — so later sends use the plain shape. SDK parity
+   * with DoubleRatchetInboxEncrypt's `sent_accept` (see sessionSendShape).
+   *
+   * Call only AFTER the sealed frame exists: flipping earlier and then failing
+   * to build it would leave the session claiming an accept it never sent, and
+   * every later frame would be a plain one the peer rejects.
+   *
+   * Re-reads inside the ratchet lock and preserves the ratchet: a send may have
+   * advanced the state between encrypting and this call, and writing back a
+   * stale snapshot would regress a ratchet whose frame is already on the wire.
+   */
+  async markAcceptSent(conversationId: string, inboxId: string): Promise<void> {
+    return ratchetMutex.runExclusive(conversationId, async () => {
+      const fresh = encryptionStateStorage.getEncryptionState(conversationId, inboxId);
+      if (!fresh || fresh.sentAccept) return;
+      encryptionStateStorage.saveEncryptionState({ ...fresh, sentAccept: true }, false, true);
+    });
+  }
+
+  /**
    * Get the return inbox address for a conversation (for sending reset messages)
    */
   getReturnInboxForConversation(conversationId: string): string | null {

--- a/services/crypto/encryption-state-storage.ts
+++ b/services/crypto/encryption-state-storage.ts
@@ -425,15 +425,14 @@ class EncryptionStateStorage {
   // Conversation Inbox Keypairs
 
   /**
-   * Save a per-conversation inbox keypair
-   * This keypair is used to receive replies for a specific conversation
+   * Save an inbox keypair used to receive replies for one SESSION.
    *
-   * Also stored keyed BY INBOX ADDRESS: the per-conversation slot is
-   * last-writer-wins, so with multi-device sends (one return inbox per
-   * device session) only the last device's keypair survived there. The
-   * per-address copy lets the send path re-advertise a SESSION's own
-   * return inbox (desktop parity), which is what makes the peer's
-   * confirming reply land back on the row the send path reads.
+   * The authoritative copy is keyed BY INBOX ADDRESS — a conversation has one
+   * inbox per session (one per peer device), and the per-conversation slot is
+   * last-writer-wins, so it only ever holds the newest. That slot is still
+   * written for backwards compatibility (records predating the per-address
+   * store are only found there by the sweeps below); nothing may READ it to
+   * decide where a session receives.
    */
   saveConversationInboxKeypair(keypair: ConversationInboxKeypair): void {
     const key = `${KEYS.CONVERSATION_INBOX_KEY}${keypair.conversationId}`;
@@ -451,20 +450,11 @@ class EncryptionStateStorage {
     }
   }
 
-
-  /**
-   * Get the inbox keypair for a conversation
-   */
-  getConversationInboxKeypair(conversationId: string): ConversationInboxKeypair | null {
-    const key = `${KEYS.CONVERSATION_INBOX_KEY}${conversationId}`;
-    const data = this.storage.getString(key);
-    if (!data) return null;
-    try {
-      return JSON.parse(data) as ConversationInboxKeypair;
-    } catch {
-      return null;
-    }
-  }
+  // NOTE: there is deliberately no getter by conversationId. Reading the
+  // last-writer-wins slot handed one device's inbox to another device's
+  // session, and rows are keyed by that inbox, so the two sessions collapsed
+  // into one row and all but the last were destroyed. Look up by ADDRESS,
+  // from the session row that needs it (services/crypto/sessionReturnInbox.ts).
 
   /**
    * Delete conversation inbox keypair (both the per-conversation slot and

--- a/services/crypto/sessionReturnInbox.ts
+++ b/services/crypto/sessionReturnInbox.ts
@@ -1,0 +1,101 @@
+/**
+ * Which conversation inbox a DM session advertises as its return address.
+ *
+ * The rule: a session's return inbox is the inbox its OWN state row is keyed
+ * by — never one shared per conversation.
+ *
+ * A Double Ratchet session is strictly linear, so a peer with N devices needs N
+ * sessions. Rows are keyed `(conversationId, inboxId)`, so advertising one
+ * conversation-wide inbox made every device of that peer re-initialize into the
+ * SAME row: last writer won, the other devices' sessions were silently
+ * destroyed, and every message to them was lost. A phone plus a laptop is
+ * enough to trigger it. Desktop mints a keyset per session and never had this.
+ *
+ * Deriving the inbox from the row is also what lets a session reach the
+ * confirmed state: the peer replies to the address we advertised, and
+ * confirmSenderSession() finds the row to confirm BY that address.
+ */
+
+import { encryptionStateStorage } from './encryption-state-storage';
+import { deriveAddress } from '@/services/onboarding/keyService';
+import type { ConversationInboxKeypair } from '@quilibrium/quorum-shared';
+
+/** The minimum of NativeCryptoProvider needed to mint an inbox keyset. */
+export interface InboxKeyGenerator {
+  generateX448(): Promise<{ public_key: number[]; private_key: number[] }>;
+  generateEd448(): Promise<{ public_key: number[]; private_key: number[] }>;
+}
+
+/**
+ * The keypair of a session's own return inbox, or null when we can't use it.
+ *
+ * Null covers rows written before per-address keypairs existed (#177): their
+ * keypair lived only in the last-writer-wins per-conversation slot and may have
+ * been overwritten, and a keyset missing its Ed448 half can never be confirmed
+ * by the peer. Either way the caller mints a fresh inbox and the session
+ * re-initializes onto it.
+ */
+export function sessionReturnInbox(
+  state: { inboxId?: string } | null | undefined
+): ConversationInboxKeypair | null {
+  if (!state?.inboxId) return null;
+  const keypair = encryptionStateStorage.getConversationInboxKeypairByAddress(state.inboxId);
+  if (!keypair?.encryptionPublicKey?.length || !keypair.encryptionPrivateKey?.length) return null;
+  if (!keypair.signingPublicKey?.length || !keypair.signingPrivateKey?.length) return null;
+  return keypair;
+}
+
+/**
+ * Mint and persist a fresh return inbox for a new session.
+ *
+ * X448 for sealing, Ed448 for signing; the address derives from the Ed448 key
+ * so inbox writes can be signature-verified, exactly like a device inbox.
+ */
+export async function mintSessionReturnInbox(
+  conversationId: string,
+  generator: InboxKeyGenerator
+): Promise<ConversationInboxKeypair> {
+  const [encryption, signing] = await Promise.all([
+    generator.generateX448(),
+    generator.generateEd448(),
+  ]);
+
+  const keypair: ConversationInboxKeypair = {
+    conversationId,
+    inboxAddress: deriveAddress(new Uint8Array(signing.public_key)),
+    encryptionPublicKey: encryption.public_key,
+    encryptionPrivateKey: encryption.private_key,
+    signingPublicKey: signing.public_key,
+    signingPrivateKey: signing.private_key,
+  };
+
+  encryptionStateStorage.saveConversationInboxKeypair(keypair);
+  encryptionStateStorage.saveInboxMapping(keypair.inboxAddress, conversationId);
+  return keypair;
+}
+
+/**
+ * The return inbox for a session we are re-initializing: its own inbox when we
+ * still hold those keys, otherwise a fresh one.
+ *
+ * `minted` tells the caller whether a subscription is still owed — a reused
+ * inbox is already subscribed, a fresh one is not, and the peer's confirming
+ * reply is lost if nothing is listening.
+ *
+ * Idempotent: the resolved inbox is stored under its own address, so the next
+ * send resolves to the same one. Inbox mappings are only ever added, never
+ * deleted — the peer may still be writing to an older address (desktop #252).
+ */
+export async function resolveSessionReturnInbox(
+  conversationId: string,
+  state: { inboxId?: string } | null | undefined,
+  generator: InboxKeyGenerator
+): Promise<{ inbox: ConversationInboxKeypair; minted: boolean }> {
+  const existing = sessionReturnInbox(state);
+  if (existing) {
+    // Re-assert routing: a lost mapping silently drops the peer's replies.
+    encryptionStateStorage.saveInboxMapping(existing.inboxAddress, conversationId);
+    return { inbox: existing, minted: false };
+  }
+  return { inbox: await mintSessionReturnInbox(conversationId, generator), minted: true };
+}

--- a/services/crypto/sessionSendShape.ts
+++ b/services/crypto/sessionSendShape.ts
@@ -1,0 +1,62 @@
+/**
+ * Which shape a DM frame must take on the wire.
+ *
+ * A frame is either PLAIN (a bare Double Ratchet envelope) or INIT-WRAPPED (the
+ * same envelope inside an InitializationEnvelope carrying our return inbox).
+ * The receiver does not choose — it demands one shape based on its own session:
+ *
+ *   sending_inbox.inbox_public_key === ''  → ConfirmDoubleRatchetSenderSession,
+ *                                            which THROWS on a plain frame
+ *                                            ('invalid initialization envelope')
+ *   otherwise                              → DoubleRatchetInboxDecrypt, which
+ *                                            accepts either shape
+ *
+ * So a peer who has not yet received our return inbox rejects every plain frame
+ * we send. Mobile used to decide the shape from `sendingInbox.inbox_public_key`
+ * — "do I know THEIR inbox?" — which answers the wrong question: a session born
+ * from a peer's init envelope knows their inbox immediately, so mobile's first
+ * reply went out plain and the peer, still unconfirmed, dropped every frame.
+ * Permanently one-way, and only recoverable by a manual reset.
+ *
+ * The SDK asks the right question — "have I told them MINE?" — via
+ * `sent_accept` (DoubleRatchetInboxEncrypt, channel.ts L976+):
+ *
+ *   sent_accept ? <plain> : <init-wrapped>, then persist sent_accept: true
+ *
+ * Both of mobile's ways of setting that flag converge on ONE meaning: the peer
+ * has our return inbox. On a session we started, `confirmSenderSession` sets it
+ * when their confirming reply arrives — proof, since only our return inbox
+ * could have carried it. On a session they started, the accept below sets it
+ * when we send ours — a weaker claim, since a lost frame is indistinguishable
+ * from a delivered one. See `sessionAcceptEvidence` in the receive path.
+ */
+
+export type SessionSendShape =
+  /** No return inbox known: keep announcing via a fresh X3DH init envelope. */
+  | 'init'
+  /** Their inbox known, ours never sent: wrap the EXISTING ratchet — no X3DH. */
+  | 'accept'
+  /** Both sides hold each other's inbox: bare envelope. */
+  | 'plain'
+  /** Nothing to seal to. */
+  | 'unsendable';
+
+export interface SendShapeState {
+  sentAccept?: boolean;
+  sendingInbox?: {
+    inbox_address?: string;
+    inbox_encryption_key?: string;
+    inbox_public_key?: string;
+  };
+}
+
+export function sessionSendShape(state: SendShapeState | null | undefined): SessionSendShape {
+  const sendingInbox = state?.sendingInbox;
+  // Without their sealing key there is no frame to build at all.
+  if (!sendingInbox?.inbox_encryption_key) return 'unsendable';
+  // An unconfirmed sender session targets their DEVICE inbox, where no session
+  // exists yet — only a full X3DH init envelope can land.
+  if (!sendingInbox.inbox_public_key) return 'init';
+  if (!sendingInbox.inbox_address) return 'unsendable';
+  return state?.sentAccept ? 'plain' : 'accept';
+}


### PR DESCRIPTION
Two structural defects in mobile's DM send path, plus the visibility fixes that made them findable. Both defects produced the same user-visible symptom: messages that silently never arrive, permanently, until a manual "reset encryption session".

## 1. One conversation inbox per DEVICE session, not per conversation (`72f410c`)

State rows are keyed `(conversationId, inboxId)`, so the inbox a session advertises IS its row key. The re-init path reused ONE conversation-wide inbox for every device of a peer, so all their sessions collapsed onto one row: last writer won, the others were silently destroyed, and every message to those devices was lost. A phone plus a laptop is enough to trigger it. Desktop mints a keyset per session and never had this.

- New `services/crypto/sessionReturnInbox.ts` owns the rule: a session's return inbox is the inbox its own row is keyed by. Rows within a conversation are unique by `inboxId`, so two sessions can no longer collide **by construction**.
- Both return inboxes are resolved BEFORE enqueuing, so a freshly minted inbox is subscribed before anything is sent (the peer's confirming reply was otherwise lost).
- Migration is lazy and idempotent: a row whose keypair we no longer hold mints a fresh inbox and re-initializes. Inbox mappings are only added, never deleted, so routing to older addresses survives (desktop #252).

## 2. Send the accept, so a peer's session can actually confirm (`17144df`)

A frame is either plain or init-wrapped, and the RECEIVER demands which. While its `sending_inbox.inbox_public_key` is empty, desktop takes `ConfirmDoubleRatchetSenderSession`, which throws `invalid initialization envelope` on a plain frame.

Mobile chose the shape by asking *"do I know THEIR inbox?"*. A session born from a peer's init envelope knows their inbox immediately, so mobile's first reply went out plain and the peer — still unconfirmed — dropped every frame. The SDK asks *"have I told them MINE?"* via `sent_accept` (`DoubleRatchetInboxEncrypt`, channel.ts L976+). Mobile stored that flag in three places, preserved it on every save, and read it nowhere.

- New `services/crypto/sessionSendShape.ts` returns `init | accept | plain | unsendable`.
- The accept wraps the EXISTING ratchet, no X3DH: the peer's Confirm path decrypts with `encryption_state.ratchet_state` (channel.ts L1123), so a fresh X3DH would replace the very session their frames are encrypted against. Signed, because it is written to their conversation inbox.
- Applied to the device fan-out (text, delete, edit, receipts, profile) and the embed path.

**Live result:** a one-sided reset from mobile went from 0/3 to **5/5 in both directions with zero peer-side errors** — the first clean pass in this bug's history.

## 3. Stop swallowing the server's rejection of an inbox write (`8f5ea97`)

The server's only channel for reporting a refused write is an inbound error payload. It was logged at `debug` and dropped, so a refused write was indistinguishable from a delivered one. Now `warn`, with the full payload, plus a warn for any inbound frame that is neither an error, a known type, nor a sealed message.

## 4. Never record an accept that did not reach the wire (`b8b6fde`)

Found by review. `sentAccept` was being set on optimism, in three ways, each re-arming the deadlock the rest of this PR fixes:

- **Batch abort:** the flag was flipped mid-loop, but a device throwing later rejects the whole callback and the transport discards every frame without requeueing. Now flipped only after the entire batch is built.
- **Unsigned accept:** signing degrades to unsigned rather than throwing, and a conversation inbox rejects an unsigned write. Now sent but not recorded, so the next send announces again.
- **Embed path:** an accept with no return-inbox keys advertised the DEVICE inbox with empty signing keys and recorded it anyway. Now falls back to the plain send, and says so.

## Verification

- **80/80 tests green**, 22 new across two suites, including a regression test pinning the old shared-inbox collapse and tests that an unrecorded accept re-announces.
- **Typecheck: 20 errors vs master's 22** — this PR removes two pre-existing ones (the old code assigned possibly-undefined signing keys; the compiler was already pointing at the shared slot being wrong). Lint clean on all touched files.
- **Three independent reviews** — correctness/regression, cross-platform interop, silent-failure. Interop verdict `INTEROP SAFE`, verified against the SDK source: the accept is accepted by both a confirmed and an unconfirmed peer, on both platforms, and cannot reset a ratchet or replace a session. The other two found the defects fixed in `b8b6fde`.
- Live-tested on Android against desktop `main` (`f0a34807d`) across several rounds.
- **iOS: reviewed, not run** (no iOS device available). No UI in this diff; the one iOS-specific surface, the App Group mirror and notification-service keystore, is already keyed by inbox address and handles N inboxes per conversation correctly.

## Known residuals, deliberately not in scope

- `sentAccept` still means "we put it on the wire", not "they got it". A frame lost after the queue accepts it still strands the session — strictly narrower than before this PR. A self-heal was attempted, measured on devices, and reverted for false positives.
- `useSendDirectReaction.ts` never init-wraps, so a reaction sent as the FIRST thing on a peer-opened session is still dropped by a desktop peer. A text message first repairs the session. Pre-existing, unchanged.
- mobile↔mobile remains untested (requires a second device). It is the pairing where both fixes must work simultaneously.