### PR TITLE
fix: config sync never published — randomBytes import resolved to undefined

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@polkadot/keyring": "14.0.1",
     "@polkadot/util": "14.0.1",
     "@polkadot/util-crypto": "14.0.1",
-    "@quilibrium/quorum-shared": "2.1.0-36",
+    "@quilibrium/quorum-shared": "2.1.0-37",
     "@react-native-async-storage/async-storage": "2.2.0",
     "@react-native-community/netinfo": "11.4.1",
     "@react-navigation/bottom-tabs": "7.4.7",

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -4,7 +4,14 @@ import { base64ToHex, numberArrayToBase64 } from '@/utils/encoding';
 import { InteractionManager } from 'react-native';
 import { sha512 } from '@noble/hashes/sha2.js';
 import { gcm } from '@noble/ciphers/aes.js';
-import { randomBytes } from '@noble/ciphers/webcrypto.js';
+// randomBytes lives in utils.js, NOT webcrypto.js, as of @noble/ciphers v2.
+// webcrypto.js still resolves, so the wrong path is not an import error — the
+// binding just lands as `undefined` and blows up at the call site in
+// encryptConfig, which saveConfig catches and logs. Every config write then
+// fails to publish while still saving locally, so the app looks fine and
+// nothing syncs outbound. Backed by crypto.getRandomValues, polyfilled at
+// startup in index.js by react-native-get-random-values.
+import { randomBytes } from '@noble/ciphers/utils.js';
 import { createMMKV, type MMKV } from 'react-native-mmkv';
 import { getQuorumClient } from '../api/quorumClient';
 import { mmkvStorage } from '../offline/storage';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,10 +2266,10 @@
     tslib "^2.8.0"
     ws "^8.18.0"
 
-"@quilibrium/quorum-shared@2.1.0-36":
-  version "2.1.0-36"
-  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-36.tgz#9419072b792c24e74f8f18918f5fc65d6dc87314"
-  integrity sha512-SBXBHrP0+Ly0GbKEjpsghjJ9a8dVDL3kb3cwEfo6OKFtRo88cDUp+K9Fgj1WcTOq/x2AI3Ys8KIFhtEx7LQbHg==
+"@quilibrium/quorum-shared@2.1.0-37":
+  version "2.1.0-37"
+  resolved "https://registry.yarnpkg.com/@quilibrium/quorum-shared/-/quorum-shared-2.1.0-37.tgz#bbc48fba6899d5a6fc960989a84830b2f8ba9941"
+  integrity sha512-ATyr20YNwSuGNU1K956asfjLoxy39nKozoRct9arwDJAFbOGlVCX3HMa3vvUPo+6tuBKd/4isKn2EJQYHmZrbA==
   dependencies:
     "@noble/hashes" "1.8.0"
     dayjs "1.11.19"


### PR DESCRIPTION
## The bug

`encryptConfig` imported `randomBytes` from `@noble/ciphers/webcrypto.js`, but **@noble/ciphers v2** (this repo pins `2.1.1`) moved that export to `utils.js`.

The old subpath still resolves, so this was never an import error. The binding just landed as `undefined` and threw at the call site on **every config write**.

## Why nobody noticed

`saveConfig` catches the throw, logs `[ConfigSync] settings POST FAILED`, and still saves locally. So the app looked healthy while this device published **nothing**.

Everything carried on the config blob was broken outbound:

- DM mute
- Blocked users
- Channel / space notification mute
- Bookmarks
- Space keys

**Inbound was unaffected** — `decryptConfig` reads the IV out of the stored blob and never needs `randomBytes`. That asymmetry is why desktop → mobile appeared to work while mobile → anywhere silently did not.

This is precisely the "cross-device nothing syncs black hole" that the `[ConfigSync]` warning was added to catch. It surfaced when a new feature called `saveConfig` from a code path that had not touched it before.

## Verification

Runtime check against the installed package:

```
webcrypto.randomBytes  = undefined   <- the bug
utils.randomBytes      = function
gcm round-trip         = {"conversationSettings":{"a":{"updatedAt":1}}}
```

- `utils.randomBytes` is backed by `crypto.getRandomValues`, already polyfilled at startup in `index.js` via `react-native-get-random-values`
- `./utils.js` is declared in the package's `exports` map, so Metro resolves it
- Typecheck: **19 pre-existing errors → 18**; the removed one is this import

## Scope

Mobile only — neither `quorum-desktop/src` nor `quorum-shared` uses this import path.