### PR TITLE
feat: sync conversation settings

### DIFF
--- a/app/(tabs)/messages/dm/[id].tsx
+++ b/app/(tabs)/messages/dm/[id].tsx
@@ -7,6 +7,7 @@ import { FarcasterDirectMessageView } from '@/components/Chat/FarcasterDirectMes
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { IconSymbol } from '@/components/ui/IconSymbol';
 import { useConversation } from '@/hooks/chat/useConversations';
+import { useDMConversationSettings } from '@/hooks/chat/useDMConversationSettings';
 import { useDMMute } from '@/hooks/chat/useDMMute';
 import { useDeleteConversationSignal } from '@/hooks/chat/useDeleteConversationSignal';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
@@ -217,59 +218,99 @@ export default function DMChatScreen() {
     toggleMute(conversationId);
   }, [conversationId, toggleMute]);
 
-  // Persist a per-conversation setting onto the stored Conversation, then
-  // invalidate both the detail (drives the settings toggles) and the list query.
-  const updateConversationSetting = useCallback(
-    async (patch: Partial<Conversation>) => {
-      if (!conversationId) return;
-      const stored = await storage.getConversation(conversationId);
-      if (!stored) return;
-      await storage.saveConversation({ ...stored, ...patch });
-      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.detail(conversationId) });
-      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
-    },
-    [conversationId, storage, queryClient]
+  // Per-conversation settings live in UserConfig.conversationSettings, so they
+  // sync across this user's devices (same carrier as mute). Writes persist
+  // OVERRIDES ONLY: a value equal to the inherited global/default is written as
+  // `undefined` so it keeps inheriting, which keeps the synced blob free of
+  // default-valued entries and lets a later change to the global still apply.
+  const { getOverride, saveOverrides, globalNonRepudiable } = useDMConversationSettings();
+  const { deliveryReceipts: globalDeliveryReceipts, readReceipts: globalReadReceipts } =
+    useReceiptSettings();
+
+  // Dual-read while the one-time migration sweep may not have run yet: synced
+  // override first, then the legacy field on the local Conversation record.
+  const readSetting = useCallback(
+    (key: 'isRepudiable' | 'saveEditHistory' | 'deliveryReceipts' | 'readReceipts') =>
+      conversationId
+        ? getOverride(conversationId, key) ?? conversation?.[key]
+        : undefined,
+    [conversationId, getOverride, conversation]
   );
 
-  // The edit hooks (useEditDirectMessage) read conversation.saveEditHistory and,
-  // when off, drop prior versions instead of accumulating — matching desktop
-  // (default false).
+  // Signing default comes from the global "always sign" preference (desktop's
+  // UserConfig.nonRepudiable, default on), so an unset conversation follows it.
+  const effectiveIsRepudiable = readSetting('isRepudiable') ?? !globalNonRepudiable;
+  const effectiveSaveEditHistory = readSetting('saveEditHistory') ?? false;
+  // Receipts stay raw (undefined = inherit) — the sheet renders `?? global` and
+  // shows the "Reset to global" link only while an override exists.
+  const conversationDeliveryReceipts = readSetting('deliveryReceipts');
+  const conversationReadReceipts = readSetting('readReceipts');
+
+  // The edit hooks (useEditDirectMessage) read this and, when off, drop prior
+  // versions instead of accumulating — matching desktop (default false), so
+  // only "on" is a genuine override worth storing.
   const handleToggleEditHistory = useCallback(
-    (value: boolean) => updateConversationSetting({ saveEditHistory: value }),
-    [updateConversationSetting]
+    (value: boolean) => {
+      if (!conversationId) return;
+      saveOverrides(conversationId, { saveEditHistory: value ? true : undefined });
+    },
+    [conversationId, saveOverrides]
   );
 
   // "Always sign messages" persists the inverse as isRepudiable. The send path
-  // and composer lock read it back from the conversation.
+  // and composer lock read the effective value back. Stored only when it differs
+  // from the global preference.
   const handleToggleRepudiable = useCallback(
-    (value: boolean) => updateConversationSetting({ isRepudiable: value }),
-    [updateConversationSetting]
+    (value: boolean) => {
+      if (!conversationId) return;
+      saveOverrides(conversationId, {
+        isRepudiable: value === !globalNonRepudiable ? undefined : value,
+      });
+    },
+    [conversationId, saveOverrides, globalNonRepudiable]
   );
 
-  // Per-conversation DM receipt override (stored on the local Conversation, like
-  // desktop; effective value = override ?? global). Cross-device sync is the
-  // unified conversation-settings task (2026-07-20). Delivery-off cascades read-off.
-  const { deliveryReceipts: globalDeliveryReceipts, readReceipts: globalReadReceipts } =
-    useReceiptSettings();
+  // Per-conversation DM receipt override; effective value = override ?? global.
+  // Delivery-off cascades read-off, matching desktop.
   const handleSetDeliveryReceipts = useCallback(
-    (value: boolean) =>
-      updateConversationSetting(value ? { deliveryReceipts: true } : { deliveryReceipts: false, readReceipts: false }),
-    [updateConversationSetting]
+    (value: boolean) => {
+      if (!conversationId) return;
+      saveOverrides(
+        conversationId,
+        value ? { deliveryReceipts: true } : { deliveryReceipts: false, readReceipts: false }
+      );
+    },
+    [conversationId, saveOverrides]
   );
   const handleSetReadReceipts = useCallback(
-    (value: boolean) => updateConversationSetting({ readReceipts: value }),
-    [updateConversationSetting]
+    (value: boolean) => {
+      if (!conversationId) return;
+      saveOverrides(conversationId, { readReceipts: value });
+    },
+    [conversationId, saveOverrides]
   );
   // Reset delivery override also clears read (read inherits when delivery does),
-  // matching desktop; reset read clears read only.
-  const handleResetDelivery = useCallback(
-    () => updateConversationSetting({ deliveryReceipts: undefined, readReceipts: undefined }),
-    [updateConversationSetting]
-  );
-  const handleResetRead = useCallback(
-    () => updateConversationSetting({ readReceipts: undefined }),
-    [updateConversationSetting]
-  );
+  // matching desktop; reset read clears read only. Clearing keeps an
+  // empty-but-timestamped entry, which is what propagates the reset to the
+  // user's other devices.
+  const handleResetDelivery = useCallback(() => {
+    if (!conversationId) return;
+    saveOverrides(conversationId, { deliveryReceipts: undefined, readReceipts: undefined });
+  }, [conversationId, saveOverrides]);
+  const handleResetRead = useCallback(() => {
+    if (!conversationId) return;
+    saveOverrides(conversationId, { readReceipts: undefined });
+  }, [conversationId, saveOverrides]);
+
+  // The chat area reads signing off the conversation record it's handed, so
+  // hand it the EFFECTIVE value (synced override → legacy local field → global).
+  // Without this the composer lock and send path would still follow the stale
+  // device-local field after a change made on another device.
+  const conversationForChat = useMemo(() => {
+    if (!conversation) return conversation;
+    if (conversation.isRepudiable === effectiveIsRepudiable) return conversation;
+    return { ...conversation, isRepudiable: effectiveIsRepudiable };
+  }, [conversation, effectiveIsRepudiable]);
 
   // Delete this conversation. Like desktop, we FIRST signal the counterparty
   // (a `delete-conversation` control message) so they reset their encryption
@@ -425,7 +466,7 @@ export default function DMChatScreen() {
 
       <DMChatArea
         conversationId={conversationId}
-        conversationData={conversation}
+        conversationData={conversationForChat ?? conversation}
         isFarcasterConversation={false}
         recipientAddress={recipientAddress}
         onShowSidebars={handleShowSidebars}
@@ -476,14 +517,14 @@ export default function DMChatScreen() {
             displayName={title}
             theme={theme}
             onDeleteConversation={handleDeleteConversation}
-            isRepudiable={conversation.isRepudiable}
+            isRepudiable={effectiveIsRepudiable}
             onToggleRepudiable={handleToggleRepudiable}
-            saveEditHistory={conversation.saveEditHistory}
+            saveEditHistory={effectiveSaveEditHistory}
             onToggleEditHistory={handleToggleEditHistory}
             isMuted={conversationMuted}
             onToggleMute={handleToggleMute}
-            deliveryReceipts={conversation.deliveryReceipts}
-            readReceipts={conversation.readReceipts}
+            deliveryReceipts={conversationDeliveryReceipts}
+            readReceipts={conversationReadReceipts}
             globalDeliveryReceipts={globalDeliveryReceipts}
             globalReadReceipts={globalReadReceipts}
             onSetDeliveryReceipts={handleSetDeliveryReceipts}

--- a/app/(tabs)/messages/index.tsx
+++ b/app/(tabs)/messages/index.tsx
@@ -14,6 +14,7 @@ import { coerceMessagePreview, previewKindIcon } from '@/utils/messagePreview';
 import { formatRowTime } from '@/utils/dateFormat';
 import { useAuth } from '@/context/AuthContext';
 import type { Conversation } from '@/hooks/chat';
+import { useDMConversationSettingsLoader } from '@/hooks/chat/useDMConversationSettings';
 import { useDMMute } from '@/hooks/chat/useDMMute';
 import { useUnifiedConversations } from '@/hooks/chat/useUnifiedConversations';
 import { useStorageAdapter } from '@/context/StorageContext';
@@ -50,7 +51,6 @@ interface InboxItem {
   address?: string;
   timestamp: number;
   unreadCount: number;
-  isRepudiable?: boolean;
   isFarcaster?: boolean;
   isMuted?: boolean;
   subtitle?: string;
@@ -171,6 +171,12 @@ export default function MessagesInbox() {
   // muted set, so the list memo re-runs on toggle via its dep on `isMuted`.
   const { isMuted, toggleMute } = useDMMute();
 
+  // Per-conversation DM settings are also config-backed. This screen doesn't
+  // read them, but loading here (as mute does) is what gets the one-time
+  // migration of device-local settings to run on app open, instead of waiting
+  // for the user to open one specific conversation.
+  useDMConversationSettingsLoader();
+
   const storage = useStorageAdapter();
   const queryClient = useQueryClient();
 
@@ -218,7 +224,6 @@ export default function MessagesInbox() {
         address: conv.address,
         timestamp: conv.timestamp,
         unreadCount: hasUnread ? 1 : 0,
-        isRepudiable: conv.isRepudiable,
         isFarcaster: conv.source === 'farcaster',
         isMuted: isMuted(conv.conversationId),
         subtitle: previewText,

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -53,7 +53,11 @@ import type {
   WebSocketClient,
   WebSocketConnectionState,
 } from '@quilibrium/quorum-shared';
-import { getLocalUserConfig } from '../services/config/configService';
+import {
+  getLocalUserConfig,
+  getLocalConversationSetting,
+  getConversationSettingForCurrentUser,
+} from '../services/config/configService';
 import { updateMessageDeliveredAt, updateMessagesReadAt } from '../services/storage/messagesDb';
 import { sendEncryptedMessageToAllDevices } from '../hooks/chat/useSendDirectMessage';
 import { toAllDeviceInfos, type DeviceInfo } from '../hooks/chat/useRecipientRegistration';
@@ -548,20 +552,28 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const receiptServiceRef = useRef<ReceiptService | null>(null);
   const sendDmReceiptAckRef = useRef<((partnerAddress: string, ack: ReceiptControlMessage) => void) | null>(null);
 
-  // Effective receipt switch: per-conversation override (stored on the local
-  // Conversation, like desktop) wins over the global setting, else the global
-  // (default OFF). Read live so a settings toggle takes effect immediately.
-  // `partner` is the DM partner address (conversationId is `partner/partner`).
-  // NOTE: the per-conversation override is NOT synced across devices yet — that's
-  // the unified conversation-settings sync task (2026-07-20).
+  // Effective receipt switch: per-conversation override wins over the global
+  // setting, else the global (default OFF). Read live so a settings toggle takes
+  // effect immediately. `partner` is the DM partner address (conversationId is
+  // `partner/partner`).
+  //
+  // The override comes from the synced UserConfig map, falling back to the
+  // legacy device-local Conversation field for a device whose one-time migration
+  // sweep hasn't run yet. This gate must stay in step with the settings sheet —
+  // gating receipts on a stale local value would keep emitting acks for a
+  // conversation the user switched off from another device.
   const isReceiptEnabled = useCallback((kind: 'delivery' | 'read', partner?: string): boolean => {
     const self = fullUserAddrRef.current;
     if (!self) return false;
     const cfg = getLocalUserConfig(self);
-    const conv = partner ? getConversationSync(`${partner}/${partner}`) : undefined;
+    const conversationId = partner ? `${partner}/${partner}` : undefined;
+    const conv = conversationId ? getConversationSync(conversationId) : undefined;
+    const override = conversationId
+      ? getLocalConversationSetting(self, conversationId, kind === 'delivery' ? 'deliveryReceipts' : 'readReceipts')
+      : undefined;
     return kind === 'delivery'
-      ? (conv?.deliveryReceipts ?? cfg?.deliveryReceipts ?? false)
-      : (conv?.readReceipts ?? cfg?.readReceipts ?? false);
+      ? (override ?? conv?.deliveryReceipts ?? cfg?.deliveryReceipts ?? false)
+      : (override ?? conv?.readReceipts ?? cfg?.readReceipts ?? false);
   }, []);
 
   // Intercept DM receipts on the decrypt path (both receive branches), BEFORE
@@ -3218,7 +3230,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
             if (withinWindow && withinLength) {
               const conversation = await storage.getConversation(conversationId);
-              const saveEditHistory = conversation?.saveEditHistory ?? false;
+              // Synced per-conversation override first, then the legacy local
+              // field (pre-migration devices). Must match the send-side gate in
+              // useEditDirectMessage or an incoming edit would retain history
+              // this device's own edits drop, and vice versa.
+              const saveEditHistory =
+                getConversationSettingForCurrentUser(conversationId, 'saveEditHistory') ??
+                conversation?.saveEditHistory ??
+                false;
               const applied = applyEdit(
                 {
                   text: targetMsg.content.text,
@@ -4818,7 +4837,14 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
 
             if (withinWindow && withinLength) {
               const conversation = await storage.getConversation(conversationId);
-              const saveEditHistory = conversation?.saveEditHistory ?? false;
+              // Synced per-conversation override first, then the legacy local
+              // field (pre-migration devices). Must match the send-side gate in
+              // useEditDirectMessage or an incoming edit would retain history
+              // this device's own edits drop, and vice versa.
+              const saveEditHistory =
+                getConversationSettingForCurrentUser(conversationId, 'saveEditHistory') ??
+                conversation?.saveEditHistory ??
+                false;
               const applied = applyEdit(
                 {
                   text: targetMsg.content.text,

--- a/hooks/chat/useDMConversationSettings.ts
+++ b/hooks/chat/useDMConversationSettings.ts
@@ -1,0 +1,316 @@
+/**
+ * useDMConversationSettings - per-conversation DM settings that sync across a
+ * user's devices.
+ *
+ * The four overrides (save-edit-history, always-sign, delivery/read receipts)
+ * live in `UserConfig.conversationSettings`, keyed by conversationId, and travel
+ * on the encrypted config blob — the same mechanism as DM mute. Reading and
+ * writing go through the shared `conversationSettingsUtils` helpers so desktop
+ * and mobile agree byte-for-byte on the map semantics (per-entry last-write-wins
+ * merge, empty-but-timestamped entry as a reset tombstone).
+ *
+ * Follows the "bookmark pattern" like useDMMute: the value is persisted to the
+ * local MMKV config and read straight back from there — never routed through the
+ * in-memory `user` object (that read-back bridge is the one that broke
+ * primaryUsername / isProfilePublic).
+ *
+ * The map is held in a module-level store exposed via useSyncExternalStore, so
+ * every consumer (the settings sheet, the composer signing lock) sees a change
+ * immediately instead of each hook instance keeping its own useState copy.
+ *
+ * OVERRIDES ONLY: a field equal to its inherited global/default is written as
+ * `undefined` (inherit), and a save with no genuine override and no existing
+ * entry is skipped entirely — so the synced blob never accumulates
+ * default-valued entries. Callers are responsible for comparing against the
+ * global before calling `saveOverrides`.
+ */
+
+import { useCallback, useEffect, useSyncExternalStore } from 'react';
+import { useAuth } from '@/context';
+import { createMMKV } from 'react-native-mmkv';
+import { useQueryClient, type QueryClient } from '@tanstack/react-query';
+import {
+  logger,
+  queryKeys,
+  setConversationSetting,
+  getConversationSetting,
+  type Conversation,
+  type ConversationSettingsMap,
+  type ConversationSettingKey,
+} from '@quilibrium/quorum-shared';
+import {
+  getLocalConversationSettings,
+  getLocalUserConfig,
+  setLocalConversationSetting,
+  setLocalConversationSettings,
+} from '@/services/config';
+import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
+
+/** Patch shape for a save: any subset of the override keys. */
+export type ConversationSettingsPatch = Partial<
+  Record<ConversationSettingKey, boolean | undefined>
+>;
+
+/** The legacy device-local fields this feature replaces. */
+const LEGACY_KEYS: ConversationSettingKey[] = [
+  'isRepudiable',
+  'saveEditHistory',
+  'deliveryReceipts',
+  'readReceipts',
+];
+
+// --- Module-level shared store (one source of truth across hook instances) ---
+
+let settingsMap: ConversationSettingsMap = {};
+/**
+ * The user's global "always sign messages" preference (desktop's
+ * UserConfig.nonRepudiable, default on) — the value an unset conversation
+ * inherits. Cached here rather than read per render because getLocalUserConfig
+ * parses the whole config blob. Refreshed on load/login, matching the freshness
+ * of every other config-carried field (restart / login / config pull, not live).
+ */
+let globalNonRepudiable = true;
+let loadedForAddress: string | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function getSnapshot(): ConversationSettingsMap {
+  return settingsMap;
+}
+
+/** Load (once per address) from the local config, then run the legacy sweep. */
+function ensureLoaded(address: string, queryClient: QueryClient): void {
+  if (loadedForAddress === address) return;
+  loadedForAddress = address;
+  settingsMap = getLocalConversationSettings(address);
+  globalNonRepudiable = getLocalUserConfig(address)?.nonRepudiable ?? true;
+  emit();
+  // Fire-and-forget: the sweep re-emits if it folds anything in.
+  void migrateLegacyConversationSettings(address, queryClient);
+}
+
+/**
+ * Clear the in-memory map on logout. Without this the module-level state
+ * outlives the session (there's no JS reload on sign-out), so a same-address
+ * re-login after a config wipe would keep serving the pre-logout overrides.
+ */
+function resetForLogout(): void {
+  if (loadedForAddress === null && Object.keys(settingsMap).length === 0) return;
+  loadedForAddress = null;
+  settingsMap = {};
+  globalNonRepudiable = true;
+  emit();
+}
+
+// --- One-time migration of the legacy device-local settings ---
+//
+// Before this feature these four fields lived on the local Conversation record
+// and never synced. The sweep folds any existing values into the synced map so a
+// user's choices reach their other devices, then STRIPS them from the local
+// record: left in place, a stale local value would shadow a reset made on
+// another device (the map's empty tombstone entry reads as "no override", so the
+// dual-read would fall through to the stale local field forever).
+
+const migrationStore = createMMKV({ id: 'dm-conv-settings' });
+/** Schema version — bump to re-run the sweep if the shape ever changes. */
+const MIGRATION_KEY_PREFIX = 'migrated:v1:';
+/** Low timestamp so any real edit (or already-synced entry) beats a seeded one. */
+const MIGRATION_TS = 1;
+
+async function migrateLegacyConversationSettings(
+  address: string,
+  queryClient: QueryClient
+): Promise<void> {
+  const flagKey = `${MIGRATION_KEY_PREFIX}${address}`;
+  if (migrationStore.getBoolean(flagKey)) return;
+
+  try {
+    const adapter = getMMKVAdapter();
+    // Deliberately unbounded: getConversations parses the entire stored list
+    // before slicing, so asking for all of it costs nothing, while a truncated
+    // page would set the flag below and leave the remaining conversations
+    // unmigrated with no retry path.
+    const { conversations } = await adapter.getConversations({
+      type: 'direct',
+      limit: Number.MAX_SAFE_INTEGER,
+    });
+
+    // PHASE 1 — collect, writing nothing.
+    let map: ConversationSettingsMap = getLocalConversationSettings(address);
+    const toStrip: string[] = [];
+    let folded = 0;
+
+    for (const conv of conversations) {
+      const id = conv.conversationId;
+      if (!id) continue;
+
+      const legacy: ConversationSettingsPatch = {};
+      for (const key of LEGACY_KEYS) {
+        const value = (conv as Conversation)[key];
+        if (typeof value === 'boolean') legacy[key] = value;
+      }
+      if (Object.keys(legacy).length === 0) continue;
+
+      // Fold in only when the synced map has nothing for this conversation —
+      // an entry already there came from a real edit (here or on another
+      // device) and must not be overwritten by a stale local value.
+      if (!map[id]) {
+        map = setConversationSetting(map, id, legacy, MIGRATION_TS);
+        folded++;
+      }
+      toStrip.push(id);
+    }
+
+    // PHASE 2 — persist the fold BEFORE touching any local record. Order
+    // matters: stripping first and saving after would lose settings outright if
+    // the app dies mid-sweep, because a stripped record carries nothing to fold
+    // on the retry. This way an interruption leaves the values safe in the
+    // config and merely defers the cleanup, which the retry finishes.
+    if (folded > 0) {
+      const persisted = await setLocalConversationSettings(address, map);
+      // Drop the result if the session moved on while we were awaiting — a
+      // sign-out plus a different sign-in would otherwise leave this user's
+      // entries in a store the next account is reading.
+      if (loadedForAddress === address) {
+        settingsMap = persisted;
+        emit();
+      }
+    }
+
+    // PHASE 3 — drop the legacy fields now that the map owns them. Left behind,
+    // a stale local value would shadow a reset made on another device: a reset
+    // writes an empty timestamped entry, which reads as "no override", so the
+    // dual-read would fall through to the local field forever.
+    // Re-read each record rather than writing back the phase-1 copy: phase 2
+    // includes a network round-trip, and an incoming message during that window
+    // updates the conversation (preview, timestamp, unread). Writing the stale
+    // copy would silently revert it.
+    for (const id of toStrip) {
+      const current = await adapter.getConversation(id);
+      if (!current) continue;
+      const cleaned = { ...current } as Record<string, unknown>;
+      for (const key of LEGACY_KEYS) delete cleaned[key];
+      await adapter.saveConversation(cleaned as Conversation);
+    }
+
+    if (toStrip.length > 0) {
+      // Cached conversation objects still carry the fields just stripped from
+      // storage, and the dual-read's fallback reads them off that cache.
+      queryClient.invalidateQueries({ queryKey: queryKeys.conversations.all('direct') });
+      for (const id of toStrip) {
+        queryClient.invalidateQueries({ queryKey: queryKeys.conversations.detail(id) });
+      }
+      logger.log(
+        `[DMConversationSettings] migrated ${folded} legacy conversation setting(s) into synced config (${toStrip.length} local record(s) cleaned)`
+      );
+    }
+
+    migrationStore.set(flagKey, true);
+  } catch (error) {
+    // Non-fatal: the dual-read fallback keeps legacy values working. The flag
+    // stays unset so the sweep retries on the next launch.
+    logger.warn(
+      `[DMConversationSettings] migration sweep failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+/** Shared session wiring: load on first sight of an address, clear on sign-out. */
+function useSettingsSession(): string | null {
+  const { user } = useAuth();
+  const address = user?.address ?? null;
+  const queryClient = useQueryClient();
+
+  // Load synchronously on first sight of this address so the very first render
+  // already has the right values (no one-frame flash of a wrong toggle).
+  // `ensureLoaded` is idempotent (guarded on `loadedForAddress`); reading an
+  // external store during render is explicitly supported by useSyncExternalStore.
+  if (address) ensureLoaded(address, queryClient);
+
+  // Clearing on sign-out is a state change, so it belongs in an effect.
+  useEffect(() => {
+    if (!address) resetForLogout();
+  }, [address]);
+
+  return address;
+}
+
+/**
+ * Prime the store and run the one-time legacy sweep WITHOUT subscribing to
+ * changes. Mount this on the conversation list, mirroring where useDMMute
+ * loads: the sweep is what folds a user's existing device-local settings into
+ * the synced map, so gating it on opening one specific chat would leave an
+ * untouched conversation's settings unsynced indefinitely.
+ */
+export function useDMConversationSettingsLoader(): void {
+  useSettingsSession();
+}
+
+export function useDMConversationSettings() {
+  const address = useSettingsSession();
+  const settings = useSyncExternalStore(subscribe, getSnapshot);
+
+  /**
+   * Read one override. `undefined` means no override — the caller falls back to
+   * the legacy local Conversation field, then the global setting, then the
+   * default.
+   */
+  const getOverride = useCallback(
+    (conversationId: string, key: ConversationSettingKey): boolean | undefined =>
+      getConversationSetting(settings, conversationId, key),
+    [settings]
+  );
+
+  /**
+   * Persist a patch of overrides. A key set to `undefined` clears that override
+   * (reset-to-global). Bumps the entry's `updatedAt` so the change wins the
+   * cross-device merge.
+   */
+  const saveOverrides = useCallback(
+    (conversationId: string, patch: ConversationSettingsPatch): void => {
+      if (!address) return;
+
+      // Overrides-only hygiene: with nothing to store AND no entry to clear
+      // there is nothing to do — skip so we never write an empty entry that
+      // only exists to say "all defaults". When an entry DOES exist we still
+      // write, so an all-inherited patch clears it and the reset propagates.
+      const hasOverride = Object.values(patch).some((v) => v !== undefined);
+      if (!hasOverride && !settingsMap[conversationId]) return;
+
+      // Optimistic in-memory update so the toggle moves immediately; the
+      // persisted map is recomputed from the stored config inside
+      // setLocalConversationSetting, so rapid toggles compose there too. The
+      // two copies can differ only in `updatedAt` (by under a millisecond),
+      // which no read path consults.
+      settingsMap = setConversationSetting(settingsMap, conversationId, patch);
+      emit();
+
+      void setLocalConversationSetting(address, conversationId, patch).catch((error) => {
+        // The local MMKV write throwing is the only way to land here (the
+        // outbound sync failure is caught and logged one level down). No
+        // rollback: the in-memory value is what the user just chose, and the
+        // next cold read reconciles from storage.
+        logger.warn(
+          `[DMConversationSettings] failed to persist override for ${conversationId}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      });
+    },
+    [address]
+  );
+
+  return {
+    settings,
+    getOverride,
+    saveOverrides,
+    /** Global "always sign" preference an unset conversation inherits. */
+    globalNonRepudiable,
+  };
+}

--- a/hooks/chat/useEditDirectMessage.ts
+++ b/hooks/chat/useEditDirectMessage.ts
@@ -19,6 +19,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuth, useWebSocket } from '@/context';
 import { useStorageAdapter } from '@/context/StorageContext';
 import { getQuorumClient } from '@/services/api/quorumClient';
+import { getLocalConversationSetting } from '@/services/config';
 import { encryptionService } from '@/services/crypto/encryption-service';
 import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
 import { generateNonce } from '@/services/onboarding/keyService';
@@ -73,8 +74,15 @@ export function useEditDirectMessage() {
       // match desktop's default everywhere — keeping history is opt-in. The
       // receive path applies the same gate so the peer's echoed edit stays
       // consistent with ours.
+      //
+      // Read the synced per-conversation override first, then fall back to the
+      // legacy device-local field for a device whose one-time migration sweep
+      // hasn't run yet.
       const conversation = await storage.getConversation(params.conversationId);
-      const saveEditHistory = conversation?.saveEditHistory ?? false;
+      const saveEditHistory =
+        getLocalConversationSetting(user.address, params.conversationId, 'saveEditHistory') ??
+        conversation?.saveEditHistory ??
+        false;
 
       // Single edit timestamp + nonce, shared by the local write and the wire
       // send so every device converges on the same edit metadata. The nonce is
@@ -223,7 +231,12 @@ export function useEditDirectMessage() {
       // Same "Save Edit History" gate as the storage write, so the optimistic
       // cache and persisted message don't diverge (default false → desktop).
       const conversation = await storage.getConversation(params.conversationId);
-      const saveEditHistory = conversation?.saveEditHistory ?? false;
+      const saveEditHistory =
+        (user?.address
+          ? getLocalConversationSetting(user.address, params.conversationId, 'saveEditHistory')
+          : undefined) ??
+        conversation?.saveEditHistory ??
+        false;
 
       // Single edit timestamp for this optimistic pass so modifiedDate and the
       // retained prior version share one time. The authoritative editNonce is

--- a/services/config/configService.ts
+++ b/services/config/configService.ts
@@ -22,10 +22,15 @@ import {
   type Bookmark,
   type NavItem,
   type EncryptionState,
+  type ConversationSettingsMap,
+  type ConversationSettingKey,
   BOOKMARKS_CONFIG,
   int64ToBytes,
   hexToBytes,
   bytesToHex,
+  getConversationSetting,
+  setConversationSetting,
+  mergeConversationSettings,
   logger,
 } from '@quilibrium/quorum-shared';
 import { getAllSpaces, getSpaceKey, getSpaceKeys, saveSpaceKey, clearSpaceStorage } from './spaceStorage';
@@ -42,6 +47,36 @@ const bookmarkStorage: MMKV = createMMKV({ id: 'quorum-bookmarks' });
 const CONFIG_KEY_PREFIX = 'user_config:';
 const BOOKMARKS_KEY_PREFIX = 'bookmarks:';
 const DELETED_BOOKMARKS_KEY = 'deleted_bookmark_ids:';
+
+/**
+ * Verbose config-sync tracing: dumps the synced per-conversation payload and,
+ * after each publish, reads the blob straight back from the server to prove it
+ * landed. Dev-only — the read-back costs an extra round trip per write.
+ *
+ * Cross-device config problems are near-impossible to diagnose from the outside
+ * because every hop fails quietly: a local-only save, a skipped publish, and a
+ * successful publish that the other device simply hasn't pulled yet all look
+ * identical from the UI.
+ */
+const CONFIG_TRACE = __DEV__;
+
+/**
+ * Shorten a conversationId for logs. A DM conversationId is the peer's address,
+ * so a full map dump is the user's contact list — and debug logs get pasted into
+ * issues and chats. The prefix is enough to correlate lines across a session
+ * without handing over who the user talks to. The setting values stay in full;
+ * they are what we are actually debugging, and they identify nobody.
+ */
+function shortConvId(conversationId: string): string {
+  return `${conversationId.slice(0, 10)}…`;
+}
+
+/** JSON for a settings map with peer addresses redacted; values kept intact. */
+function redactedSettings(map: ConversationSettingsMap | undefined): string {
+  return JSON.stringify(
+    Object.fromEntries(Object.entries(map ?? {}).map(([id, v]) => [shortConvId(id), v]))
+  );
+}
 
 // NavItems Validation
 
@@ -333,11 +368,19 @@ export async function getConfig(address: string): Promise<UserConfig> {
 
   // Check timestamp - if local is newer, use local
   if (remoteConfig.timestamp < (localConfig?.timestamp ?? 0)) {
+    if (CONFIG_TRACE) {
+      logger.log(
+        `[ConfigSync] pull: KEPT LOCAL (remote ts=${remoteConfig.timestamp} older than local ts=${localConfig?.timestamp}) — remote not decrypted, nothing merged`
+      );
+    }
     return localConfig!;
   }
 
   // If timestamps match, use local (no update needed)
   if (remoteConfig.timestamp === localConfig?.timestamp) {
+    if (CONFIG_TRACE) {
+      logger.log(`[ConfigSync] pull: UP TO DATE (ts=${remoteConfig.timestamp})`);
+    }
     return localConfig;
   }
 
@@ -398,6 +441,21 @@ export async function getConfig(address: string): Promise<UserConfig> {
       });
     }
 
+    // Per-conversation DM overrides merge per ENTRY (last-write-wins on each
+    // entry's `updatedAt`), not as a whole blob — otherwise an unrelated config
+    // save on another device would clobber an edit made here to a DIFFERENT
+    // conversation. The shared helper is the single source of truth for those
+    // semantics so desktop and mobile agree byte-for-byte.
+    //
+    // Re-read the local side HERE rather than reusing the `localConfig`
+    // snapshot above: the signature verification between them yields the event
+    // loop, so a settings toggle can land in that window, and the wholesale
+    // saveLocalUserConfig below would otherwise write it straight back out.
+    const mergedConversationSettings = mergeConversationSettings(
+      getLocalUserConfig(address)?.conversationSettings,
+      (decryptedConfig as UserConfig).conversationSettings
+    );
+
     // Save to local storage
     // IMPORTANT: Preserve name and profile_image fields from remote config
     const configWithTimestamp: UserConfig = {
@@ -421,8 +479,23 @@ export async function getConfig(address: string): Promise<UserConfig> {
       notificationSettings: (decryptedConfig as any).notificationSettings,
       // Synced personal block list (per-space viewer-side hide).
       blockedUsers: (decryptedConfig as any).blockedUsers,
+      // Per-entry merged (see above) rather than taken from the remote blob, so
+      // a stale remote copy can't drop an override made on this device.
+      conversationSettings: mergedConversationSettings,
     } as UserConfig;
     saveLocalUserConfig(configWithTimestamp);
+
+    if (CONFIG_TRACE) {
+      const remoteEntries = Object.keys(
+        (decryptedConfig as UserConfig).conversationSettings ?? {}
+      ).length;
+      logger.log(
+        `[ConfigSync] pull: TOOK REMOTE ts=${remoteConfig.timestamp} (local was ${localConfig?.timestamp ?? 'none'}); conversationSettings remote=${remoteEntries} merged=${Object.keys(mergedConversationSettings).length}`
+      );
+      logger.log(
+        `[ConfigSync] pull merged conversationSettings=${redactedSettings(mergedConversationSettings)}`
+      );
+    }
 
     return configWithTimestamp;
   } catch (error) {
@@ -523,6 +596,15 @@ export async function saveConfig(config: UserConfig): Promise<void> {
   config.bookmarks = getLocalBookmarks(address);
   config.deletedBookmarkIds = getDeletedBookmarkIds(address);
 
+  // A skipped publish is the quietest way for cross-device sync to "not work":
+  // the value saves locally, the UI looks right, and nothing ever leaves the
+  // device. Say so out loud, matching the POST-failure warning below.
+  if (!config.allowSync) {
+    logger.warn('[ConfigSync] NOT publishing — allowSync is off; the change is local-only');
+  } else if (!privateKey || !publicKey) {
+    logger.warn('[ConfigSync] NOT publishing — no keypair available; the change is local-only');
+  }
+
   // Sync to server if allowed
   if (config.allowSync && privateKey && publicKey) {
     try {
@@ -567,6 +649,35 @@ export async function saveConfig(config: UserConfig): Promise<void> {
       // Clear deleted bookmark tombstones after successful sync
       clearDeletedBookmarkIds(address);
       config.deletedBookmarkIds = [];
+
+      // Success is as diagnostic as failure: without it, "no logs" is
+      // indistinguishable between published-fine and never-attempted.
+      const convEntries = Object.keys(config.conversationSettings ?? {}).length;
+      logger.log(
+        `[ConfigSync] published ts=${ts} bytes=${encryptedConfig.length} conversationSettings=${convEntries}`
+      );
+
+      if (CONFIG_TRACE) {
+        logger.log(
+          `[ConfigSync] payload conversationSettings=${redactedSettings(config.conversationSettings)}`
+        );
+        // Read straight back from the server. This is the only check that
+        // proves the write actually landed rather than just being accepted:
+        // a matching timestamp means another device pulling now would see it.
+        try {
+          const echo = await client.getUserSettings(address);
+          const storedTs = echo?.timestamp;
+          logger.log(
+            storedTs === ts
+              ? `[ConfigSync] server read-back CONFIRMS ts=${ts}`
+              : `[ConfigSync] server read-back MISMATCH — wrote ts=${ts}, server has ts=${storedTs}`
+          );
+        } catch (echoError) {
+          logger.warn(
+            `[ConfigSync] server read-back failed: ${echoError instanceof Error ? echoError.message : String(echoError)}`
+          );
+        }
+      }
     } catch (error) {
       // Sync failure must be LOUD: a silent 400 here (e.g. the evals-bloat
       // size limit, desktop bug #108) makes new spaces / signing keys /
@@ -657,6 +768,118 @@ export function isConversationMutedForCurrentUser(conversationId: string): boole
   const address = getCurrentUserAddressFromStorage();
   if (!address) return false;
   return getLocalMutedConversations(address).includes(conversationId);
+}
+
+// --- Per-conversation DM setting overrides (synced via UserConfig) ---
+//
+// `conversationSettings[conversationId]` holds only the fields that DIFFER from
+// the user's global setting / the app default: saveEditHistory, isRepudiable,
+// deliveryReceipts, readReceipts. An absent field means "inherit", so a later
+// change to the global default still follows. Same carrier as mute (the bookmark
+// pattern: written into UserConfig, read straight back from the local MMKV
+// config, never routed through the in-memory `user` object).
+//
+// Read/write/merge all go through the shared helpers so desktop and mobile agree
+// byte-for-byte on the map semantics, including the per-entry last-write-wins
+// merge and the empty-but-timestamped reset tombstone.
+
+export function getLocalConversationSettings(address: string): ConversationSettingsMap {
+  return getLocalUserConfig(address)?.conversationSettings ?? {};
+}
+
+/**
+ * Read one per-conversation override. `undefined` means the conversation has no
+ * override for that field — the caller falls back to the legacy local
+ * Conversation record, then the global setting, then the default.
+ */
+export function getLocalConversationSetting(
+  address: string,
+  conversationId: string,
+  key: ConversationSettingKey
+): boolean | undefined {
+  return getConversationSetting(getLocalConversationSettings(address), conversationId, key);
+}
+
+/**
+ * Resolve one override for the CURRENT user without the caller needing the
+ * address. Used by the inbound decrypt path (receipt gating, received edits),
+ * which runs outside React and only has a conversationId.
+ */
+export function getConversationSettingForCurrentUser(
+  conversationId: string,
+  key: ConversationSettingKey
+): boolean | undefined {
+  const address = getCurrentUserAddressFromStorage();
+  if (!address) return undefined;
+  return getLocalConversationSetting(address, conversationId, key);
+}
+
+/**
+ * Persist a patch of overrides for one conversation, bumping that entry's
+ * `updatedAt` so the change wins the cross-device merge. A key set to
+ * `undefined` clears that override (reset-to-global).
+ *
+ * Returns the new map so a caller holding an in-memory copy can update without
+ * re-reading storage.
+ */
+export async function setLocalConversationSetting(
+  address: string,
+  conversationId: string,
+  patch: Partial<Record<ConversationSettingKey, boolean | undefined>>
+): Promise<ConversationSettingsMap> {
+  const current = getLocalUserConfig(address) ?? getDefaultUserConfig(address);
+  const conversationSettings = setConversationSetting(
+    current.conversationSettings,
+    conversationId,
+    patch
+  );
+  if (CONFIG_TRACE) {
+    logger.log(
+      `[ConversationSettings] write ${shortConvId(conversationId)} patch=${JSON.stringify(patch)} → entry=${JSON.stringify(conversationSettings[conversationId])}`
+    );
+  }
+  const updated: UserConfig = { ...current, conversationSettings };
+  saveLocalUserConfig(updated);
+  try {
+    if (updated.allowSync) {
+      await saveConfig(updated);
+    }
+  } catch (error) {
+    // Best-effort sync — the setting change is already saved locally. Still log:
+    // a silent failure here means the setting never leaves this device, which is
+    // exactly the "nothing syncs" black hole saveConfig warns about.
+    logger.warn(
+      `[ConversationSettings] setting saved locally but NOT published: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  return conversationSettings;
+}
+
+/**
+ * Merge a whole map into the stored config (used by the one-time legacy
+ * migration sweep). Merges rather than replaces because the caller builds its
+ * map across a sequence of awaits: a genuine edit can land in that window, and
+ * per-entry LWW keeps it (migration entries carry `updatedAt = 1` and lose to
+ * anything real). Returns the merged map.
+ */
+export async function setLocalConversationSettings(
+  address: string,
+  conversationSettings: ConversationSettingsMap
+): Promise<ConversationSettingsMap> {
+  const current = getLocalUserConfig(address) ?? getDefaultUserConfig(address);
+  const merged = mergeConversationSettings(current.conversationSettings, conversationSettings);
+  const updated: UserConfig = { ...current, conversationSettings: merged };
+  saveLocalUserConfig(updated);
+  try {
+    if (updated.allowSync) {
+      await saveConfig(updated);
+    }
+  } catch (error) {
+    logger.warn(
+      `[ConversationSettings] migrated settings saved locally but NOT published: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+  return merged;
 }
 
 // --- Channel / Space notification mute (synced via UserConfig) ---

--- a/services/config/index.ts
+++ b/services/config/index.ts
@@ -21,6 +21,12 @@ export {
   getLocalMutedConversations,
   setMutedConversations,
   isConversationMutedForCurrentUser,
+  // Per-conversation DM setting overrides (config-backed, syncs across devices)
+  getLocalConversationSettings,
+  getLocalConversationSetting,
+  getConversationSettingForCurrentUser,
+  setLocalConversationSetting,
+  setLocalConversationSettings,
   // Channel/Space notification mute (config-backed, syncs across devices)
   getLocalMutedChannels,
   setMutedChannels,


### PR DESCRIPTION
Save Edit History, Always Sign, and the delivery/read receipt overrides were device-local: set on the phone, invisible on desktop. They now live in `UserConfig.conversationSettings`, keyed by conversationId, travelling on the existing encrypted config blob — the same carrier as DM mute. Desktop shipped its half in quorum-desktop#248; this is the mobile half, built on the shared helpers so both apps agree byte-for-byte on the map semantics.

## Storage and merge

- `conversationSettings` merges **per entry** (last-write-wins on each entry's `updatedAt`) rather than as a whole blob, so an unrelated config save on another device cannot clobber an edit to a *different* conversation.
- The local side is re-read at write time: the signature verification above it yields the event loop, and the save that follows is a wholesale overwrite.
- Added to the explicit inbound preservation list so a future refactor cannot silently drop it.
- Helpers follow the mute bookmark pattern — write into `UserConfig`, persist locally first, best-effort outbound sync, read back from MMKV rather than through the in-memory `user` object.

## Reads and writes

- New `useDMConversationSettings`: module-level store + `useSyncExternalStore`, so every consumer sees a toggle immediately (same shape as `useDMMute`).
- Writes persist **overrides only**. A value equal to its inherited global/default is written as `undefined`, and a save with nothing to override and no existing entry is skipped — the synced blob never accumulates default-valued entries.
- Every read dual-reads: synced override → legacy local field → global → default.
- **Including the receive path** — the receipt gate and both DM received-edit checks. These run independently of the settings sheet, so updating only the UI would leave receipts gated on stale values.
- The chat area receives the *effective* `isRepudiable`, so the composer lock and send path follow a change made on another device.

## Migration

A one-time sweep folds legacy `Conversation` fields into the map at `updatedAt=1` (any real edit wins), then strips them from the local record. Left in place, a stale local value shadows a reset from another device: a reset writes an empty timestamped entry, which reads as "no override", so the dual-read would fall back to the stale field forever.

Ordered **collect → persist → strip**. Stripping first would lose settings outright if the app died mid-sweep, since a stripped record folds to nothing on retry. Records are re-read before stripping so a message arriving mid-sweep is not reverted; the final write merges rather than replaces; the store update is dropped if the session changed while awaiting. It runs from the conversation list as well as the DM screen, so it does not wait for the user to open one specific chat.

## Instrumentation

Cross-device config problems were undiagnosable because silence was ambiguous — a local-only save, a skipped publish, and a successful publish the other device had not pulled all looked identical.

Publishing now logs success, and loudly logs the skip cases (`allowSync` off, no keypair). Under `CONFIG_TRACE` (`__DEV__`, absent from release bundles) it also logs the per-write patch, the pull decision with remote-vs-merged counts, and a **server read-back** that re-fetches the blob and compares timestamps — the only check proving a write is retrievable rather than merely accepted.

Conversation ids are peer addresses, so a full map dump would be the user's contact list; ids are truncated in logs while values are kept in full. Keys, message content and the blob itself are never logged, only the blob's byte count.

## Behaviour note

Signing now inherits the global "always sign" preference when a conversation has no override, matching desktop. Default config sets `nonRepudiable: true`, so existing behaviour is unchanged.

## Verification

Device-verified: a receipt override written on mobile was confirmed present on the server by read-back, then read and displayed on desktop — exercising write → overrides-only patch → publish → server round trip → desktop pull → merge → display.

Still unexercised: the migration sweep (needs a device with legacy settings stored), signing and edit-history specifically, and receive-path gating.

Typecheck 18 errors, matching `master`; no new lint warnings.