### PR TITLE
fix(dm): self-echo guards compared against a stale null user closure

### DIFF
--- a/__tests__/dmSelfEchoGuards.test.ts
+++ b/__tests__/dmSelfEchoGuards.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Self-echo guards in the DM receive path must compare against the address REF,
+ * never `user?.address` from the enclosing closure.
+ *
+ * Why this test is static rather than behavioural: the guards live inside
+ * `handleIncomingMessage` / `applyDMGroupResults` in WebSocketContext, two
+ * ~2000-line `useCallback`s wired to the websocket, MMKV, SQLite and the native
+ * crypto module. There is no harness that can drive a frame through them, so the
+ * invariant is asserted against the source text instead.
+ *
+ * The failure this prevents (shipped once, survived a fix, resurfaced):
+ * WebSocketProvider mounts before AuthContext restores the user, so `user` is
+ * null on the first render. Both receive callbacks depend only on stable
+ * singletons (queryClient, the memoised storage adapter, and callbacks derived
+ * from those), so they are created ONCE with `user === null` and never
+ * recreated. Every `user?.address` inside them then evaluates to `undefined`
+ * forever, and each self-echo guard silently becomes dead code — our own
+ * messages echoed from another device are treated as a stranger's, creating a
+ * phantom conversation with ourselves that wears our own name and avatar.
+ *
+ * `fullUserAddrRef.current` is reassigned on every render, so it is correct
+ * regardless of when the callback was created.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SOURCE_PATH = path.join(__dirname, '..', 'context', 'WebSocketContext.tsx');
+const source = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+/**
+ * Self-comparisons still reading the stale closure. These are the space-message
+ * paths, tracked separately because enabling them changes which copy of your own
+ * space message renders (echo vs optimistic update) and needs its own testing.
+ * Anything NOT listed here is a new regression.
+ */
+const KNOWN_STALE_CLOSURE_SITES = [
+  'if (participant.address === user?.address) {',
+  'if (senderId && senderId === user?.address) {',
+];
+
+/** Guards that must be ref-based, as exact source lines. */
+const REQUIRED_REF_GUARDS = [
+  // Path 1 — init envelope: self-echo with no channelId is unattributable.
+  'if (initSenderAddress === fullUserAddrRef.current) {',
+  // Path 2 — subsequent message on an established session.
+  'if (senderAddress === fullUserAddrRef.current && decryptedMessage.channelId) {',
+  '} else if (senderAddress === fullUserAddrRef.current) {',
+  // Drop our own profile off the row so it can't overwrite the partner's.
+  'if (authenticatedDmSender && authenticatedDmSender === fullUserAddrRef.current) {',
+  // Native batch path.
+  'const isSelfSyncEcho = senderAddress === fullUserAddrRef.current;',
+];
+
+const trimmedLines = source.split('\n').map((line) => line.trim());
+
+describe('DM self-echo guards', () => {
+  it.each(REQUIRED_REF_GUARDS)('compares against the ref: %s', (guard) => {
+    expect(trimmedLines).toContain(guard);
+  });
+
+  it('gates delete-conversation-self on the ref in BOTH receive paths', () => {
+    const gate =
+      'const isSelfSender = !!selfContent.senderId && selfContent.senderId === fullUserAddrRef.current;';
+    // One in handleIncomingMessage (fallback path), one in applyDMGroupResults.
+    expect(trimmedLines.filter((line) => line === gate)).toHaveLength(2);
+  });
+
+  it('introduces no new self-comparison against the stale closure', () => {
+    const offenders = trimmedLines.filter(
+      (line) => /===\s*user\?\.address/.test(line) && !KNOWN_STALE_CLOSURE_SITES.includes(line)
+    );
+
+    // If this fails, use `fullUserAddrRef.current` instead of `user?.address`.
+    // Only add to KNOWN_STALE_CLOSURE_SITES if the surrounding callback genuinely
+    // lists `user` in its dependency array.
+    expect(offenders).toEqual([]);
+  });
+});

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -410,7 +410,18 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const userAddrRef = useRef<string>('???');
   userAddrRef.current = shortAddr(user?.address);
 
-  // Store full user address for comparison in callbacks (not shortened)
+  // Store full user address for comparison in callbacks (not shortened).
+  //
+  // ALWAYS use this ref for self-comparisons inside the receive callbacks —
+  // never `user?.address` directly. This provider mounts before AuthContext has
+  // restored the user, so `user` is null on the first render, and the big
+  // receive callbacks (handleIncomingMessage, applyDMGroupResults) depend only
+  // on stable singletons. They are therefore created ONCE with `user === null`
+  // and never recreated, which silently turns every `user?.address` inside them
+  // into `undefined` for the app's whole lifetime. That is not theoretical: it
+  // disabled every self-echo guard in the live DM path, so our own messages
+  // echoed from another device were treated as a stranger's and created a
+  // phantom conversation with ourselves, wearing our own name and avatar.
   const fullUserAddrRef = useRef<string | undefined>(undefined);
   fullUserAddrRef.current = user?.address;
 
@@ -2787,7 +2798,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
             // message carries no channelId, we cannot determine the real partner.
             // Drop it to prevent a phantom selfAddress/selfAddress conversation row.
             const initSenderAddress = conversationId.split('/')[0];
-            if (initSenderAddress === user?.address) {
+            if (initSenderAddress === fullUserAddrRef.current) {
               if (decryptedMessage.channelId) {
                 // Has channelId — redirect to the real partner conversation.
                 const actualRecipient = decryptedMessage.channelId;
@@ -3136,10 +3147,10 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           // This matches desktop behavior in MessageService.ts lines 2082-2086
           const senderAddress = conversationId.split('/')[0];
           authenticatedDmSender = senderAddress; // before the rewrite below
-          if (senderAddress === user?.address && decryptedMessage.channelId) {
+          if (senderAddress === fullUserAddrRef.current && decryptedMessage.channelId) {
             const actualRecipient = decryptedMessage.channelId;
             conversationId = `${actualRecipient}/${actualRecipient}`;
-          } else if (senderAddress === user?.address) {
+          } else if (senderAddress === fullUserAddrRef.current) {
             // Channel-less self-echo — can't attribute to a partner, nothing to
             // display. Drop it so it can't create a self-address conversation row.
             return;
@@ -3154,7 +3165,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // overwrite the partner's row. Mirrors desktop's
         // `envelope.user_address != self_address` check. authenticatedDmSender
         // is the true (pre-rewrite) sender.
-        if (authenticatedDmSender && authenticatedDmSender === user?.address) {
+        if (authenticatedDmSender && authenticatedDmSender === fullUserAddrRef.current) {
           userProfileFromEnvelope = undefined;
         }
 
@@ -3313,7 +3324,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // also receives the fan-out but must NEVER delete our copy.
         if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
           const selfContent = decryptedMessage.content as { senderId?: string; conversationAddress?: string };
-          const isSelfSender = !!selfContent.senderId && selfContent.senderId === user?.address;
+          const isSelfSender = !!selfContent.senderId && selfContent.senderId === fullUserAddrRef.current;
 
           // Always clear the processed control message from the inbox (self or not).
           deleteProcessedEnvelope(message.inboxAddress, message.timestamp);
@@ -4635,7 +4646,7 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         // is self. Runs before the conversation-save so it can't resurrect a row.
         if ((decryptedMessage.content?.type as string) === 'delete-conversation-self') {
           const selfContent = decryptedMessage.content as { senderId?: string; conversationAddress?: string };
-          const isSelfSender = !!selfContent.senderId && selfContent.senderId === user?.address;
+          const isSelfSender = !!selfContent.senderId && selfContent.senderId === fullUserAddrRef.current;
 
           // Always clear the processed control message from the inbox (self or not).
           const originalSelfMsg = batch.find(m => m.timestamp === msgResult.timestamp);


### PR DESCRIPTION
## The bug

A conversation with **yourself** surfaces in the DM list, showing your own name and avatar. Deleting it brings it back on the next reconnection.

This was fixed once in #145 and reopened: the guards it added were verified holding under the receipt stream, then the phantom row came back later. This PR explains why and fixes it.

## Root cause

`handleIncomingMessage` is a `useCallback` whose dependency array is `[queryClient, storage, applyDmProfileUpdate]` — **`user` is not in it**, and all three of those deps are permanently stable:

- `queryClient` — context value
- `storage` — `useMemo(() => new MMKVAdapter(), [])`
- `applyDmProfileUpdate` — `useCallback` on `[storage, scheduleConversationRefresh]`, itself `[queryClient]`

`WebSocketProvider` is mounted unconditionally inside `AuthProvider` (`app/_layout.tsx`), while `user` starts as `null` and is restored later by an async effect. So the callback is created **once, with `user === null`, and never recreated**. Every `user?.address` inside it evaluates to `undefined` for the app's whole lifetime.

That silently disabled four guards in the live DM path and one in the batch path:

| Guard | Effect when dead |
|---|---|
| init-envelope self-echo drop | self-echo falls through |
| subsequent-message self-echo drop | self-echo falls through |
| drop our own profile off the row | row gets **our** name + avatar |
| `delete-conversation-self` (both paths) | cross-device DM delete never applies |

With the guards dead, a self-echo reaches the conversation-row save and creates `conversationId = <self>/<self>`, with `displayName`/`icon` taken from the envelope profile — which on a self-echo is ours. That is precisely the reported row.

**Why #145 looked like it worked:** the batch path (`applyDMGroupResults`) was already correct — its `isSelfSyncEcho` uses `fullUserAddrRef.current`. The delivery/read-ack stream it was verified against flows through that path, so the row count held at 1. Init envelopes and individual decrypts go through the live path, where the comparison was dead, so the row resurfaced later.

**Why desktop doesn't show this:** desktop's equivalent lives in `MessageService`, a plain class. No closure to go stale.

`react-hooks/exhaustive-deps` has been flagging this the whole time — it names `user?.address` as a missing dependency — but it is one of 36 warnings on this file.

## The fix

Switch the six sites to `fullUserAddrRef.current`, the ref this file already declares for exactly this purpose ("so callbacks always have the latest value") and already uses at ~20 other sites. It is reassigned on every render, so it is correct regardless of when the callback was created.

Adding `user?.address` to the dependency arrays would also work, but would rebuild the two largest callbacks in the app on every profile edit.

## Deliberately out of scope

Three space-message self-comparisons (`participant.address === user?.address`, and two `senderId === user?.address`) have the same defect and are left for a follow-up PR: enabling them changes which copy of your own space message renders (inbox echo vs optimistic update), which needs its own testing. They are recorded as a named allowlist in the new test, so the invariant still fails on any *new* violation.

## Testing

New `__tests__/dmSelfEchoGuards.test.ts` asserts the guards are ref-based and that no new stale-closure self-comparison is introduced. It is a static test because these guards sit inside two ~2000-line callbacks wired to the websocket, MMKV, SQLite and the native crypto module, with no harness able to drive a frame through them; the reasoning is documented in the file header.

- Fails **6/7 against the pre-fix source**; the single passing case is the batch guard that was already correct.
- Full suite: **87 passed, 11 suites**.
- `tsc --noEmit`: unchanged from master (the one pre-existing `MessageHandler` error remains, shifted by the added comment).
- `eslint`: 0 errors, warning set unchanged.

Behavioural verification on device is still pending — the phantom row should stop reappearing after deletion.
