### PR TITLE
fix: DM chat scroll jump on translucent modals

### DIFF
--- a/patches/react-native-keyboard-controller+1.21.11.patch
+++ b/patches/react-native-keyboard-controller+1.21.11.patch
@@ -1,8 +1,21 @@
 diff --git a/node_modules/react-native-keyboard-controller/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts b/node_modules/react-native-keyboard-controller/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
-index 48178d9..90b3977 100644
+index 48178d9..2f0ac01 100644
 --- a/node_modules/react-native-keyboard-controller/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
 +++ b/node_modules/react-native-keyboard-controller/src/components/KeyboardChatScrollView/useChatKeyboard/index.ts
-@@ -166,7 +166,16 @@ function useChatKeyboard(
+@@ -82,7 +82,11 @@ function useChatKeyboard(
+       onStart: (e) => {
+         "worklet";
+ 
+-        if (freeze.value) {
++        // Patched (quorum-mobile): see the NO-OP EVENT note on onMove below.
++        // Safe to gate onStart on this condition (unlike a blanket gate) because
++        // the condition itself asserts `padding` is already 0 — so skipping the
++        // `padding.value = effective` bookkeeping cannot leave it stale.
++        if (freeze.value || (e.height === 0 && padding.value === 0)) {
+           return;
+         }
+ 
+@@ -166,7 +170,30 @@ function useChatKeyboard(
        onMove: (e) => {
          "worklet";
  
@@ -16,7 +29,37 @@ index 48178d9..90b3977 100644
 +        // onStart/onEnd, which only do bookkeeping (padding/offset capture) that
 +        // the cold-open emoji-panel lift depends on; gating those left `padding`
 +        // stale and killed that lift. See patches/.
-+        if (freeze.value || e.target <= 0) {
++        //
++        // NO-OP EVENT guard (second condition): a Modal declared
++        // `statusBarTranslucent`/`navigationBarTranslucent` keeps its window
++        // edge-to-edge over the Activity, so the focus-less event it emits can
++        // still carry a POSITIVE target and slip past the check above. Such an
++        // event reports height 0 while the keyboard is ALREADY closed
++        // (`padding === 0`), i.e. nothing to animate — yet the code below would
++        // still `scrollTo(offsetBeforeScroll)`, and onStart has just rewritten
++        // that to `scroll - actualOpenShift` using the LAST real keyboard open's
++        // shift. Each such event therefore yanks the list up by a stale keyboard
++        // height, and repeats (open + close + a native Alert) clamp it to 0 —
++        // the conversation snaps back to its first message. A genuine keyboard
++        // close is unaffected: `padding` still holds the open height until onEnd
++        // runs, so only true no-ops are dropped.
++        if (freeze.value || e.target <= 0 || (e.height === 0 && padding.value === 0)) {
            return;
          }
  
+@@ -355,6 +382,15 @@ function useChatKeyboard(
+         // Record actual scroll displacement so close can be symmetric
+         if (effective > 0 && offsetBeforeScroll.value !== -1) {
+           actualOpenShift.value = scroll.value - offsetBeforeScroll.value;
++        } else if (effective === 0) {
++          // Patched (quorum-mobile): the keyboard has finished closing, so the
++          // open-shift has served its purpose (onStart's close branch already
++          // consumed it to restore offsetBeforeScroll). Leaving it set lets a
++          // later focus-less event compute `scroll - <stale shift>` and yank the
++          // list toward the top; see the NO-OP EVENT note in onMove. Zeroing it
++          // makes that arithmetic a no-op instead of a jump. A real open
++          // recomputes it here at the end of its own animation.
++          actualOpenShift.value = 0;
+         }
+       },
+     },


### PR DESCRIPTION
Opening an image viewer or a confirm dialog over a chat scrolled the message list back toward the first message of the conversation. Worst case (Fix Encryption: confirm dialog, then the sheet closing, then a native alert) landed on the very first message.

This is a regression of the modal-jump fix in `5828176`. That fix guards the keyboard worklet's `scrollTo` with `e.target <= 0`, dropping the focus-less keyboard event a native `<Modal>` emits when it grabs input focus.

PR #141 then added `statusBarTranslucent` + `navigationBarTranslucent` to `BaseModal`, `CenterModal`, `ImageViewer` and `VideoViewer`. Those flags make the dialog window edge-to-edge over the Activity, so the focus-less event now arrives with a **positive** target and walks past the guard. `MessageActionSheet` keeps a plain `<Modal>` and still reports `target <= 0`, which is why long-press never reproduced it while image-enlarge and every confirm dialog did.

The event is not harmless once it gets through. `onStart`'s closing branch rewrites `offsetBeforeScroll` to `scroll - actualOpenShift`, and `actualOpenShift` still holds the last real keyboard open's shift because nothing ever cleared it. `onMove` then scrolls there, yanking the list up by a stale keyboard height; `clampedScrollTarget` floors at 0, so a few events in a row walk it to the top.

## Changes

Two hunks added to `patches/react-native-keyboard-controller+1.21.11.patch`, keeping the existing target guard:

- **No-op event guard** (`onMove`, and safely also `onStart`): ignore an event reporting height 0 while `padding` is already 0 — there is nothing to animate. This is modal-agnostic, so it also covers native `Alert` and system permission dialogs rather than depending on which window owns focus. A real close is unaffected (`padding` holds the open height until `onEnd`); a real open is unaffected (`onStart` sets `padding` before the first `onMove`). Gating `onStart` is safe here precisely because the condition asserts `padding` is already 0, so the skipped bookkeeping cannot go stale.
- **Clear `actualOpenShift` once the keyboard finishes closing**: defence in depth, so anything that ever slips through both guards degrades to `scrollTo(scroll)` — a no-op — instead of a jump.

No app code changed. `MessagesList` is shared by `DMChatArea` and `SpaceChatArea` through the same `ChatKeyboardScrollView`, so this covers DMs and Spaces together.

## Verification

- Verified on-device: image enlarge and Fix Encryption no longer scroll the conversation back to its start.
- Patch applies cleanly to a pristine tree and reproduces the intended file byte-for-byte.
- 87/87 jest tests pass.

Note for anyone pulling this: it is a `node_modules` change, so it needs a Metro cache reset, not just a reload.