### PR TITLE
fix(dm): a read ack must never invent a delivery

### DIFF
--- a/__tests__/receiptReconciliation.test.ts
+++ b/__tests__/receiptReconciliation.test.ts
@@ -1,0 +1,253 @@
+/**
+ * Receipt truthfulness at the storage layer.
+ *
+ * The invariant under test: a read ack may never invent a delivery. Read acks
+ * carry only a high-water mark ("read up to Y"), so expanding them across the
+ * whole range used to stamp delivered+read on messages that never landed — the
+ * sender confidently showed ✓✓ for messages the recipient had never seen.
+ *
+ * Mirrors quorum-desktop's `src/dev/tests/db/receiptReconciliation.test.ts`.
+ * Both platforms defer the decision to the same shared resolvers, so the two
+ * suites assert the same behaviour against different storage engines.
+ *
+ * `expo-sqlite` is backed by node's built-in SQLite here, so these exercise the
+ * real SQL — the WHERE clause and the ownership filter are part of what makes
+ * the invariant hold, not just the resolver call.
+ */
+
+import type { Message } from '@quilibrium/quorum-shared';
+
+const ME = 'QmMyAddress';
+const PEER = 'QmPeerAddress';
+
+jest.mock('expo-sqlite', () => {
+  // node:sqlite gives real SQL semantics. Its API is close to expo's but not
+  // identical, so map the handful of methods messagesDb actually uses.
+  const { DatabaseSync } = require('node:sqlite');
+
+  const wrap = (db: any) => ({
+    execSync: (sql: string) => db.exec(sql),
+    runSync: (sql: string, params: unknown[] = []) => db.prepare(sql).run(...params),
+    getFirstSync: (sql: string, params: unknown[] = []) => db.prepare(sql).get(...params) ?? null,
+    getAllSync: (sql: string, params: unknown[] = []) => db.prepare(sql).all(...params),
+    prepareSync: (sql: string) => {
+      const stmt = db.prepare(sql);
+      return { executeSync: (...params: unknown[]) => stmt.run(...params), finalizeSync: () => {} };
+    },
+    withTransactionSync: (fn: () => void) => fn(),
+    closeSync: () => db.close(),
+  });
+
+  return {
+    openDatabaseSync: () => wrap(new DatabaseSync(':memory:')),
+    deleteDatabaseSync: () => {},
+  };
+});
+
+// A 32-byte hex string standing in for the Ed448 identity key. messagesDb runs
+// it through HKDF to derive the SQLCipher key; plain SQLite ignores PRAGMA key,
+// so any well-formed hex works. Inlined because jest hoists mock factories above
+// every module-scope const.
+jest.mock('expo-secure-store', () => ({
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY: 'whenUnlockedThisDeviceOnly',
+  getItem: () => 'ab'.repeat(32),
+  getItemAsync: async () => 'ab'.repeat(32),
+}));
+
+// MMKV is native-only. The migration flag reads 'done' so the one-shot
+// MMKV→SQLite sweep short-circuits — it is not what these tests are about.
+jest.mock('../services/offline/storage', () => ({
+  storage: {
+    getString: (key: string) => (key === 'messages-sqlite-migration:v1' ? 'done' : undefined),
+    getAllKeys: () => [],
+    set: () => {},
+    remove: () => {},
+  },
+}));
+
+type Db = typeof import('../services/storage/messagesDb');
+
+describe('messagesDb — DM receipt reconciliation', () => {
+  let db: Db;
+
+  beforeEach(() => {
+    // messagesDb caches its connection and cipher key at module scope, so a
+    // fresh module registry is what gives each test a fresh in-memory DB.
+    jest.resetModules();
+    db = require('../services/storage/messagesDb');
+  });
+
+  /** A DM has spaceId === channelId === the partner address. */
+  async function saveDm(over: {
+    messageId: string;
+    createdDate: number;
+    senderId?: string;
+    deliveredAt?: number;
+    readAt?: number;
+  }) {
+    await db.saveMessage({
+      messageId: over.messageId,
+      spaceId: PEER,
+      channelId: PEER,
+      createdDate: over.createdDate,
+      modifiedDate: over.createdDate,
+      content: { type: 'post', senderId: over.senderId ?? ME, text: 'hi' },
+      deliveredAt: over.deliveredAt,
+      readAt: over.readAt,
+    } as unknown as Message);
+  }
+
+  const get = (messageId: string) => db.getMessage({ spaceId: PEER, channelId: PEER, messageId });
+
+  const readAck = (upToMessageId: string, upToTimestamp: number, at = 9_000) =>
+    db.updateMessagesReadAt(PEER, ME, upToMessageId, upToTimestamp, at);
+
+  describe('read acks', () => {
+    it('does NOT mark an undelivered message as read or delivered', async () => {
+      // The core bug: this message never landed, so it has no deliveredAt.
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+      await saveDm({ messageId: 'hwm', createdDate: 500, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const lost = await get('lost');
+      expect(lost?.readAt).toBeUndefined();
+      expect(lost?.deliveredAt).toBeUndefined();
+    });
+
+    it('marks a delivered in-range message as read', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const m1 = await get('m1');
+      expect(m1?.readAt).toBe(9_000);
+      expect(m1?.deliveredAt).toBe(800); // untouched — the real delivery time
+    });
+
+    it('stamps both on the high-water-mark message, since reading proves arrival', async () => {
+      await saveDm({ messageId: 'hwm', createdDate: 500 });
+
+      await readAck('hwm', 500);
+
+      const hwm = await get('hwm');
+      expect(hwm?.readAt).toBe(9_000);
+      expect(hwm?.deliveredAt).toBe(9_000);
+    });
+
+    it("leaves the peer's own messages alone", async () => {
+      await saveDm({ messageId: 'theirs', createdDate: 400, senderId: PEER });
+
+      await readAck('hwm', 500);
+
+      const theirs = await get('theirs');
+      expect(theirs?.readAt).toBeUndefined();
+    });
+
+    it('ignores delivered messages newer than the high-water mark', async () => {
+      await saveDm({ messageId: 'newer', createdDate: 600, deliveredAt: 800 });
+
+      await readAck('hwm', 500);
+
+      const newer = await get('newer');
+      expect(newer?.readAt).toBeUndefined();
+    });
+
+    it('reproduces the reported bug: lost messages stay blank, neighbours upgrade', async () => {
+      // Ten sent messages; #4 and #7 never landed on the recipient.
+      for (let n = 1; n <= 10; n++) {
+        const lost = n === 4 || n === 7;
+        await saveDm({
+          messageId: `m${n}`,
+          createdDate: n * 100,
+          deliveredAt: lost ? undefined : 800,
+        });
+      }
+
+      await readAck('m10', 1000);
+
+      const results = await Promise.all(
+        Array.from({ length: 10 }, (_, i) => get(`m${i + 1}`))
+      );
+      const readIds = results.filter((m) => m?.readAt !== undefined).map((m) => m!.messageId);
+
+      expect(readIds).toEqual(['m1', 'm2', 'm3', 'm5', 'm6', 'm8', 'm9', 'm10']);
+      expect(results[3]?.readAt).toBeUndefined(); // m4 lost
+      expect(results[3]?.deliveredAt).toBeUndefined();
+      expect(results[6]?.readAt).toBeUndefined(); // m7 lost
+      expect(results[6]?.deliveredAt).toBeUndefined();
+    });
+  });
+
+  describe('delivery acks', () => {
+    it('stamps deliveredAt when no read ack has arrived', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 9_000);
+
+      const m1 = await get('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBeUndefined();
+    });
+
+    it('completes the upgrade when a read ack already covered the message', async () => {
+      // The common out-of-order case: read debounce (5s) beats delivery (10s).
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 9_000, new Map([[PEER, 500]]));
+
+      const m1 = await get('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('does not mark read when the message is newer than the watermark', async () => {
+      await saveDm({ messageId: 'm2', createdDate: 600 });
+
+      await db.updateMessageDeliveredAt('m2', 9_000, new Map([[PEER, 500]]));
+
+      const m2 = await get('m2');
+      expect(m2?.deliveredAt).toBe(9_000);
+      expect(m2?.readAt).toBeUndefined();
+    });
+  });
+
+  describe('ack ordering', () => {
+    it('converges on delivered+read when the read ack arrives first', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      // Read ack lands first — nothing to write yet, delivery is unconfirmed.
+      await readAck('hwm', 500);
+      expect((await get('m1'))?.readAt).toBeUndefined();
+
+      // Delivery ack lands second and completes the upgrade.
+      await db.updateMessageDeliveredAt('m1', 9_000, new Map([[PEER, 500]]));
+
+      const m1 = await get('m1');
+      expect(m1?.deliveredAt).toBe(9_000);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('converges on delivered+read when the delivery ack arrives first', async () => {
+      await saveDm({ messageId: 'm1', createdDate: 400 });
+
+      await db.updateMessageDeliveredAt('m1', 800);
+      await readAck('hwm', 500);
+
+      const m1 = await get('m1');
+      expect(m1?.deliveredAt).toBe(800);
+      expect(m1?.readAt).toBe(9_000);
+    });
+
+    it('leaves a permanently lost message blank in both orders', async () => {
+      await saveDm({ messageId: 'lost', createdDate: 400 });
+
+      await readAck('hwm', 500);
+      await readAck('hwm2', 600); // a later read ack must not rescue it either
+
+      const lost = await get('lost');
+      expect(lost?.readAt).toBeUndefined();
+      expect(lost?.deliveredAt).toBeUndefined();
+    });
+  });
+});

--- a/__tests__/receiptWiring.test.ts
+++ b/__tests__/receiptWiring.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Receipt truthfulness at the WebSocketContext wiring layer.
+ *
+ * The decision logic lives in quorum-shared (and is unit-tested there and, via
+ * the SQLite path, in receiptReconciliation.test.ts). What is mobile-specific —
+ * and therefore what can silently regress here — is the WIRING: that the ack
+ * callbacks actually delegate to the shared resolvers instead of sweeping
+ * inline, and that the read-ack watermark is recorded so a delivery ack landing
+ * afterwards can still complete the ✓✓ upgrade.
+ *
+ * Why this test is static rather than behavioural: these callbacks are built
+ * inside a `useEffect` in a ~6000-line provider wired to the websocket, MMKV,
+ * SQLite and native crypto. There is no harness that can drive an ack through
+ * them, so the invariants are asserted against the source text — the same
+ * approach dmSelfEchoGuards.test.ts takes for the same file.
+ *
+ * The regression this prevents: `deliveredAt: m.deliveredAt || now` inside the
+ * read-ack sweep. A read ack is only a high-water mark ("read up to Y"), so
+ * that backfill stamped delivered+read onto messages that never reached the
+ * recipient at all — the sender showed ✓✓ for messages nobody ever received.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SOURCE_PATH = path.join(__dirname, '..', 'context', 'WebSocketContext.tsx');
+const source = fs.readFileSync(SOURCE_PATH, 'utf8');
+
+/** Slice the source between two anchors, failing loudly if either moved. */
+function section(startAnchor: string, endAnchor: string): string {
+  const start = source.indexOf(startAnchor);
+  expect(start).toBeGreaterThan(-1);
+  const end = source.indexOf(endAnchor, start);
+  expect(end).toBeGreaterThan(start);
+  return source.slice(start, end);
+}
+
+const readAckBody = () => section('onReadAckProcessed: (', '\n    });');
+const deliveryAckBody = () => section('onAckProcessed: (messageIds)', 'onReadFlush:');
+
+describe('WebSocketContext — receipt ack wiring', () => {
+  describe('read acks', () => {
+    it('never backfills deliveredAt from a read ack', () => {
+      // The exact shape of the shipped bug, plus the generic form.
+      expect(readAckBody()).not.toMatch(/deliveredAt:\s*m\.deliveredAt\s*\|\|/);
+      expect(readAckBody()).not.toMatch(/deliveredAt:\s*\w+\.deliveredAt\s*\|\|\s*now/);
+    });
+
+    it('validates the inbound timestamp before writing anything', () => {
+      const body = readAckBody();
+      expect(body).toContain('isReadAckTimestampValid(upToTimestamp, now)');
+      // Must guard, not merely compute: an unbounded timestamp from a peer would
+      // otherwise mark our entire outbound history read.
+      expect(body).toMatch(/if\s*\(!isReadAckTimestampValid\(upToTimestamp,\s*now\)\)\s*return;/);
+      // And it must come before the cache write.
+      expect(body.indexOf('isReadAckTimestampValid')).toBeLessThan(body.indexOf('setQueryData'));
+    });
+
+    it('records the watermark so a later delivery ack can finish the upgrade', () => {
+      const body = readAckBody();
+      expect(body).toContain('readWatermarksRef.current.set(');
+      expect(body).toContain('advanceReadWatermark(');
+    });
+
+    it('delegates the per-message decision to the shared resolver', () => {
+      const body = readAckBody();
+      expect(body).toContain('resolveReadAckPatch(m, ctx)');
+      // No inline high-water-mark sweep — that IS the bug.
+      expect(body).not.toMatch(/m\.createdDate\s*<=\s*upToTimestamp/);
+    });
+
+    it('passes the high-water-mark id through to persistence', () => {
+      // The HWM message is the one case a read ack may stamp deliveredAt on
+      // (reading it proves it arrived), so the id has to reach the DB layer.
+      expect(readAckBody()).toContain(
+        'updateMessagesReadAt(conversationAddress, self, upToMessageId, upToTimestamp, now)'
+      );
+    });
+  });
+
+  describe('delivery acks', () => {
+    it('delegates the per-message decision to the shared resolver', () => {
+      expect(deliveryAckBody()).toContain('resolveDeliveryAckPatch(m, { readWatermark, now })');
+    });
+
+    it('resolves the watermark per conversation from the query key', () => {
+      // The ack itself carries no conversation; the cache key does.
+      expect(deliveryAckBody()).toMatch(/readWatermarksRef\.current\.get\(String\(queryKey\[2\]/);
+    });
+
+    it('hands the watermarks to persistence too', () => {
+      expect(deliveryAckBody()).toContain(
+        'updateMessageDeliveredAt(id, now, readWatermarksRef.current)'
+      );
+    });
+  });
+
+  describe('receipt settings', () => {
+    it('gates read receipts on delivery receipts at the service layer', () => {
+      // Delivery is load-bearing for read now: ✓✓ requires a real deliveredAt.
+      // A stale `readReceipts: true, deliveryReceipts: false` override would
+      // otherwise leave a conversation with permanently blank receipts.
+      const body = section('const isReceiptEnabled = useCallback', '}, []);');
+      expect(body).toContain("kind === 'delivery' ? delivery : delivery && resolve('readReceipts')");
+    });
+  });
+});

--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -9,13 +9,17 @@
  */
 
 import {
+  advanceReadWatermark,
   bytesToHex,
   createRNWebSocketClient,
   int64ToBytes,
+  isReadAckTimestampValid,
   logger,
   MAX_MESSAGE_LENGTH,
   queryKeys,
   ReceiptService,
+  resolveDeliveryAckPatch,
+  resolveReadAckPatch,
 } from '@quilibrium/quorum-shared';
 import { useQueryClient } from '@tanstack/react-query';
 import { PERSISTABLE_TYPES, DM_GUARD_PASSTHROUGH_TYPES } from '@/components/Chat/types';
@@ -563,6 +567,11 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   const receiptServiceRef = useRef<ReceiptService | null>(null);
   const sendDmReceiptAckRef = useRef<((partnerAddress: string, ack: ReceiptControlMessage) => void) | null>(null);
 
+  // How far the partner has read, per DM conversation. In-memory only: it exists
+  // to bridge the ~5s gap between a read ack and the delivery acks it outran, so
+  // a restart mid-window costs at most a few ✓✓ that the next read ack restores.
+  const readWatermarksRef = useRef<Map<string, number>>(new Map());
+
   // Effective receipt switch: per-conversation override wins over the global
   // setting, else the global (default OFF). Read live so a settings toggle takes
   // effect immediately. `partner` is the DM partner address (conversationId is
@@ -573,18 +582,27 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
   // sweep hasn't run yet. This gate must stay in step with the settings sheet —
   // gating receipts on a stale local value would keep emitting acks for a
   // conversation the user switched off from another device.
+  //
+  // Read is NESTED under delivery, matching desktop and the settings sheet (which
+  // hides the read toggle when delivery is off). Enforcing it here and not just in
+  // the UI matters now that delivery is load-bearing for read: ✓✓ is only granted
+  // to a message with a real deliveredAt, so a stale
+  // `readReceipts: true, deliveryReceipts: false` override would otherwise leave a
+  // conversation with permanently blank receipts and no explanation.
   const isReceiptEnabled = useCallback((kind: 'delivery' | 'read', partner?: string): boolean => {
     const self = fullUserAddrRef.current;
     if (!self) return false;
     const cfg = getLocalUserConfig(self);
     const conversationId = partner ? `${partner}/${partner}` : undefined;
     const conv = conversationId ? getConversationSync(conversationId) : undefined;
-    const override = conversationId
-      ? getLocalConversationSetting(self, conversationId, kind === 'delivery' ? 'deliveryReceipts' : 'readReceipts')
-      : undefined;
-    return kind === 'delivery'
-      ? (override ?? conv?.deliveryReceipts ?? cfg?.deliveryReceipts ?? false)
-      : (override ?? conv?.readReceipts ?? cfg?.readReceipts ?? false);
+    const resolve = (setting: 'deliveryReceipts' | 'readReceipts'): boolean => {
+      const override = conversationId
+        ? getLocalConversationSetting(self, conversationId, setting)
+        : undefined;
+      return override ?? conv?.[setting] ?? cfg?.[setting] ?? false;
+    };
+    const delivery = resolve('deliveryReceipts');
+    return kind === 'delivery' ? delivery : delivery && resolve('readReceipts');
   }, []);
 
   // Intercept DM receipts on the decrypt path (both receive branches), BEFORE
@@ -5684,23 +5702,36 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
         sendDmReceiptAckRef.current?.(address, { senderId: self, type: 'delivery-ack', messageIds });
       },
       onAckProcessed: (messageIds) => {
+        // Delivery acks carry real message IDs, so they are the source of truth
+        // for "it arrived". If a read ack already covered the message, this also
+        // completes the ✓✓ upgrade it could not grant on its own.
         const now = Date.now();
         const ids = new Set(messageIds);
-        // We don't know which conversation — patch deliveredAt across all DM caches.
-        queryClient.setQueriesData<InfiniteMessagesData>({ queryKey: ['messages', 'infinite'] }, (old) => {
-          if (!old?.pages) return old;
+        // The ack does not say which conversation it belongs to, but the query
+        // key does — so read the caches out and patch each one by key, rather
+        // than blind-updating them all.
+        const cached = queryClient.getQueriesData<InfiniteMessagesData>({ queryKey: ['messages', 'infinite'] });
+        for (const [queryKey, old] of cached) {
+          if (!old?.pages) continue;
+          // ['messages', 'infinite', spaceId, channelId] — for DMs both are the partner.
+          const readWatermark = readWatermarksRef.current.get(String(queryKey[2] ?? '')) ?? 0;
           let changed = false;
           const pages = old.pages.map((page) => {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
-              if (ids.has(m.messageId) && !m.deliveredAt) { changed = true; pageChanged = true; return { ...m, deliveredAt: now }; }
-              return m;
+              if (!ids.has(m.messageId)) return m;
+              const patch = resolveDeliveryAckPatch(m, { readWatermark, now });
+              if (!patch) return m;
+              changed = true; pageChanged = true;
+              return { ...m, ...patch };
             });
             return pageChanged ? { ...page, messages } : page;
           });
-          return changed ? { ...old, pages } : old;
-        });
-        for (const id of messageIds) updateMessageDeliveredAt(id, now).catch(() => {});
+          if (changed) queryClient.setQueryData<InfiniteMessagesData>(queryKey, { ...old, pages });
+        }
+        for (const id of messageIds) {
+          updateMessageDeliveredAt(id, now, readWatermarksRef.current).catch(() => {});
+        }
       },
       onReadFlush: (address, hwm) => {
         sendDmReceiptAckRef.current?.(address, {
@@ -5709,6 +5740,19 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
       },
       onReadAckProcessed: (upToMessageId, upToTimestamp, conversationAddress) => {
         const now = Date.now();
+
+        // A peer sending an unbounded timestamp would otherwise mark our entire
+        // outbound history read.
+        if (!isReadAckTimestampValid(upToTimestamp, now)) return;
+
+        // Remember how far they have read, so delivery acks still in flight can
+        // finish the upgrade when they land (see onAckProcessed).
+        readWatermarksRef.current.set(
+          conversationAddress,
+          advanceReadWatermark(readWatermarksRef.current.get(conversationAddress) ?? 0, upToTimestamp),
+        );
+
+        const ctx = { upToMessageId, upToTimestamp, now };
         const key = queryKeys.messages.infinite(conversationAddress, conversationAddress);
         queryClient.setQueryData<InfiniteMessagesData>(key, (old) => {
           if (!old?.pages) return old;
@@ -5716,17 +5760,17 @@ export function WebSocketProvider({ children }: WebSocketProviderProps) {
           const pages = old.pages.map((page) => {
             let pageChanged = false;
             const messages = page.messages.map((m) => {
-              if (m.content?.senderId === self && m.createdDate <= upToTimestamp && !m.readAt) {
-                changed = true; pageChanged = true;
-                return { ...m, readAt: now, deliveredAt: m.deliveredAt || now };
-              }
-              return m;
+              if (m.content?.senderId !== self) return m;
+              const patch = resolveReadAckPatch(m, ctx);
+              if (!patch) return m;
+              changed = true; pageChanged = true;
+              return { ...m, ...patch };
             });
             return pageChanged ? { ...page, messages } : page;
           });
           return changed ? { ...old, pages } : old;
         });
-        updateMessagesReadAt(conversationAddress, self, upToTimestamp, now).catch(() => {});
+        updateMessagesReadAt(conversationAddress, self, upToMessageId, upToTimestamp, now).catch(() => {});
       },
     });
 

--- a/services/storage/messagesDb.ts
+++ b/services/storage/messagesDb.ts
@@ -33,7 +33,11 @@ import type {
   GetMessagesResult,
   Message,
 } from '@quilibrium/quorum-shared';
-import { logger } from '@quilibrium/quorum-shared';
+import {
+  logger,
+  resolveDeliveryAckPatch,
+  resolveReadAckPatch,
+} from '@quilibrium/quorum-shared';
 
 const DB_NAME = 'quorum-messages.db';
 const MIGRATION_FLAG_KEY = 'messages-sqlite-migration:v1';
@@ -608,9 +612,18 @@ export async function deleteMessage(messageId: string): Promise<void> {
 /**
  * DM delivery receipt: stamp deliveredAt on a single sent message. Patches
  * the JSON payload (deliveredAt is not a dedicated column). No-op if the row
- * is gone or already delivered.
+ * is gone or the ack changes nothing.
+ *
+ * Also completes a read upgrade when a read ack already covered this message.
+ * The read debounce (5s) is shorter than the delivery one (10s), so read acks
+ * usually land first, when there is no delivery to gate the ✓✓ on yet.
+ * `readWatermarks` is keyed by conversation (spaceId); omit it to skip that.
  */
-export async function updateMessageDeliveredAt(messageId: string, deliveredAt: number): Promise<void> {
+export async function updateMessageDeliveredAt(
+  messageId: string,
+  deliveredAt: number,
+  readWatermarks?: ReadonlyMap<string, number>
+): Promise<void> {
   const db = await ensureDb();
   if (!db) return;
   const row = db.getFirstSync<{ payload: string }>(
@@ -620,19 +633,27 @@ export async function updateMessageDeliveredAt(messageId: string, deliveredAt: n
   if (!row) return;
   let msg: Message;
   try { msg = JSON.parse(row.payload) as Message; } catch { return; }
-  if (msg.deliveredAt) return;
-  msg.deliveredAt = deliveredAt;
-  db.runSync(`UPDATE messages SET payload = ? WHERE message_id = ?;`, [JSON.stringify(msg), messageId]);
+  const readWatermark = readWatermarks?.get(msg.spaceId) ?? 0;
+  const patch = resolveDeliveryAckPatch(msg, { readWatermark, now: deliveredAt });
+  if (!patch) return;
+  db.runSync(
+    `UPDATE messages SET payload = ? WHERE message_id = ?;`,
+    [JSON.stringify({ ...msg, ...patch }), messageId]
+  );
 }
 
 /**
- * DM read receipt: stamp readAt (and deliveredAt if missing) on all OWN
- * messages in a conversation up to a high-water timestamp. DM spaceId and
- * channelId are both the partner address.
+ * DM read receipt: stamp readAt on OWN messages in a conversation up to a
+ * high-water timestamp. DM spaceId and channelId are both the partner address.
+ *
+ * Only messages carrying a genuine deliveredAt are marked — a read ack must
+ * never invent a delivery, or messages lost in transport light up with ✓✓ they
+ * never earned. The HWM message itself is exempt: reading it proves it arrived.
  */
 export async function updateMessagesReadAt(
   conversationAddress: string,
   selfAddress: string,
+  upToMessageId: string,
   upToTimestamp: number,
   readAt: number
 ): Promise<void> {
@@ -643,13 +664,17 @@ export async function updateMessagesReadAt(
      WHERE space_id = ? AND channel_id = ? AND created_date <= ?;`,
     [conversationAddress, conversationAddress, upToTimestamp]
   );
+  const ctx = { upToMessageId, upToTimestamp, now: readAt };
   for (const row of rows) {
     let msg: Message;
     try { msg = JSON.parse(row.payload) as Message; } catch { continue; }
-    if (msg.content?.senderId !== selfAddress || msg.readAt) continue;
-    msg.readAt = readAt;
-    if (!msg.deliveredAt) msg.deliveredAt = readAt;
-    db.runSync(`UPDATE messages SET payload = ? WHERE message_id = ?;`, [JSON.stringify(msg), row.message_id]);
+    if (msg.content?.senderId !== selfAddress) continue;
+    const patch = resolveReadAckPatch(msg, ctx);
+    if (!patch) continue;
+    db.runSync(
+      `UPDATE messages SET payload = ? WHERE message_id = ?;`,
+      [JSON.stringify({ ...msg, ...patch }), row.message_id]
+    );
   }
 }
 


### PR DESCRIPTION
## The bug

Read acks carry only a high-water mark ("read up to timestamp Y"). The sender expanded that into "every message of mine at or below Y was **read AND delivered**", so messages that never landed on the recipient sat in that range too and got stamped with a delivery they never earned.

Ten messages, #4 and #7 lost in transport. The recipient never renders them, so its read-observer never fires for them, it does not even know they exist. It reads #10 and sends one ack. The sender sweeps everything at or below that timestamp and lights up #4 and #7 with the double tick. The recipient can never contradict this: the false claim is manufactured entirely on the **sender** side, which is why the bug survived regardless of how well the recipient behaved.

Delivery acks were always honest, they carry the actual set of received message IDs. The read-ack backfill was the only thing fabricating deliveries.

## The fix

Delivery is the single source of truth. `readAt` may only be set on a message that already carries a genuine `deliveredAt`. A read ack advances a watermark; it never manufactures a delivery. A lost message now shows *nothing* while its neighbours show both ticks, which surfaces transport loss instead of hiding it.

**The one-line version of this is wrong**, which is worth spelling out. The read debounce (5s) is shorter than the delivery debounce (10s), so when someone reads without replying the read ack reliably arrives **before** the delivery acks for those same messages, at a point where nothing has a `deliveredAt` yet. Simply requiring `deliveredAt` would mark nothing, and when the delivery acks then landed there would be no `readAt` to upgrade: receipts would silently stall at one tick forever for anyone who reads without replying.

So the read ack records a per-conversation watermark, and the delivery ack completes the upgrade for anything at or below it. Whichever ack lands second finishes the job, in either order. The high-water-mark message itself is exempt and may be stamped delivered, since reading it proves it arrived.

The decision logic is **not** duplicated here. It lives in `quorum-shared` (`2.1.0-37`, already pinned and installed), and both the React Query cache sweep and the SQLite scan call the same resolvers, so mobile and desktop cannot drift on what a tick means.

## Changes

- `context/WebSocketContext.tsx` — `onAckProcessed` and `onReadAckProcessed` call the shared resolvers instead of sweeping inline. Adds `readWatermarksRef` (`Map<conversationAddress, number>`). The inbound read-ack timestamp is now validated: a peer sending `Number.MAX_SAFE_INTEGER` would otherwise have marked the sender's entire outbound history read.
- `services/storage/messagesDb.ts` — `updateMessagesReadAt` takes `upToMessageId` and applies `resolveReadAckPatch`; `updateMessageDeliveredAt` takes an optional `readWatermarks` map and applies `resolveDeliveryAckPatch`. One caller each, both updated.

The watermark is **in-memory only, deliberately**. It exists to bridge the ~5s gap between a read ack and the delivery acks it outran. A restart mid-window costs at most a few double ticks, which the next read ack restores. That avoids a schema change entirely.

**Read receipts are now nested under delivery receipts** in `isReceiptEnabled`, matching desktop. The settings sheet already hid the read toggle when delivery was off, but the service layer read the two flags independently. Now that delivery is load-bearing for read, a stale `readReceipts: true, deliveryReceipts: false` override would otherwise produce permanently blank receipts with no explanation.

**Incidental:** the delivery-ack cache sweep used `setQueriesData`, which never exposes the query key, so it could not tell which conversation a cache belonged to. Switched to `getQueriesData` plus a per-key `setQueryData` (desktop's shape), which the per-conversation watermark lookup requires.

## What this does NOT fix

This closes the *fabrication* path, not every possible false tick. If the recipient decrypts a message (so it genuinely sends a delivery ack) but a downstream bug drops it before it reaches the UI, the ack is real and this cannot cure it. **A false tick surviving this change is evidence of that separate transport/persistence bug** rather than a failed fix, which is a useful narrowing.

## Verification

- `npx tsc --noEmit` gives 21 errors, **byte-identical to the pre-change baseline**. All pre-existing and in unrelated files (`services/calling/*`, farcaster, `app/explore.tsx`). Zero new.
- `npx jest` gives **108 passed / 13 suites** (was 87/11).
- `npx eslint` on the two production files gives 36 warnings, 0 errors, **identical count before and after**. The new test files add 2 `no-require-imports` warnings, both unavoidable: jest hoists mock factories above imports, and `jest.resetModules()` needs a dynamic re-require. Repo-wide lint (301 errors / 260 warnings) is untouched and pre-existing.

**`__tests__/receiptReconciliation.test.ts` (12 tests)** — behavioural, against the **real SQL**. `expo-sqlite` is mocked onto node's built-in `node:sqlite`, so the `WHERE` clause and the ownership filter are exercised, not just the resolver call. A direct port of desktop's suite, so both platforms assert the same behaviour against different storage engines.

**Proven to catch the bug:** restoring the old logic fails exactly 5 tests and all 12 pass with the fix.

| Test | What it protects |
|---|---|
| undelivered message stays blank | the core invariant |
| the 10-message #4/#7 scenario | the exact reported symptom |
| delivery ack completes a read already covered | the watermark path |
| read-ack-first convergence | the ordering trap |
| lost message blank in both orders | no ack sequence rescues it |

(Desktop's equivalent caught 4. Mobile catches a fifth because its old delivery-ack path also lacked the watermark upgrade.)

**`__tests__/receiptWiring.test.ts` (9 tests)** — static assertions over the WebSocketContext callbacks, the same technique `dmSelfEchoGuards.test.ts` already uses for this file. These callbacks are built inside a `useEffect` in a ~6000-line provider wired to the websocket, MMKV, SQLite and native crypto; there is no harness that can drive an ack through them. It guards the mobile-specific risk, which is the *wiring* rather than the logic: no `deliveredAt || now` backfill, timestamp validated before any write, watermark recorded, resolvers used instead of an inline sweep, `upToMessageId` threaded to persistence, and the read-under-delivery nesting. **All 9 fail against the previous version of the file** (checked by restoring `HEAD:context/WebSocketContext.tsx` and re-running) and all 9 pass after.

## Still owed: two-device runtime check

Cannot be automated, needs a real peer. Same three checks desktop still owes, plus one specific to mobile:

1. Normal conversation still reaches the double tick in both directions (no regression).
2. **Read *without replying* still upgrades to the double tick** — the highest-risk check. This is the ordering trap: if the watermark wiring is wrong, receipts stall at one tick and never upgrade.
3. Force a loss (break the session / drop a frame): the lost message stays blank while its neighbours show the double tick.
4. **The single tick appears mobile to desktop.** The messageId-mismatch prerequisite is fixed in code (it landed in `aaa0b79`, #175, which is why its task file still reads `open`) but was never confirmed at runtime. That prerequisite matters because before it, the read-ack backfill was the *only* thing setting `deliveredAt` on the mobile to desktop direction, so shipping this without it would remove receipts in that direction entirely. Structurally satisfied; this observation is what confirms it, and it closes that task too.
