### PR TITLE
harness: headless DM harness, slice 1 (toolchain)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,13 @@ yarn-error.*
 # local env files
 .env*.local
 
+# Headless DM harness (dev/harness) — LOCAL ONLY, NEVER COMMIT.
+# .state/ holds persisted device keysets and logs/ holds captured ratchet
+# state: both are REAL private key material from real accounts. The harness
+# also talks to production, so these are not synthetic fixtures.
+dev/harness/.state/
+dev/harness/logs/
+
 # typescript
 *.tsbuildinfo
 

--- a/dev/harness/README.md
+++ b/dev/harness/README.md
@@ -1,0 +1,111 @@
+# Headless DM harness (mobile) — slice 1
+
+Run **mobile's own client code** in Node, with no device, no emulator and no
+Metro. Slice 1 proves the toolchain; later slices add identity, transport and
+two-bot DM scenarios.
+
+```bash
+yarn harness:smoke     # offline, no keys, no network — safe anywhere
+yarn harness           # every scenario
+```
+
+## Why this exists
+
+The DM investigation
+(`.agents/bugs/2026-07-24-dm-desktop-frames-undecryptable-state-divergence.md`)
+ends at a wall: frames are handed to `ws.send`, signed, socket open, and never
+arrive. Client visibility stops there, because below it is React Native's native
+WebSocket. §26 puts the drop at ~80% node-side with that exact residual
+unresolved.
+
+Two `dm-loss` runs on the desktop harness (2026-07-28) measured **0.0% loss in
+both directions**, on fresh throwaways and on aged multi-device accounts. That
+is the first desktop-side measurement of this drop, and it moves probability
+toward the RN native layer — but it does not isolate it, because desktop differs
+from mobile in more than the transport.
+
+**This harness is the single-variable experiment.** Mobile's client code, on
+Node's `ws` transport:
+
+- loss **disappears** ⟹ RN's native WebSocket is the culprit. Client-side, fixable.
+- loss **appears** ⟹ RN native is exonerated; it is mobile's send logic or
+  node-side handling of mobile-shaped writes, with a headless repro to hand over.
+
+Every previous round changed platform, transport and client code together. This
+changes one thing.
+
+## ⚠️ What it deliberately does NOT test
+
+The harness runs the Rust channel crate's **WASM** build, because Node cannot
+load the ARM `.so` that the app uses through uniffi. Consequences, and they are
+real:
+
+- **The uniffi bridge is not exercised** — `parseNativeResult`, the base64/JSON
+  round-trips, `ratchet-mutex` under genuine native async timing.
+- **The native batch decrypt path cannot run at all.** `batchUnsealEnvelopes` and
+  `batchProcessMessages` are native-only with no WASM equivalent. Scenarios must
+  force the per-message path.
+- **SQLCipher is not exercised** — the harness drops `PRAGMA key`.
+
+A green harness therefore does **not** mean mobile is healthy. It means the
+layers this harness covers are healthy.
+
+## How it stays out of the app's way
+
+| concern | how |
+|---|---|
+| `yarn test` collecting these files | Scenarios are `*.scenario.ts`. The app's `testMatch` is `**/*.test.ts` — it never matches. **`jest.config.js` is not modified.** |
+| a new test-runner dependency | None. Reuses the installed jest via a separate `jest.harness.config.js`. |
+| `package.json` / `yarn.lock` churn | Two script lines. **No dependency added**, no lockfile change, no `yarn install`, so the `postinstall` cache wipe never runs. |
+| the app bundle | Nothing in `app/`, `components/`, `services/` or `hooks/` imports `dev/harness`. Metro never sees it. |
+
+## The SDK alias — read before you touch `jest.harness.config.js`
+
+The app has never needed `@quilibrium/quilibrium-js-sdk-channels` and **must not
+gain it as a dependency**. Mobile reaches the Rust channel crate through uniffi
+(`libchannel.so`, ARM machine code); the SDK carries the same crate's *other*
+binding, the WASM one, which is the only build a Node process can execute.
+
+So the harness config resolves it from the sibling desktop checkout:
+
+```
+../quorum-desktop/node_modules/@quilibrium/quilibrium-js-sdk-channels
+```
+
+On this machine that path is a **yarn-link symlink to the SDK source repo**,
+which has no `node_modules` of its own — which is why `@babel/runtime` is also
+mapped back to mobile's tree. If the SDK ever stops resolving, check that link
+first.
+
+Requirement: a `quorum-desktop` checkout beside this repo with dependencies
+installed. Desktop's own harness already depends on a sibling SDK checkout for
+the WASM binary, so this is the existing convention rather than a new one.
+
+## ⚠️ Safety
+
+- **Throwaway or dedicated test accounts only.** Never a personal identity.
+- `dev/harness/.state/` and `dev/harness/logs/` are gitignored because they hold
+  **real device keysets and ratchet key material**. Never commit them.
+- Scenarios talk to **production** by default, the same relay the app uses. Runs
+  create real registrations and real frames.
+- Bots must persist their device keyset and reuse it, or every run adds a device
+  registration to the account — feeding the known ghost-device accumulation
+  problem.
+
+## Layout
+
+| file | role |
+|---|---|
+| `shim.ts` | browser globals the SDK bundle touches at import (`window.Buffer`) |
+| `smoke.scenario.ts` | offline: WASM loads, real keys, sign+verify with tamper rejection |
+| `../../jest.harness.config.js` | node env, SDK alias, `*.scenario.ts` matcher |
+
+## Status
+
+- **Slice 1 — toolchain proven.** WASM loads under mobile's jest; the crate
+  really executes (sign/verify, tampered message rejected). App suite unaffected:
+  13 suites / 108 tests, unchanged.
+- Slices 2-4 (crypto-provider shim, storage shims, DM core extraction, two-bot
+  scenarios) are specced in
+  `quorum-desktop/.agents/tasks/2026-07-27-cross-platform-dm-harness.md` — note
+  that plan lives in the **desktop** repo, because `.agents/` is gitignored here.

--- a/dev/harness/shim.ts
+++ b/dev/harness/shim.ts
@@ -1,0 +1,38 @@
+// Browser-surface shim. Side-effect only.
+//
+// MUST evaluate before the SDK bundle. The SDK ships a BROWSER build that does
+// `window.Buffer = buffer.Buffer` at module scope, so merely importing it in a
+// bare Node environment throws `ReferenceError: window is not defined` before a
+// single line of harness code runs.
+//
+// Wired via jest.harness.config.js `setupFiles`, which jest evaluates before the
+// test module and therefore before any import inside it. Doing it with a plain
+// `import './shim'` at the top of a scenario also works, but relies on every
+// future scenario author remembering — setupFiles makes it structural.
+//
+// This is NOT jsdom and NOT a mock. It is the few globals a browser bundle
+// touches at load, deliberately kept minimal so the harness keeps Node's REAL
+// WebSocket and REAL webcrypto — faking either would defeat the point of running
+// the client for real.
+import { Buffer as NodeBuffer } from 'node:buffer';
+
+const g = globalThis as unknown as {
+  window?: unknown;
+  Buffer?: unknown;
+  crypto?: unknown;
+};
+
+if (!g.window) g.window = g;
+const w = g.window as { location?: unknown; Buffer?: unknown; crypto?: unknown };
+
+// A concrete origin so any config reader that inspects window.location does not
+// throw. The value is never used: the harness passes explicit URLs to the API
+// client and the transport.
+if (!w.location) w.location = { origin: 'http://localhost' };
+
+if (!g.Buffer) g.Buffer = NodeBuffer;
+if (!w.Buffer) w.Buffer = NodeBuffer;
+
+// Node 22 provides globalThis.crypto (webcrypto). Mirror it onto window for the
+// SDK's window.crypto.subtle paths.
+if (g.crypto && !w.crypto) w.crypto = g.crypto;

--- a/dev/harness/smoke.scenario.ts
+++ b/dev/harness/smoke.scenario.ts
@@ -1,0 +1,62 @@
+// SLICE 1 SPIKE — offline, no relay, no account.
+//
+// Proves the single most uncertain thing about running mobile's client code
+// headlessly: that the Rust channel crate's WASM binding loads and produces real
+// keys inside THIS repo's toolchain. Everything else in the harness is ordinary
+// wiring; if this fails, the approach needs a different runner and the whole
+// slice plan changes.
+//
+// Deliberately offline so it is safe to run anywhere, any time, with no keys and
+// no network. Run: yarn harness:smoke
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+
+const WASM = resolve(
+  __dirname,
+  '../../../quorum-desktop/node_modules/@quilibrium/quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm'
+);
+
+describe('harness smoke (offline)', () => {
+  it('loads the channel WASM and generates real ed448 + x448 keypairs', () => {
+    // channel_raw and the high-level `channel` API share one wasm var, so this
+    // initialises both.
+    channel_raw.initSync(readFileSync(WASM));
+
+    const ed = JSON.parse(channel_raw.js_generate_ed448());
+    const x = JSON.parse(channel_raw.js_generate_x448());
+
+    // Assert real key sizes rather than "is an array" — a stub returning []
+    // would pass the loose version.
+    //
+    // Lengths MEASURED against the running crate, not taken from the curve
+    // specs — note x448 is asymmetric here (57-byte public, 56-byte private),
+    // which is not what the raw spec would suggest. Two earlier drafts of this
+    // test guessed and failed. If these ever change, measure again rather than
+    // reasoning about what they ought to be.
+    expect(ed.public_key).toHaveLength(57);
+    expect(ed.private_key).toHaveLength(57);
+    expect(x.public_key).toHaveLength(57);
+    expect(x.private_key).toHaveLength(56);
+
+    // Two calls must not return the same key — catches a wasm that loaded but
+    // is returning a constant.
+    const ed2 = JSON.parse(channel_raw.js_generate_ed448());
+    expect(ed2.public_key).not.toEqual(ed.public_key);
+  });
+
+  it('signs and verifies with the generated key (the crate is really executing)', () => {
+    const ed = JSON.parse(channel_raw.js_generate_ed448());
+    const priv = Buffer.from(new Uint8Array(ed.private_key)).toString('base64');
+    const pub = Buffer.from(new Uint8Array(ed.public_key)).toString('base64');
+    const msg = Buffer.from('harness slice 1').toString('base64');
+
+    const sig = JSON.parse(channel_raw.js_sign_ed448(priv, msg)) as string;
+    expect(channel_raw.js_verify_ed448(pub, msg, sig)).toBe('true');
+
+    // A tampered message must fail — proves verification is real, not a stub
+    // returning 'true' unconditionally.
+    const other = Buffer.from('harness slice 1!').toString('base64');
+    expect(channel_raw.js_verify_ed448(pub, other, sig)).not.toBe('true');
+  });
+});

--- a/jest.harness.config.js
+++ b/jest.harness.config.js
@@ -1,0 +1,62 @@
+// Jest config for the HEADLESS DM HARNESS — a separate runner from the app's
+// jest.config.js, which it must never share.
+//
+// Why separate: the app config uses the jest-expo preset (React Native
+// environment, native module mocks). The harness needs the opposite — a plain
+// Node environment with real networking and real crypto, because the whole point
+// is to run mobile's client code with nothing about it faked.
+//
+// Why the app config never picks these files up: its testMatch is
+// `**/__tests__/**/*.test.ts` + `**/*.test.ts`. Harness scenarios are named
+// `*.scenario.ts`, which matches neither. `yarn test` is untouched by design —
+// no testPathIgnorePatterns edit, no risk of collecting these under the wrong
+// setup. Keep the naming; it is load-bearing, not cosmetic.
+const path = require('path');
+
+// The SDK is NOT a mobile dependency and must not become one. The app uses the
+// Rust channel crate through uniffi (libchannel.so, ARM machine code) — it has
+// never needed the wasm build. Node cannot load that .so, so the harness needs
+// the crate's OTHER binding, the wasm one, which ships in the SDK package.
+// Resolved from the sibling desktop checkout so mobile's package.json and
+// yarn.lock stay untouched. Same convention as desktop's own harness, which
+// already resolves the wasm binary from a sibling repo.
+const SDK = path.resolve(
+  __dirname,
+  '../quorum-desktop/node_modules/@quilibrium/quilibrium-js-sdk-channels'
+);
+
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['<rootDir>/dev/harness/**/*.scenario.ts'],
+  // Same Windows named-pipe failure the app's jest.config.js works around, and
+  // for the same reason: Watchman only speeds up file discovery, so disabling it
+  // is behaviour-safe. Without this the runner dies before collecting anything.
+  watchman: false,
+  // Evaluates before the test module, so the browser-globals shim is guaranteed
+  // to land before the SDK bundle assigns `window.Buffer` at import time.
+  // Without it every scenario dies with "window is not defined".
+  setupFiles: ['<rootDir>/dev/harness/shim.ts'],
+  // Scenarios talk to a live relay; the default 5s kills them mid-handshake.
+  testTimeout: 4 * 60 * 60 * 1000,
+  moduleNameMapper: {
+    // Mobile's tsconfig path alias, spelled out for jest.
+    '^@/(.*)$': '<rootDir>/$1',
+    '^@quilibrium/quilibrium-js-sdk-channels$': SDK,
+    // SDK is reached via desktop's node_modules, which on this machine is a
+    // yarn-link SYMLINK to the SDK source checkout — and that checkout has no
+    // node_modules of its own. So the SDK's own runtime deps cannot resolve
+    // relative to it and must be pulled from mobile's tree instead.
+    '^@babel/runtime/(.*)$': '<rootDir>/node_modules/@babel/runtime/$1',
+    // The NODE build of shared, not index.native.js — the native barrel imports
+    // RN modules (AsyncStorage et al) that are null outside a device. Same
+    // reasoning the app's jest.config.js already documents.
+    '^@quilibrium/quorum-shared$':
+      '<rootDir>/node_modules/@quilibrium/quorum-shared/dist/index.js',
+  },
+  transform: {
+    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],
+  },
+  transformIgnorePatterns: [
+    'node_modules/(?!(@quilibrium/quorum-shared|multiformats|@noble|bs58|base-x|uint8arrays))',
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest",
+    "harness": "jest --config jest.harness.config.js",
+    "harness:smoke": "jest --config jest.harness.config.js smoke",
     "prebuild": "echo '\\n⚠️  prebuild is NOT a safe operation on this project.\\n\\nThe iOS folder is the source of truth and contains manual customizations\\n(QuorumNotificationService target, App Group entitlements, pinned\\nobjectVersion) that are not declared in app.json and would be lost.\\n\\nIf you genuinely need to prebuild, snapshot first:\\n  scripts/snapshot-ios-customizations.sh\\n  npx expo prebuild --no-install   (or --clean if you must)\\n  scripts/restore-ios-customizations.sh\\n\\nSee PREBUILD.md for the full rationale.\\n' && exit 1",
     "prebuild:snapshot": "scripts/snapshot-ios-customizations.sh",
     "prebuild:restore": "scripts/restore-ios-customizations.sh",


### PR DESCRIPTION
Run mobile's **own client code** in Node — no device, no emulator, no Metro. This is slice 1 and proves the toolchain only; identity, transport and two-bot DM scenarios follow.

## Why

The DM investigation ends at a wall: frames are handed to `ws.send`, signed, socket open, and never arrive. Client visibility stops there, because below it is React Native's native WebSocket. §26 of the investigation puts the drop at ~80% node-side with exactly that residual unresolved.

Two `dm-loss` runs on the desktop harness (2026-07-28) measured **0.0% loss in both directions** — on fresh throwaways and on aged multi-device accounts. That's the first desktop-side measurement of the drop, and it moves probability toward the RN native layer. But it can't isolate it, because desktop differs from mobile in more than the transport.

**This harness is the single-variable experiment:** mobile's client code, on Node's `ws` transport.

- Loss **disappears** → RN's native WebSocket is the culprit. Client-side and fixable, and it reverses "upstream, out of our hands" for [quorum-mobile#183](https://github.com/QuilibriumNetwork/quorum-mobile/issues/183) item 2.
- Loss **appears** → RN native is exonerated; it's mobile's send logic or node-side handling of mobile-shaped writes, and you get a headless repro to hand upstream.

Every prior round changed platform, transport and client code together. This changes one thing.

## Blast radius — deliberately near-zero

| concern | outcome |
|---|---|
| new dependencies | **None.** Reuses installed jest via a separate `jest.harness.config.js`. |
| `jest.config.js` | **Not modified.** Scenarios are `*.scenario.ts`; the app's `testMatch` is `**/*.test.ts` and never matches. |
| `package.json` | **Two script lines**, nothing else. |
| `yarn.lock` | **Unchanged** — so no `yarn install`, so the `postinstall` Metro/`.expo` cache wipe never runs. |
| the app bundle | Nothing in `app/`, `components/`, `services/`, `hooks/` imports `dev/harness`. Metro never sees it. |
| `.gitignore` | Adds `dev/harness/.state/` + `logs/` — they hold **real device keysets and ratchet key material**. |

The SDK is **aliased** from the sibling desktop checkout, never added as a mobile dependency. The app reaches the Rust channel crate through uniffi (`libchannel.so`, ARM) and must keep doing so; the harness needs that same crate's WASM binding purely because Node cannot load an ARM `.so`. Desktop's own harness already resolves the WASM from a sibling checkout, so this follows existing convention.

## ⚠️ Known limits (in the README, not left to be discovered)

Running WASM instead of native means:
- **the uniffi bridge is not exercised** (`parseNativeResult`, base64/JSON round-trips, `ratchet-mutex` under real native async timing)
- **the native-only batch decrypt path cannot run at all** — `batchUnsealEnvelopes` / `batchProcessMessages` have no WASM equivalent
- **SQLCipher is skipped**

A green harness does not mean mobile is healthy. It means the layers it covers are healthy.

## Verification

- **App suite: 13 suites / 108 tests, green and unchanged.** Count is identical pre- and post-change, confirming the harness files are not collected.
- **Harness smoke: green.** WASM loads, generates real ed448/x448 keys, signs and verifies — and rejects a tampered message, so the crate is genuinely executing rather than stubbed.
- Key lengths in the smoke test are *measured* against the running crate, not taken from the curve specs (x448 is asymmetric here: 57-byte public, 56-byte private). Two earlier drafts guessed and failed.

## Requires

A `quorum-desktop` checkout beside this repo with dependencies installed. Documented in `dev/harness/README.md`, along with the yarn-link detail that makes `@babel/runtime` need mapping back to mobile's tree.

## Reviewer note

The follow-on plan lives in **quorum-desktop** at `.agents/tasks/2026-07-27-cross-platform-dm-harness.md`, because `.agents/` is gitignored in this repo.