### PR TITLE
harness: crypto seam — run mobile's CryptoProvider on WASM

### DIFF
--- a/dev/harness/crypto-shim.scenario.ts
+++ b/dev/harness/crypto-shim.scenario.ts
@@ -1,0 +1,119 @@
+// Offline. Proves the crypto seam end to end: two parties establish a real X3DH
+// session and exchange double-ratchet messages THROUGH THE SHIM, using the same
+// CryptoProvider interface mobile's own code calls.
+//
+// This is the keystone for every later slice. If mobile's crypto abstraction
+// works headlessly, the rest is transport and storage wiring. If it does not,
+// nothing above it is worth building.
+//
+// Run: yarn harness
+import { NativeCryptoProvider } from './wasm-provider-shim';
+
+const SESSION_KEY_LENGTH = 96; // 32 session + 32 sending header + 32 receiving header
+
+const b64ToBytes = (b64: string) => Array.from(Buffer.from(b64, 'base64'));
+
+describe('crypto shim (offline)', () => {
+  it('establishes a real X3DH session and round-trips double-ratchet messages', async () => {
+    const alice = new NativeCryptoProvider();
+    const bob = new NativeCryptoProvider();
+
+    // Long-term identity + signed pre-keys, and Alice's one-shot ephemeral.
+    const aliceIdentity = await alice.generateX448();
+    const bobIdentity = await bob.generateX448();
+    const bobSignedPre = await bob.generateX448();
+    const aliceEphemeral = await alice.generateX448();
+
+    // Both sides derive the SAME 96-byte secret from opposite directions. This
+    // is the real agreement — if the two backends disagreed on anything, the
+    // keys would differ here and every later assertion would be meaningless.
+    const aliceSecret = await alice.senderX3DH({
+      sending_identity_private_key: aliceIdentity.private_key,
+      sending_ephemeral_private_key: aliceEphemeral.private_key,
+      receiving_identity_key: bobIdentity.public_key,
+      receiving_signed_pre_key: bobSignedPre.public_key,
+      session_key_length: SESSION_KEY_LENGTH,
+    });
+    const bobSecret = await bob.receiverX3DH({
+      sending_identity_private_key: bobIdentity.private_key,
+      sending_signed_private_key: bobSignedPre.private_key,
+      receiving_identity_key: aliceIdentity.public_key,
+      receiving_ephemeral_key: aliceEphemeral.public_key,
+      session_key_length: SESSION_KEY_LENGTH,
+    });
+
+    expect(aliceSecret).toBe(bobSecret);
+
+    const secret = b64ToBytes(aliceSecret);
+    const sessionKey = secret.slice(0, 32);
+    const sendingHeaderKey = secret.slice(32, 64);
+    const nextReceivingHeaderKey = secret.slice(64, 96);
+
+    let aliceState = await alice.newDoubleRatchet({
+      session_key: sessionKey,
+      sending_header_key: sendingHeaderKey,
+      next_receiving_header_key: nextReceivingHeaderKey,
+      is_sender: true,
+      sending_ephemeral_private_key: aliceEphemeral.private_key,
+      receiving_ephemeral_key: bobSignedPre.public_key,
+    });
+    let bobState = await bob.newDoubleRatchet({
+      session_key: sessionKey,
+      sending_header_key: sendingHeaderKey,
+      next_receiving_header_key: nextReceivingHeaderKey,
+      is_sender: false,
+      sending_ephemeral_private_key: bobSignedPre.private_key,
+      receiving_ephemeral_key: aliceEphemeral.public_key,
+    });
+
+    // A→B
+    const plaintext = 'harness: mobile crypto running headlessly';
+    const sent = await alice.doubleRatchetEncrypt({
+      ratchet_state: aliceState,
+      message: Array.from(new TextEncoder().encode(plaintext)),
+    });
+    aliceState = sent.ratchet_state;
+
+    const received = await bob.doubleRatchetDecrypt({
+      ratchet_state: bobState,
+      envelope: sent.envelope,
+    });
+    bobState = received.ratchet_state;
+
+    expect(new TextDecoder().decode(new Uint8Array(received.message))).toBe(plaintext);
+
+    // B→A, which forces a DH ratchet turn — the step where the two sides would
+    // diverge if state handling were wrong. A one-way test would miss it.
+    const replyText = 'and back again';
+    const reply = await bob.doubleRatchetEncrypt({
+      ratchet_state: bobState,
+      message: Array.from(new TextEncoder().encode(replyText)),
+    });
+    const replyOut = await alice.doubleRatchetDecrypt({
+      ratchet_state: aliceState,
+      envelope: reply.envelope,
+    });
+
+    expect(new TextDecoder().decode(new Uint8Array(replyOut.message))).toBe(replyText);
+  });
+
+  it('refuses the native-only batch paths loudly instead of degrading silently', async () => {
+    const provider = new NativeCryptoProvider();
+
+    // A scenario that silently fell back to per-message decrypt here would
+    // "pass" while never touching the batch path — which is both mobile's DM
+    // receive fast path and a live suspect. Failing loudly is the point.
+    await expect(provider.batchProcessMessages()).rejects.toThrow(/native-only/);
+    await expect(provider.batchUnsealEnvelopes()).rejects.toThrow(/native-only/);
+  });
+
+  it('can be constructed repeatedly (WASM init is once-per-process)', () => {
+    // initSync throws if called twice, so scenarios must be free to construct
+    // providers without coordinating. Guard regression would break every later
+    // slice in a confusing way.
+    expect(() => {
+      new NativeCryptoProvider();
+      new NativeCryptoProvider();
+    }).not.toThrow();
+  });
+});

--- a/dev/harness/wasm-provider-shim.ts
+++ b/dev/harness/wasm-provider-shim.ts
@@ -1,0 +1,93 @@
+// The crypto seam. This is what lets mobile's client code run in Node at all.
+//
+// The app talks to the Rust `channel` crate through uniffi — `libchannel.so`,
+// ARM machine code, reached via Expo's native module bridge. A Node process on a
+// PC cannot load that: there is no Android runtime and the wrong CPU. So
+// `requireNativeModule('QuorumCrypto')` fails before any harness code runs.
+//
+// The SAME Rust crate also has a WASM build (that is what desktop/web use), and
+// WASM runs in any JS engine. `quorum-shared` already models exactly this split:
+// `CryptoProvider` is the interface, `NativeCryptoProvider` and
+// `WasmCryptoProvider` are its two backends. Swapping one for the other is the
+// architecture working as designed, not a hack.
+//
+// Named `NativeCryptoProvider` deliberately: every call site in the app does a
+// bare `new NativeCryptoProvider()`, so aliasing the module in
+// jest.harness.config.js swaps the backend with ZERO app changes.
+//
+// ⚠️ WHAT THIS COSTS — do not let a green harness be read as "mobile is healthy":
+//   - the uniffi bridge is NOT exercised (parseNativeResult's error sniffing,
+//     the base64/JSON round-trips, ratchet-mutex under real native async timing)
+//   - the native-only BATCH decrypt path cannot run here at all
+//   - anything that is a defect in the .so rather than in the crate is invisible
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { channel_raw } from '@quilibrium/quilibrium-js-sdk-channels';
+import { WasmCryptoProvider, type ChannelWasmModule } from '@quilibrium/quorum-shared';
+
+// The published SDK package ships no .wasm; it is resolved from the SDK source
+// checkout, the same convention desktop's harness uses. Override with SDK_WASM.
+const WASM_PATH =
+  process.env.SDK_WASM ??
+  resolve(
+    __dirname,
+    '../../../quorum-desktop/node_modules/@quilibrium/quilibrium-js-sdk-channels/src/wasm/channelwasm_bg.wasm'
+  );
+
+let initialised = false;
+
+/**
+ * Initialise the crate's WASM binding exactly once per process.
+ *
+ * `channel_raw` and the high-level `channel` API are one bundle sharing a single
+ * `wasm` var, so this initialises both. Calling initSync twice throws, hence the
+ * guard — scenarios construct providers freely and must not have to coordinate.
+ */
+export function initHarnessCrypto(): ChannelWasmModule {
+  if (!initialised) {
+    channel_raw.initSync(readFileSync(WASM_PATH));
+    initialised = true;
+  }
+  return channel_raw as unknown as ChannelWasmModule;
+}
+
+/** Methods that exist ONLY in the native module — no WASM or JS equivalent. */
+function nativeOnly(name: string): never {
+  throw new Error(
+    `[harness] ${name}() is native-only (uniffi → Rust) and has no WASM equivalent, ` +
+      `so it cannot run headlessly. A scenario reaching this is silently routing ` +
+      `around the very code it means to test — force the per-message path instead. ` +
+      `See dev/harness/README.md "What it deliberately does NOT test".`
+  );
+}
+
+/**
+ * Drop-in for services/crypto/native-provider's NativeCryptoProvider.
+ *
+ * Inherits the whole CryptoProvider surface from WasmCryptoProvider — key
+ * generation, X3DH, double and triple ratchet, inbox encrypt/decrypt — because
+ * both implement the same interface against the same crate.
+ */
+export class NativeCryptoProvider extends WasmCryptoProvider {
+  constructor() {
+    super(initHarnessCrypto());
+  }
+
+  // ---- native-only surface: fail loudly rather than silently degrade ----
+  //
+  // These are direct QuorumCrypto.* uniffi calls in the real provider. The batch
+  // pair especially matters: batchProcessMessages is mobile's DM receive fast
+  // path AND a live suspect in the delivery investigation (it has a documented
+  // `truncated: true` partial-failure mode). Quietly falling back to per-message
+  // decrypt here would let a scenario "pass" while never touching the code under
+  // suspicion — the exact failure mode round 28 of that investigation hit.
+  async batchProcessMessages(): Promise<never> {
+    return nativeOnly('batchProcessMessages');
+  }
+
+  async batchUnsealEnvelopes(): Promise<never> {
+    return nativeOnly('batchUnsealEnvelopes');
+  }
+}
+
+export default NativeCryptoProvider;

--- a/jest.harness.config.js
+++ b/jest.harness.config.js
@@ -52,6 +52,21 @@ module.exports = {
     // reasoning the app's jest.config.js already documents.
     '^@quilibrium/quorum-shared$':
       '<rootDir>/node_modules/@quilibrium/quorum-shared/dist/index.js',
+    // The two mappings below are lifted from the app's jest.config.js, which hit
+    // the same problems loading the shared bundle. Kept verbatim rather than
+    // re-derived — if the app's version changes, change this to match.
+    //
+    // multiformats only exposes an ESM `import` condition for this subpath, so
+    // jest's CJS resolver cannot find it; point at the concrete file.
+    '^multiformats/bases/base58$':
+      '<rootDir>/node_modules/multiformats/dist/src/bases/base58.js',
+    // The shared bundle mixes crypto with web-UI, markdown and date utilities
+    // that other exports use lazily and the crypto paths never touch — several
+    // not even installed here. Stub them so loading the bundle does not require
+    // untransformable ESM / web-only packages. The real crypto deps (@noble/*,
+    // multiformats, @tanstack/react-query) resolve normally.
+    '^(unified|remark-gfm|remark-parse|remark-stringify|strip-markdown|clsx|react-dom|react-dropzone|react-tooltip|@tabler/icons-react)(/.*)?$':
+      '<rootDir>/jest/empty-module.js',
   },
   transform: {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],


### PR DESCRIPTION
Follows #189. This is the keystone for every later harness slice: if mobile's crypto abstraction works headlessly, the rest is transport and storage wiring. If it doesn't, nothing above it is worth building.

## The seam

Mobile reaches the Rust `channel` crate through uniffi — `libchannel.so`, ARM machine code, via Expo's native module bridge. A Node process on a PC can't load that, so `requireNativeModule('QuorumCrypto')` fails before any harness code runs.

The same crate also has a WASM build, and `quorum-shared` **already models this exact split**: `CryptoProvider` is the interface, `NativeCryptoProvider` and `WasmCryptoProvider` are its two backends. Swapping one for the other is the architecture working as designed, not a workaround.

The shim is deliberately named `NativeCryptoProvider`, because every call site in the app does a bare `new NativeCryptoProvider()` — so aliasing the module in the harness config swaps the backend with **zero app changes**.

## Native-only methods fail loudly

`batchProcessMessages` and `batchUnsealEnvelopes` are direct uniffi calls with no WASM equivalent. They throw with an explanatory message rather than degrading.

This matters more than it looks. `batchProcessMessages` is mobile's DM receive fast path *and* a live suspect in the delivery investigation — it has a documented `truncated: true` partial-failure mode. A silent fallback to per-message decrypt would let a scenario **pass while never touching the code under suspicion**, which is precisely the failure mode round 28 of that investigation hit (a rig blind spot produced a confident, entirely wrong 21-frame loss claim).

## Proven, not assumed

The scenario runs a genuine two-party session:

1. **X3DH agreement** — Alice via `senderX3DH`, Bob via `receiverX3DH`, from opposite directions. Asserts both derive the *identical* 96-byte secret. If the backends disagreed on anything, this fails here and every later assertion would be meaningless.
2. **Double-ratchet round trip in both directions** — A→B then B→A, which forces a **DH ratchet turn**. That's the step where the two sides diverge if state handling is wrong; a one-way test would miss it.
3. **Repeated construction** — `initSync` throws if called twice, so scenarios must be free to construct providers without coordinating.

## Risk

- **No app code touched.** Nothing in `app/`, `components/`, `services/`, `hooks/`.
- **No dependencies, no `yarn.lock` change**, so no `yarn install` and no `postinstall` cache wipe.
- `jest.config.js` untouched; scenarios are still `*.scenario.ts`.
- Two `moduleNameMapper` entries are lifted **verbatim** from the app's `jest.config.js`, which hit the same shared-bundle resolution problems (multiformats' ESM-only subpath; web-only deps reached on lazy export paths). Kept identical rather than re-derived, with a note to keep them in sync.

## Verification

- **App suite: 13 suites / 108 tests — unchanged and green**
- **Harness suite: 2 suites / 5 tests — green**

## Still not tested (unchanged from #189)

Running WASM instead of native means the uniffi bridge, the native batch decrypt path, and SQLCipher are all outside what this can see. A green harness does not mean mobile is healthy.