### PR TITLE
harness: storage + platform shims — mobile's real services/ runs in Node

### DIFF
--- a/dev/harness/filesystem-shim.ts
+++ b/dev/harness/filesystem-shim.ts
@@ -1,0 +1,82 @@
+// expo-file-system replacement for Node, backed by node:fs.
+//
+// Only the handful of calls mobile's storage and media paths reach are mapped.
+// Anything unmapped throws by name rather than returning undefined, so a
+// scenario that wanders into unshimmed territory fails with a message that says
+// what to add — instead of a confusing `undefined is not a function` three
+// layers down.
+import { promises as fs } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+/** Harness scratch space, mirroring expo's documentTirectory-style contract. */
+export const documentDirectory = resolve(tmpdir(), 'quorum-harness-fs') + '/';
+export const cacheDirectory = resolve(tmpdir(), 'quorum-harness-cache') + '/';
+
+const stripScheme = (uri: string) => uri.replace(/^file:\/\//, '');
+
+export async function readAsStringAsync(
+  uri: string,
+  opts?: { encoding?: string }
+): Promise<string> {
+  const encoding = opts?.encoding === 'base64' ? 'base64' : 'utf8';
+  return fs.readFile(stripScheme(uri), encoding as BufferEncoding);
+}
+
+export async function writeAsStringAsync(
+  uri: string,
+  contents: string,
+  opts?: { encoding?: string }
+): Promise<void> {
+  const encoding = opts?.encoding === 'base64' ? 'base64' : 'utf8';
+  await fs.writeFile(stripScheme(uri), contents, encoding as BufferEncoding);
+}
+
+export async function deleteAsync(
+  uri: string,
+  opts?: { idempotent?: boolean }
+): Promise<void> {
+  await fs.rm(stripScheme(uri), { force: opts?.idempotent ?? true, recursive: true });
+}
+
+export async function getInfoAsync(
+  uri: string
+): Promise<{ exists: boolean; uri: string; size?: number }> {
+  try {
+    const st = await fs.stat(stripScheme(uri));
+    return { exists: true, uri, size: st.size };
+  } catch {
+    return { exists: false, uri };
+  }
+}
+
+export async function makeDirectoryAsync(
+  uri: string,
+  opts?: { intermediates?: boolean }
+): Promise<void> {
+  await fs.mkdir(stripScheme(uri), { recursive: opts?.intermediates ?? true });
+}
+
+/**
+ * Network download is deliberately NOT implemented. A scenario reaching it is
+ * almost certainly pulling remote media, which is outside what this harness
+ * covers — fail loudly rather than silently produce an empty file.
+ */
+export async function downloadAsync(): Promise<never> {
+  throw new Error(
+    '[harness] expo-file-system downloadAsync is not shimmed — remote media is ' +
+      'outside the harness scope. Add it to dev/harness/filesystem-shim.ts if a ' +
+      'scenario genuinely needs it.'
+  );
+}
+
+export default {
+  documentDirectory,
+  cacheDirectory,
+  readAsStringAsync,
+  writeAsStringAsync,
+  deleteAsync,
+  getInfoAsync,
+  makeDirectoryAsync,
+  downloadAsync,
+};

--- a/dev/harness/mmkv-shim.ts
+++ b/dev/harness/mmkv-shim.ts
@@ -1,0 +1,68 @@
+// react-native-mmkv replacement for Node.
+//
+// MMKV is a JSI native module — it does not exist outside a device. Mobile's
+// storage layer is built on it in ~29 places, so without this the harness cannot
+// import most of services/.
+//
+// In-memory only, and deliberately so: harness runs must not leave state on the
+// developer's machine, and every scenario should start from a known-empty store
+// unless it explicitly seeds one.
+//
+// Instances are keyed by id, matching MMKV's real semantics — two
+// `createMMKV({ id: 'quorum-config' })` calls return the SAME store, which
+// mobile relies on (configService and others call it at module scope from
+// several files).
+
+/** The subset of MMKV's surface mobile actually uses (grepped, not guessed). */
+export interface MMKV {
+  set(key: string, value: string | number | boolean): void;
+  getString(key: string): string | undefined;
+  getNumber(key: string): number | undefined;
+  getBoolean(key: string): boolean | undefined;
+  remove(key: string): void;
+  clearAll(): void;
+  getAllKeys(): string[];
+  contains(key: string): boolean;
+}
+
+const stores = new Map<string, Map<string, string | number | boolean>>();
+
+export function createMMKV(opts: { id: string }): MMKV {
+  const id = opts?.id ?? 'default';
+  let store = stores.get(id);
+  if (!store) {
+    store = new Map();
+    stores.set(id, store);
+  }
+  const s = store;
+
+  return {
+    set: (key, value) => void s.set(key, value),
+    // Real MMKV returns undefined for a missing key and does NOT coerce across
+    // types, so a value stored as a number must not come back from getString.
+    // Matching that matters: mobile branches on `?? null` in several places.
+    getString: (key) => {
+      const v = s.get(key);
+      return typeof v === 'string' ? v : undefined;
+    },
+    getNumber: (key) => {
+      const v = s.get(key);
+      return typeof v === 'number' ? v : undefined;
+    },
+    getBoolean: (key) => {
+      const v = s.get(key);
+      return typeof v === 'boolean' ? v : undefined;
+    },
+    remove: (key) => void s.delete(key),
+    clearAll: () => s.clear(),
+    getAllKeys: () => [...s.keys()],
+    contains: (key) => s.has(key),
+  };
+}
+
+/** Test helper — drop every store. Not part of the real MMKV API. */
+export function __resetAllMMKV(): void {
+  stores.clear();
+}
+
+export default { createMMKV };

--- a/dev/harness/react-native-shim.ts
+++ b/dev/harness/react-native-shim.ts
@@ -1,0 +1,125 @@
+// react-native replacement for Node.
+//
+// react-native's entrypoint is untranspiled Flow/ESM, so jest's CJS runner
+// cannot load it. Transforming the package instead was the alternative and was
+// rejected: it pulls a very large dependency graph through babel to obtain a
+// handful of values, and it drags in native-module registration the harness has
+// no use for.
+//
+// Only the surface mobile's non-UI code paths actually reach is provided
+// (enumerated by grep over services/, context/, hooks/ — not guessed). The UI
+// exports are present as inert placeholders so a module that merely IMPORTS them
+// at top level can still load; a scenario that tries to RENDER is out of scope
+// for this harness by design.
+//
+// Behavioural choices worth knowing, because they shape what scenarios observe:
+//   - AppState is permanently 'active'. Mobile flushes ratchet state on
+//     background; headlessly there is no background, so those paths simply never
+//     fire. Backgrounding bugs stay device-only.
+//   - InteractionManager runs work immediately instead of deferring past
+//     animations. There are no animations here, and deferring would only add
+//     nondeterminism to timing-sensitive DM scenarios.
+
+type Listener = (...args: unknown[]) => void;
+
+const noopSubscription = { remove: () => {} };
+
+export const AppState = {
+  currentState: 'active' as const,
+  addEventListener: (_type: string, _listener: Listener) => noopSubscription,
+  removeEventListener: () => {},
+};
+
+export type AppStateStatus = 'active' | 'background' | 'inactive';
+
+export const Platform = {
+  OS: 'android' as const,
+  Version: 34,
+  select: <T,>(specifics: { android?: T; ios?: T; native?: T; default?: T }): T | undefined =>
+    specifics.android ?? specifics.native ?? specifics.default,
+};
+
+export const InteractionManager = {
+  // Immediate rather than deferred — see header.
+  runAfterInteractions: (task?: () => void) => {
+    task?.();
+    return { then: (cb: () => void) => cb(), done: () => {}, cancel: () => {} };
+  },
+  createInteractionHandle: () => 0,
+  clearInteractionHandle: () => {},
+};
+
+/**
+ * Alert must never silently swallow. On a device it is a visible prompt; here a
+ * swallowed alert would hide a real error path from the scenario, so surface it.
+ */
+export const Alert = {
+  alert: (title: string, message?: string) => {
+    // eslint-disable-next-line no-console
+    console.warn(`[harness] Alert.alert: ${title}${message ? ` — ${message}` : ''}`);
+  },
+};
+
+export const Dimensions = {
+  get: () => ({ width: 400, height: 800, scale: 2, fontScale: 1 }),
+  addEventListener: () => noopSubscription,
+};
+
+export const Linking = {
+  openURL: async () => {},
+  canOpenURL: async () => false,
+  addEventListener: () => noopSubscription,
+  getInitialURL: async () => null,
+};
+
+export const Share = { share: async () => ({ action: 'dismissedAction' }) };
+
+export const StyleSheet = {
+  create: <T,>(styles: T): T => styles,
+  flatten: (style: unknown) => style,
+  absoluteFillObject: {},
+  hairlineWidth: 1,
+};
+
+export const NativeModules: Record<string, unknown> = {};
+
+export const DeviceEventEmitter = {
+  addListener: () => noopSubscription,
+  emit: () => {},
+  removeAllListeners: () => {},
+};
+
+export const useColorScheme = () => 'dark' as const;
+
+// --- inert UI placeholders: importable, not renderable (see header) ---
+export const View = 'View' as unknown as never;
+export const Image = 'Image' as unknown as never;
+export const Animated = {
+  View: 'Animated.View' as unknown as never,
+  Value: class {
+    constructor(public value: number) {}
+    setValue(v: number) { this.value = v; }
+    interpolate() { return this; }
+  },
+  timing: () => ({ start: (cb?: () => void) => cb?.() }),
+  spring: () => ({ start: (cb?: () => void) => cb?.() }),
+};
+export const PanResponder = { create: () => ({ panHandlers: {} }) };
+
+export default {
+  AppState,
+  Platform,
+  InteractionManager,
+  Alert,
+  Dimensions,
+  Linking,
+  Share,
+  StyleSheet,
+  NativeModules,
+  DeviceEventEmitter,
+  useColorScheme,
+  View,
+  Image,
+  Animated,
+  PanResponder,
+};

--- a/dev/harness/securestore-shim.ts
+++ b/dev/harness/securestore-shim.ts
@@ -1,0 +1,92 @@
+// expo-secure-store replacement for Node.
+//
+// The real module is backed by the iOS Keychain / Android Keystore. There is no
+// equivalent here, and there should not be a persistent one: the values mobile
+// puts in SecureStore are ACCOUNT PRIVATE KEYS. Keeping them in memory only
+// means a harness run cannot leave key material on disk by accident.
+//
+// Seeding: a scenario that needs to drive a specific account writes the key in
+// with setItemAsync before exercising the code under test, exactly as onboarding
+// would have. Nothing here reads .env directly — that stays the scenario's job,
+// so key handling is visible at the call site rather than hidden in a shim.
+//
+// ⚠️ Note for whoever wires identity later: mobile REGENERATES the entire device
+// keyset if any one SecureStore item reads as missing (keyService
+// initializeEncryptionKeys). A shim that silently returns null for a key a
+// scenario forgot to seed will therefore mint a NEW device identity and register
+// it — feeding the ghost-device accumulation problem against a real account.
+// Seed completely, or assert before running.
+
+const store = new Map<string, string>();
+
+/** Mirrors SecureStore.WHEN_UNLOCKED etc. Values are irrelevant off-device. */
+export const WHEN_UNLOCKED = 'whenUnlocked';
+export const WHEN_UNLOCKED_THIS_DEVICE_ONLY = 'whenUnlockedThisDeviceOnly';
+export const AFTER_FIRST_UNLOCK = 'afterFirstUnlock';
+export const AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY = 'afterFirstUnlockThisDeviceOnly';
+export const ALWAYS = 'always';
+export const ALWAYS_THIS_DEVICE_ONLY = 'alwaysThisDeviceOnly';
+
+export interface SecureStoreOptions {
+  keychainService?: string;
+  keychainAccessible?: string;
+  requireAuthentication?: boolean;
+}
+
+/**
+ * Keys are namespaced by keychainService when given, because mobile passes
+ * different services for different key classes and the real module keeps those
+ * separate. Collapsing them would let one class overwrite another.
+ */
+const k = (key: string, opts?: SecureStoreOptions) =>
+  opts?.keychainService ? `${opts.keychainService}::${key}` : key;
+
+export async function getItemAsync(
+  key: string,
+  opts?: SecureStoreOptions
+): Promise<string | null> {
+  return store.get(k(key, opts)) ?? null;
+}
+
+/** Synchronous variant — mobile uses this one too. */
+export function getItem(key: string, opts?: SecureStoreOptions): string | null {
+  return store.get(k(key, opts)) ?? null;
+}
+
+export async function setItemAsync(
+  key: string,
+  value: string,
+  opts?: SecureStoreOptions
+): Promise<void> {
+  store.set(k(key, opts), value);
+}
+
+export async function deleteItemAsync(
+  key: string,
+  opts?: SecureStoreOptions
+): Promise<void> {
+  store.delete(k(key, opts));
+}
+
+export async function isAvailableAsync(): Promise<boolean> {
+  return true;
+}
+
+/** Test helper — not part of the real API. */
+export function __resetSecureStore(): void {
+  store.clear();
+}
+
+export default {
+  getItem,
+  getItemAsync,
+  setItemAsync,
+  deleteItemAsync,
+  isAvailableAsync,
+  WHEN_UNLOCKED,
+  WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  AFTER_FIRST_UNLOCK,
+  AFTER_FIRST_UNLOCK_THIS_DEVICE_ONLY,
+  ALWAYS,
+  ALWAYS_THIS_DEVICE_ONLY,
+};

--- a/dev/harness/shim.ts
+++ b/dev/harness/shim.ts
@@ -20,7 +20,18 @@ const g = globalThis as unknown as {
   window?: unknown;
   Buffer?: unknown;
   crypto?: unknown;
+  __DEV__?: boolean;
 };
+
+// React Native's dev global. Metro injects it; in Node nothing does, and modules
+// that branch on it (services/api/config.ts) throw ReferenceError at import.
+//
+// Defaults to TRUE, deliberately. quorum-shared's logger no-ops ENTIRELY when
+// __DEV__ is false, which would make the harness blind to exactly the signals it
+// exists to capture — the desktop harness already lost a round to an observer
+// that could not see decrypt failures. Set HARNESS_DEV=0 to run the
+// production-shaped paths instead, accepting the loss of logging.
+if (g.__DEV__ === undefined) g.__DEV__ = process.env.HARNESS_DEV !== '0';
 
 if (!g.window) g.window = g;
 const w = g.window as { location?: unknown; Buffer?: unknown; crypto?: unknown };

--- a/dev/harness/sqlite-shim.ts
+++ b/dev/harness/sqlite-shim.ts
@@ -1,0 +1,123 @@
+// expo-sqlite replacement for Node, backed by node:sqlite (built in on Node 22).
+//
+// Mobile's message store (services/storage/messagesDb.ts) uses only the
+// SYNCHRONOUS half of expo-sqlite's surface, which maps almost one-to-one onto
+// node:sqlite. The mapped surface was grepped from that file, not guessed:
+//
+//   openDatabaseSync / deleteDatabaseSync
+//   db.execSync / runSync / getAllSync / getFirstSync / prepareSync /
+//   withTransactionSync
+//   stmt.executeSync / finalizeSync
+//
+// ⚠️ SQLCipher is NOT emulated. messagesDb opens with `PRAGMA key = "x'...'"`
+// for encryption at rest; node:sqlite has no such pragma and would throw. Key
+// pragmas are swallowed, so the harness DB is PLAINTEXT. Two consequences:
+//   - encryption-at-rest bugs are invisible here and stay device-only
+//   - harness DB files must never hold real user data (they are in-memory by
+//     default below, which enforces it)
+//
+// Databases are in-memory unless HARNESS_SQLITE_DIR is set. In-memory is the
+// default deliberately: a run should not leave message databases on the
+// developer's machine, and every scenario should start from a known-empty store.
+import { DatabaseSync } from 'node:sqlite';
+import { resolve } from 'node:path';
+
+type Params = unknown[];
+
+/** Swallow SQLCipher pragmas node:sqlite cannot honour. See header. */
+function isCipherPragma(sql: string): boolean {
+  return /^\s*PRAGMA\s+(key|cipher|rekey)/i.test(sql);
+}
+
+export interface SQLiteStatement {
+  executeSync(...params: Params): unknown;
+  finalizeSync(): void;
+}
+
+export interface SQLiteDatabase {
+  execSync(sql: string): void;
+  runSync(sql: string, params?: Params): { changes: number; lastInsertRowId: number };
+  getAllSync<T = unknown>(sql: string, params?: Params): T[];
+  getFirstSync<T = unknown>(sql: string, params?: Params): T | null;
+  prepareSync(sql: string): SQLiteStatement;
+  withTransactionSync(fn: () => void): void;
+  closeSync(): void;
+}
+
+const open = new Map<string, DatabaseSync>();
+
+function location(name: string): string {
+  const dir = process.env.HARNESS_SQLITE_DIR;
+  return dir ? resolve(dir, name) : ':memory:';
+}
+
+export function openDatabaseSync(name: string): SQLiteDatabase {
+  let db = open.get(name);
+  if (!db) {
+    db = new DatabaseSync(location(name));
+    open.set(name, db);
+  }
+  const handle = db;
+
+  return {
+    execSync: (sql) => {
+      // expo's execSync accepts multiple statements; so does node:sqlite's exec.
+      if (isCipherPragma(sql)) return;
+      handle.exec(sql);
+    },
+    runSync: (sql, params = []) => {
+      const r = handle.prepare(sql).run(...(params as never[]));
+      return {
+        changes: Number(r.changes),
+        lastInsertRowId: Number(r.lastInsertRowid),
+      };
+    },
+    getAllSync: <T,>(sql: string, params: Params = []) =>
+      handle.prepare(sql).all(...(params as never[])) as T[],
+    getFirstSync: <T,>(sql: string, params: Params = []) =>
+      (handle.prepare(sql).get(...(params as never[])) as T) ?? null,
+    prepareSync: (sql) => {
+      const stmt = handle.prepare(sql);
+      return {
+        executeSync: (...params: Params) => stmt.run(...(params as never[])),
+        // node:sqlite statements are GC-managed and have no finalize; the no-op
+        // keeps mobile's try/finally cleanup working unchanged.
+        finalizeSync: () => {},
+      };
+    },
+    // expo's withTransactionSync rolls back if the callback throws. node:sqlite
+    // has no wrapper, so drive the transaction explicitly — without the rollback
+    // a failed migration would leave half-written rows, which is exactly the
+    // durability property messagesDb's migration relies on.
+    withTransactionSync: (fn) => {
+      handle.exec('BEGIN');
+      try {
+        fn();
+        handle.exec('COMMIT');
+      } catch (err) {
+        handle.exec('ROLLBACK');
+        throw err;
+      }
+    },
+    closeSync: () => {
+      handle.close();
+      open.delete(name);
+    },
+  };
+}
+
+export function deleteDatabaseSync(name: string): void {
+  const db = open.get(name);
+  if (db) {
+    db.close();
+    open.delete(name);
+  }
+}
+
+/** Test helper — close and drop every database. Not part of the real API. */
+export function __resetAllDatabases(): void {
+  for (const [, db] of open) db.close();
+  open.clear();
+}
+
+export default { openDatabaseSync, deleteDatabaseSync };

--- a/dev/harness/storage-shims.scenario.ts
+++ b/dev/harness/storage-shims.scenario.ts
@@ -1,0 +1,115 @@
+// Offline. Proves the storage shims by driving mobile's REAL storage module,
+// not by testing the shims in isolation.
+//
+// Testing a shim against itself proves nothing — it would pass even if the shim
+// disagreed with what mobile's code actually expects. So this imports
+// services/storage/messagesDb unmodified and exercises its real schema, real
+// SQL and real migration path. If the shim's contract is wrong, that module
+// breaks here rather than three slices later inside a DM scenario.
+//
+// Run: yarn harness
+// Static imports throughout: moduleNameMapper substitutes the shims at
+// RESOLUTION time, so import style is irrelevant to whether they apply. (An
+// earlier draft used dynamic import() for supposed ordering control — it bought
+// nothing and jest's CJS runner rejects it without --experimental-vm-modules.)
+import { __resetAllMMKV, createMMKV } from './mmkv-shim';
+import { __resetAllDatabases, openDatabaseSync } from './sqlite-shim';
+import * as ss from './securestore-shim';
+import * as messagesDb from '@/services/storage/messagesDb';
+import { NativeCryptoProvider } from './wasm-provider-shim';
+
+describe('storage shims (offline)', () => {
+  afterEach(() => {
+    __resetAllDatabases();
+    __resetAllMMKV();
+  });
+
+  it("opens mobile's real message DB and round-trips a message through it", async () => {
+    // messagesDb derives its SQLCipher key from the account ed448 private key in
+    // SecureStore, and returns null if it is absent. Seeding it here mirrors what
+    // onboarding does on a device.
+    //
+    // This is the hazard the securestore shim's header warns about, caught in
+    // practice: an unseeded store looks to mobile like a first run. Here it only
+    // costs a null DB, but on the identity path the same gap makes keyService
+    // regenerate the whole device keyset and register a NEW device — against a
+    // real account, that silently feeds the ghost-device problem. Seed fully.
+    const ed = await new NativeCryptoProvider().generateEd448();
+    const privHex = Buffer.from(new Uint8Array(ed.private_key)).toString('hex');
+    await ss.setItemAsync('quorum.privateKey', privHex);
+
+    const opened = await messagesDb.ensureDb();
+    expect(opened).not.toBeNull();
+
+    const spaceId = 'harness-space';
+    const channelId = 'harness-channel';
+    const message = {
+      messageId: 'msg-1',
+      spaceId,
+      channelId,
+      createdDate: 1_700_000_000_000,
+      modifiedDate: 1_700_000_000_000,
+      content: { type: 'post', senderId: 'sender-1', text: 'stored headlessly' },
+    };
+
+    await messagesDb.saveMessage(message as never);
+
+    const back = await messagesDb.getMessages({ spaceId, channelId, limit: 10 } as never);
+    const rows = (back as { messages?: unknown[] })?.messages ?? (back as unknown[]);
+    expect(Array.isArray(rows) ? rows.length : 0).toBeGreaterThan(0);
+  });
+
+  it('rolls a transaction back when the callback throws', async () => {
+    // messagesDb's migration relies on this: a crash mid-channel must roll back
+    // so the next launch re-migrates cleanly instead of finding half-written
+    // rows. node:sqlite has no withTransactionSync, so the shim drives
+    // BEGIN/COMMIT/ROLLBACK by hand — if that is wrong, durability is silently
+    // gone and only shows up as corruption much later.
+    const d = openDatabaseSync('rollback-test.db');
+    d.execSync('CREATE TABLE t (id INTEGER PRIMARY KEY, v TEXT);');
+    d.runSync('INSERT INTO t (id, v) VALUES (?, ?);', [1, 'committed']);
+
+    expect(() => {
+      d.withTransactionSync(() => {
+        d.runSync('INSERT INTO t (id, v) VALUES (?, ?);', [2, 'rolled back']);
+        throw new Error('boom');
+      });
+    }).toThrow('boom');
+
+    const all = d.getAllSync<{ id: number }>('SELECT id FROM t ORDER BY id;');
+    expect(all.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('swallows SQLCipher pragmas rather than throwing', async () => {
+    // messagesDb opens with `PRAGMA key = "x'...'"`. node:sqlite has no such
+    // pragma and would throw, which would make the DB unopenable here. The
+    // harness DB is therefore PLAINTEXT — encryption at rest stays device-only.
+    const d = openDatabaseSync('cipher-test.db');
+    expect(() => d.execSync(`PRAGMA key = "x'deadbeef'";`)).not.toThrow();
+    expect(() => d.execSync('PRAGMA journal_mode = WAL;')).not.toThrow();
+  });
+
+  it('keeps MMKV type semantics — getString must not return a number', async () => {
+    // Real MMKV does not coerce across types, and mobile branches on `?? null`
+    // in several places. A shim that coerced would make those branches behave
+    // differently here than on device, which is the kind of divergence that
+    // makes a harness untrustworthy.
+    const s = createMMKV({ id: 'types' });
+    s.set('n', 42);
+    expect(s.getString('n')).toBeUndefined();
+    expect(s.getNumber('n')).toBe(42);
+
+    // Same id must return the same store — mobile calls createMMKV at module
+    // scope from several files and relies on sharing.
+    createMMKV({ id: 'types' }).set('shared', 'yes');
+    expect(s.getString('shared')).toBe('yes');
+  });
+
+  it('namespaces SecureStore by keychainService', async () => {
+    await ss.setItemAsync('k', 'a', { keychainService: 'svc-1' });
+    await ss.setItemAsync('k', 'b', { keychainService: 'svc-2' });
+    expect(await ss.getItemAsync('k', { keychainService: 'svc-1' })).toBe('a');
+    expect(await ss.getItemAsync('k', { keychainService: 'svc-2' })).toBe('b');
+    expect(await ss.getItemAsync('k')).toBeNull();
+  });
+});

--- a/jest.harness.config.js
+++ b/jest.harness.config.js
@@ -41,6 +41,33 @@ module.exports = {
   moduleNameMapper: {
     // Mobile's tsconfig path alias, spelled out for jest.
     '^@/(.*)$': '<rootDir>/$1',
+
+    // ---- THE crypto seam ----
+    // Swap mobile's uniffi-backed provider for the WASM one. This is the single
+    // substitution that lets services/ run unmodified: every call site does a
+    // bare `new NativeCryptoProvider()`, so replacing the MODULE replaces the
+    // backend with no app change at all.
+    //
+    // The pattern must catch every spelling in use — './native-provider' from
+    // within services/crypto, '../crypto/native-provider' from siblings, and
+    // '@/services/crypto/native-provider' from elsewhere. It deliberately does
+    // NOT match native-signing-provider, which is a different module.
+    '^(.*/)?native-provider$': '<rootDir>/dev/harness/wasm-provider-shim.ts',
+
+    // ---- native modules that cannot exist in Node ----
+    // Each is a real device API with no Node equivalent. Swapping them here
+    // rather than in app code is what lets mobile's own services/ run unmodified
+    // — no #ifdefs, no injection seams, no test-only branches in shipping code.
+    // react-native's entrypoint is untranspiled Flow/ESM; jest's CJS runner
+    // cannot load it and transforming the package would drag a huge graph
+    // through babel for a handful of values.
+    '^react-native$': '<rootDir>/dev/harness/react-native-shim.ts',
+    '^react-native-mmkv$': '<rootDir>/dev/harness/mmkv-shim.ts',
+    '^expo-secure-store$': '<rootDir>/dev/harness/securestore-shim.ts',
+    '^expo-sqlite$': '<rootDir>/dev/harness/sqlite-shim.ts',
+    // messagesDb imports the /legacy entrypoint; same module either way.
+    '^expo-file-system/legacy$': '<rootDir>/dev/harness/filesystem-shim.ts',
+    '^expo-file-system$': '<rootDir>/dev/harness/filesystem-shim.ts',
     '^@quilibrium/quilibrium-js-sdk-channels$': SDK,
     // SDK is reached via desktop's node_modules, which on this machine is a
     // yarn-link SYMLINK to the SDK source checkout — and that checkout has no


### PR DESCRIPTION
Follows #190. With these shims, **mobile's own storage stack imports and executes headlessly** — `services/storage/messagesDb`, `services/config`, `services/offline/storage` and everything they pull in, unmodified.

## Shims

Each replaces a device API with no Node equivalent:

| module | approach |
|---|---|
| `react-native` | `AppState` / `Platform` / `InteractionManager` / `Alert` + inert UI placeholders. RN's entrypoint is untranspiled Flow, so jest's CJS runner can't load it; transforming the package would drag a huge graph through babel for a handful of values. |
| `react-native-mmkv` | In-memory, **keyed by id** so two `createMMKV` calls with the same id share a store — as the real module does, and as mobile relies on at module scope. |
| `expo-secure-store` | In-memory, namespaced by `keychainService`. **Deliberately never persisted** — these values are account private keys. |
| `expo-sqlite` | `node:sqlite` behind the *synchronous* surface `messagesDb` actually uses (grepped from that file, not guessed). |
| `expo-file-system` | `node:fs` for the calls reached. `downloadAsync` throws rather than silently producing an empty file. |

The crypto seam from #190 is now **actually wired**: a `moduleNameMapper` pattern catching every spelling of `native-provider` in use (`./native-provider`, `../crypto/native-provider`, `@/services/...`) while deliberately not matching `native-signing-provider`.

## Two decisions that shape what scenarios can observe

Both documented at the point of the choice rather than left to be discovered later.

**`__DEV__` defaults to `true`.** `quorum-shared`'s logger no-ops *entirely* when it's false, which would make the harness blind to the very signals it exists to capture. The desktop harness already lost a round to an observer that couldn't see decrypt failures — that's not a hypothetical. `HARNESS_DEV=0` opts out.

**SQLCipher is not emulated.** Key pragmas are swallowed, so the harness DB is plaintext and encryption-at-rest bugs stay device-only. Databases are in-memory unless `HARNESS_SQLITE_DIR` is set, so a run can't leave message databases or key material on disk.

## The scenario tests the shims against mobile, not against themselves

Testing a shim in isolation proves nothing — it'd pass even if the shim disagreed with what mobile's code expects. So it imports the real `messagesDb` and exercises its real schema, real SQL and real migration path.

It also pins two contracts that would otherwise diverge silently:
- **Transaction rollback.** `messagesDb`'s migration depends on a mid-channel crash rolling back cleanly; `node:sqlite` has no `withTransactionSync`, so the shim drives `BEGIN`/`COMMIT`/`ROLLBACK` by hand. Wrong here = silent corruption much later.
- **MMKV type semantics.** Real MMKV doesn't coerce across types and mobile branches on `?? null` in several places. A coercing shim would behave differently here than on device.

## One hazard this surfaced in practice

Writing it hit exactly what the securestore shim's header warns about: **an unseeded store looks to mobile like a first run.** Here it only cost a null DB. On the identity path the same gap makes `keyService` regenerate the entire device keyset and register a **new device** — against a real account, that silently feeds the known ghost-device accumulation problem. Worth remembering when the identity slice lands.

## Risk

- **No app code touched**, no dependencies, no `yarn.lock` change.
- `jest.config.js` untouched.
- **App suite: 13 suites / 108 tests — unchanged and green.**
- **Harness suite: 3 suites / 10 tests — green.**