### PR TITLE
harness: mobile's own transport, over Node's WebSocket

### DIFF
--- a/dev/harness/transport.scenario.ts
+++ b/dev/harness/transport.scenario.ts
@@ -1,0 +1,75 @@
+// NETWORKED. Talks to the production relay. No account, no keys, no writes —
+// it opens a socket, subscribes to a random address that owns nothing, and
+// closes. Nothing is registered and nothing is sent.
+//
+// ─── Why this scenario is the point of the whole harness ────────────────────
+//
+// Issue #183 item 2: frames are handed to ws.send, signed, socket open, and
+// never arrive. Client visibility ends there because below it is React Native's
+// native WebSocket. §26 of the investigation puts the drop at ~80% node-side
+// with exactly that residual unresolved.
+//
+// Mobile's transport is shared's RNWebSocketClient, and at rn-websocket.ts:113
+// it does:
+//
+//     // React Native uses the global WebSocket class
+//     this.ws = new WebSocket(this.url);
+//
+// It constructs the GLOBAL WebSocket. On a device that global is RN's native
+// implementation; under Node it is Node's. So importing the very same client
+// class here swaps the implementation underneath mobile's own transport JS and
+// changes nothing else — the single-variable experiment 29 device rounds could
+// never run, because each of those changed platform, transport and client code
+// together.
+//
+// This scenario only proves the swap connects. Measuring loss across it needs
+// identity + two bots, which is the next slice.
+//
+// Run: yarn harness transport      (skip with HARNESS_OFFLINE=1)
+import { RNWebSocketClient } from '@quilibrium/quorum-shared';
+
+const WS_URL = process.env.QUORUM_WS_URL ?? 'wss://api.quorummessenger.com/ws';
+const OFFLINE = process.env.HARNESS_OFFLINE === '1';
+
+// CI and offline work must not fail on a network scenario.
+const maybe = OFFLINE ? describe.skip : describe;
+
+maybe('transport (networked — production relay)', () => {
+  it("connects with mobile's own RNWebSocketClient over Node's WebSocket", async () => {
+    // The global the client will construct. Asserted rather than assumed: if a
+    // future Node or a stray polyfill removed it, the failure below would look
+    // like a relay problem instead of a missing global.
+    expect(typeof globalThis.WebSocket).toBe('function');
+
+    const client = new RNWebSocketClient({
+      url: WS_URL,
+      // One attempt. An infinite reconnect would turn a relay outage into a
+      // hanging scenario rather than a clear failure.
+      maxReconnectAttempts: 1,
+      reconnectInterval: 1000,
+    });
+
+    const states: string[] = [];
+    client.onStateChange?.((s: string) => states.push(s));
+
+    try {
+      await client.connect();
+      expect(client.state).toBe('connected');
+
+      // Subscribe to an address nobody owns. The relay accepts the listen and
+      // has nothing to deliver, which exercises the send path without creating
+      // any state — no registration, no frames, nothing to clean up.
+      const orphan = 'Qm' + 'h'.repeat(44);
+      await client.listen?.([orphan]);
+
+      // Still connected after a write proves the socket is genuinely open, not
+      // merely reported open by a handshake that the relay then dropped.
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(client.state).toBe('connected');
+    } finally {
+      client.disconnect?.();
+    }
+
+    expect(states).toContain('connected');
+  }, 60_000);
+});


### PR DESCRIPTION
Follows #191. This is the experiment the harness exists to run — now connecting.

## The finding

**No transport shim is needed.** Mobile's transport is shared's `RNWebSocketClient`, and at `rn-websocket.ts:113`:

```js
// React Native uses the global WebSocket class
this.ws = new WebSocket(this.url);
```

It constructs the **global** `WebSocket`. On a device that global is React Native's native implementation; under Node it's Node's. So importing the same client class swaps the implementation beneath mobile's own transport JS and changes nothing else.

That's the single-variable experiment 29 device rounds could never run — each of those varied platform, transport and client code together.

## Why it matters

Issue #183 item 2: frames are handed to `ws.send` — signed, socket open — and never arrive. Client visibility ends there because below it is RN's native WebSocket. §26 puts the drop at ~80% node-side with exactly that residual unresolved:

> client JS visibility ends at `ws.send` into RN's native layer, so a native-layer drop cannot be fully excluded

Running mobile's transport JS over a different WebSocket implementation is how that gets separated.

## What this scenario does

Opens a socket against production, subscribes to an address nobody owns, closes. **No account, no registration, no frames written, nothing to clean up.** It asserts the global exists before constructing (so a missing global fails as itself rather than looking like a relay outage), and re-checks connection state after a write, since a handshake can report open on a socket the relay then drops.

## ⚠️ Scope — what this does NOT show

It proves the swap **connects**. It is not yet evidence about the black hole: measuring loss needs identity plus two bots exchanging frames, which is the next slice. A connected socket says nothing about whether writes survive.

## CI

Networked scenarios honour `HARNESS_OFFLINE=1` and skip rather than fail. Verified both ways.

## Verification

- **App suite: 13 suites / 108 tests — unchanged and green**
- Harness networked: 4 suites / 11 tests green
- Harness with `HARNESS_OFFLINE=1`: 3 suites / 10 tests green, 1 skipped

No app code, no dependencies, no lockfile change.