### PR TITLE
Headless DM harness: two mobile clients exchange DMs in Node, and the loss is measured

### DIFF
--- a/context/WebSocketContext.tsx
+++ b/context/WebSocketContext.tsx
@@ -200,7 +200,12 @@ function deleteProcessedEnvelope(inboxAddress: string, timestamp: number): void 
   }
 }
 
-async function deleteInboxMessages(
+// Exported (no behaviour change) so the headless harness can clear a device
+// inbox before measuring delivery. The relay redelivers un-acked frames
+// indefinitely, so a run that starts on a backlog counts old undecryptable
+// frames as fresh losses. Reusing this rather than reimplementing the signing
+// keeps the harness from drifting away from the real delete path.
+export async function deleteInboxMessages(
   inboxAddress: string,
   timestamps: number[],
   deviceKeyset: DeviceKeyset

--- a/dev/harness/README.md
+++ b/dev/harness/README.md
@@ -1,13 +1,53 @@
-# Headless DM harness (mobile) — slice 1
+# Headless DM harness (mobile)
 
 Run **mobile's own client code** in Node, with no device, no emulator and no
-Metro. Slice 1 proves the toolchain; later slices add identity, transport and
-two-bot DM scenarios.
+Metro.
 
 ```bash
 yarn harness:smoke     # offline, no keys, no network — safe anywhere
-yarn harness           # every scenario
+yarn harness           # every scenario (networked ones hit production)
+yarn harness:dm        # the two-bot DM measurement — see below
 ```
+
+`HARNESS_OFFLINE=1 yarn harness` skips everything networked.
+
+## The measurement
+
+`yarn harness:dm` starts **two processes**, one bot each, pairs them through a
+run directory, exchanges numbered DMs and reports loss per direction:
+
+```
+[dm] A→B: sent=40 arrived=40 loss=0.0%
+[dm] B→A: sent=40 arrived=40 loss=0.0%
+[dm] total: 80/80 delivered
+[dm] no loss.
+```
+
+Knobs: `HARNESS_ROUNDS`, `HARNESS_SEND_INTERVAL_MS`, `HARNESS_SETTLE_MS`.
+Diagnostics: `HARNESS_LOG_DEBUG=1` turns on mobile's own `logger.debug` lines
+(subscriptions, routing); `HARNESS_CRYPTO_DEBUG=1` reports crate-level crypto
+failures with the function that produced them.
+
+**One bot per process, and that is not negotiable.** Mobile reaches storage
+through module singletons, so two bots in one process would share identity and
+ratchet state. `jest.isolateModulesAsync` isolates static require-graphs (proven
+in `two-bot-feasibility.scenario.ts`) but *not* lazy `require()`s, which run
+after the isolate closes — a silent leak that would fuse the two devices being
+compared. See the header of `bot.ts`.
+
+### Reading a result honestly
+
+`leftOnMyInbox` in the per-role summary is the number of frames still queued on
+that bot's device inbox. It is the difference between two very different
+findings: frames still sitting there **arrived and were not consumed** (a
+receive/session problem), while an empty inbox with missing messages means they
+were never posted or went elsewhere. A delivery count alone cannot tell them
+apart — an early run showed 100% "loss" that was in fact 40 frames delivered
+perfectly and refused by the receiver's session.
+
+Also drain before measuring (the scenario does): the relay redelivers un-acked
+frames forever, so a run started on a backlog counts a previous run's
+undecryptable leftovers as fresh losses.
 
 ## Why this exists
 
@@ -96,16 +136,49 @@ the WASM binary, so this is the existing convention rather than a new one.
 
 | file | role |
 |---|---|
-| `shim.ts` | browser globals the SDK bundle touches at import (`window.Buffer`) |
-| `smoke.scenario.ts` | offline: WASM loads, real keys, sign+verify with tamper rejection |
-| `../../jest.harness.config.js` | node env, SDK alias, `*.scenario.ts` matcher |
+| `shim.ts` | browser globals the SDK bundle touches at import; optional debug logging |
+| `babel.harness.js` | app babel config + one transform: lazy `import()` → `require` |
+| `wasm-provider-shim.ts` | the crypto seam — WASM in place of uniffi, plus the native error conventions mobile's code expects |
+| `wasm-signing-shim.ts`, `crypto-barrel-shim.ts` | the other two spellings of that seam |
+| `context-barrel-shim.ts` | narrows `@/context` to the DM contexts |
+| `mmkv-shim.ts`, `securestore-shim.ts`, `sqlite-shim.ts`, `filesystem-shim.ts`, `react-native-shim.ts` | device APIs with no Node equivalent |
+| `identity.ts` | registers/reuses an account through mobile's own onboarding |
+| `bot.ts` | a full headless client: renders mobile's real `WebSocketProvider` |
+| `rendezvous.ts`, `run-two-bots.mjs` | pairs two bot processes and reports loss |
+| `*.scenario.ts` | the scenarios themselves |
+| `../../jest.harness.config.js` | node env, module seams, `*.scenario.ts` matcher |
 
 ## Status
 
-- **Slice 1 — toolchain proven.** WASM loads under mobile's jest; the crate
-  really executes (sign/verify, tampered message rejected). App suite unaffected:
-  13 suites / 108 tests, unchanged.
-- Slices 2-4 (crypto-provider shim, storage shims, DM core extraction, two-bot
-  scenarios) are specced in
-  `quorum-desktop/.agents/tasks/2026-07-27-cross-platform-dm-harness.md` — note
-  that plan lives in the **desktop** repo, because `.agents/` is gitignored here.
+Mobile's real client code runs headlessly end to end: onboarding, connect,
+subscribe, DM send and DM receive. Measured 2026-07-28 on production, two
+throwaway accounts, one device each:
+
+**40 rounds each direction — 80/80 delivered, 0.0% loss, zero decrypt failures,
+both inboxes empty at the end.**
+
+What that does and does not mean: mobile's own send/receive logic does not lose
+these messages when RN's native WebSocket is removed. It moves probability
+toward the native layer; it does not settle it, because a fresh two-device pair
+may simply be the population least likely to show an intermittent, account-aged
+fault. Treat it as one variable eliminated, not a verdict.
+
+Three findings that cost real time and are worth knowing before touching this:
+
+1. **The two crypto backends are not interchangeable at the error level.** They
+   implement the same `CryptoProvider` interface, but mobile's native provider
+   reports a decrypt failure as `{message: [], decryptionError}` and
+   base64-decodes a string `message`, while `WasmCryptoProvider` throws for some
+   errors and passes others through untouched. Mobile's app code is written
+   against the native conventions, so an unbridged WASM provider turned a
+   recoverable failure into `SyntaxError: Unexpected token 'D'` thrown far from
+   its cause. `wasm-provider-shim.ts` now mirrors the native conventions.
+2. **Simultaneous session open forks the pair.** Having both bots send from the
+   same instant failed all 50 messages of a 25-round run on X3DH while every
+   frame arrived perfectly — and the forked state persisted into later runs
+   through retained undecryptable frames. The baseline scenario has one
+   initiator; simultaneous open deserves its own scenario.
+3. **App suite unaffected**: 13 suites / 108 tests, unchanged. `jest.config.js`
+   is untouched, no dependency was added, `yarn.lock` was never modified.
+
+*Last updated: 2026-07-28*

--- a/dev/harness/babel.harness.js
+++ b/dev/harness/babel.harness.js
@@ -1,0 +1,68 @@
+// Babel config for the harness jest run ONLY. The app's babel.config.js is
+// untouched and is reused verbatim here — this file adds exactly one transform
+// on top of it.
+//
+// ── Why ─────────────────────────────────────────────────────────────────────
+//
+// Mobile's DM send path uses lazy `await import(...)` in several places
+// (useSendDirectMessage → useRecipientRegistration, sendEncryptedMessageToAllDevices
+// → the crypto provider). jest's CJS runtime cannot execute a dynamic import
+// without --experimental-vm-modules, and neither babel-preset-expo nor
+// @babel/plugin-transform-modules-commonjs lowers it here (measured, not
+// assumed: the emitted code still contains a bare `import(...)`).
+//
+// The alternatives were worse. --experimental-vm-modules switches jest to real
+// ESM, which does not coexist well with the moduleNameMapper this harness is
+// built on. Adding babel-plugin-dynamic-import-node would mean a new dependency
+// and a yarn.lock change in a repo other people build from — a much larger blast
+// radius than a local transform for a config nothing else reads.
+//
+// ⚠️ Limit worth knowing: `require()` returns module.exports where a real
+// dynamic import resolves to a module NAMESPACE. For babel-compiled modules with
+// named exports — which is every call site on the DM paths — those are the same
+// object. A future `const m = await import('x'); m.default(...)` against a true
+// ESM package would not be, and would need interop added here.
+
+/** Rewrites `import(x)` into `Promise.resolve().then(() => require(x))`. */
+function lowerDynamicImport({ types: t }) {
+  return {
+    name: 'harness-lower-dynamic-import',
+    visitor: {
+      Import(path) {
+        // The Import node is the callee; its parent is the whole `import(x)`
+        // call, which is what has to be replaced.
+        const call = path.parentPath;
+        if (!call.isCallExpression()) return;
+        call.replaceWith(
+          t.callExpression(
+            t.memberExpression(
+              t.callExpression(
+                t.memberExpression(t.identifier('Promise'), t.identifier('resolve')),
+                []
+              ),
+              t.identifier('then')
+            ),
+            [
+              t.arrowFunctionExpression(
+                [],
+                t.callExpression(t.identifier('require'), call.node.arguments)
+              ),
+            ]
+          )
+        );
+      },
+    },
+  };
+}
+
+const appConfig = require('../../babel.config.js');
+
+module.exports = function (api) {
+  const base = appConfig(api);
+  return {
+    ...base,
+    // Prepended, so the app's own plugin order is preserved — reanimated's
+    // plugin must stay last, and it still is.
+    plugins: [lowerDynamicImport, ...(base.plugins ?? [])],
+  };
+};

--- a/dev/harness/bot-connect.scenario.ts
+++ b/dev/harness/bot-connect.scenario.ts
@@ -1,0 +1,51 @@
+// NETWORKED. Mounts a full headless mobile client and lets it bring ITSELF up.
+//
+//   yarn harness bot-connect          (skip with HARNESS_OFFLINE=1)
+//
+// This is the proof that the provider-rendering approach works at all: the bot
+// never calls connect(). It mounts WebSocketProvider authenticated, and mobile's
+// own effect loads the device keys, opens the socket and subscribes to the device
+// inbox. If this passes, mobile's connect path runs headlessly end to end.
+//
+// ⚠️ Talks to the PRODUCTION relay with a throwaway account. See identity.ts.
+import { createBot } from './bot';
+
+const OFFLINE = process.env.HARNESS_OFFLINE === '1';
+const maybe = OFFLINE ? describe.skip : describe;
+
+maybe('bot-connect (networked — production relay)', () => {
+  it('a mounted bot connects and subscribes without being told to', async () => {
+    const bot = await createBot('connect-bot');
+    try {
+      await bot.waitForConnected();
+      expect(bot.connectionState()).toBe('connected');
+
+      // The device must be in the account's registration, read back from the
+      // relay rather than trusted locally — a device missing there is how the
+      // "peer prunes sessions for an unregistered device" failure starts.
+      const reg = await bot.registration();
+      const inboxes = (reg?.device_registrations ?? []).map(
+        (d: { inbox_registration?: { inbox_address?: string } }) =>
+          d.inbox_registration?.inbox_address
+      );
+      expect(inboxes).toContain(bot.identity.inboxAddress);
+
+      // Device count is worth seeing in the log: harness runs that mint a new
+      // device every time would show it climbing, and would also inflate the
+      // send fan-out this bench measures.
+      // eslint-disable-next-line no-console
+      console.log(
+        `[bot-connect] ${bot.identity.address.slice(0, 12)} ` +
+          `devices=${(reg?.device_registrations ?? []).length} ` +
+          `inbox=${bot.identity.inboxAddress.slice(0, 16)}`
+      );
+
+      // Stay up briefly: a socket that connects and immediately drops would
+      // otherwise read as success.
+      await new Promise((r) => setTimeout(r, 3000));
+      expect(bot.connectionState()).toBe('connected');
+    } finally {
+      await bot.stop();
+    }
+  }, 180_000);
+});

--- a/dev/harness/bot.ts
+++ b/dev/harness/bot.ts
@@ -1,0 +1,271 @@
+// A full headless mobile client: mobile's REAL WebSocketProvider (which is where
+// the entire DM receive path lives), its REAL send hook, its REAL storage — with
+// only the device-native leaves shimmed.
+//
+// ── Why this is shaped so differently from desktop's bot ────────────────────
+//
+// Desktop's harness constructs `new MessageService(deps)`: a plain class, no UI.
+// Mobile has no such seam. Its DM receive path is ~4000 lines of useCallback
+// INSIDE WebSocketProvider — handleIncomingMessage, applyDMGroupResults,
+// processMessageQueue. There is no way to call that code without a React tree,
+// and reimplementing it would test the harness rather than the app.
+//
+// So the bot renders the provider. That works because WebSocketProvider renders
+// no native views — it returns a context around its children — and because the
+// provider BOOTSTRAPS ITSELF: mount it with isAuthenticated + a user and its own
+// effect calls connect(), which loads device keys from SecureStore, opens the
+// socket and subscribes to the device inbox. All mobile's code, unmodified.
+//
+// A `Probe` child then calls mobile's own useWebSocket() and
+// useSendDirectMessage() and hands them out, so the bot's send() IS the app's
+// send path — nonce, message-id hash, Ed448 signing, device fan-out and all.
+//
+// ── ONE BOT PER PROCESS. This is not a style choice. ────────────────────────
+//
+// Mobile reaches its storage through module singletons (mmkvStorage,
+// encryptionStateStorage, the messagesDb module, the SecureStore wrapper). Two
+// bots in one process would share every one of them: the second identity would
+// overwrite the first, and their ratchet state would fuse. They would not be two
+// clients.
+//
+// jest.isolateModulesAsync was measured and DOES isolate a static require-graph
+// (see two-bot-feasibility.scenario.ts), but it is not sufficient here: app code
+// also reaches storage through LAZY requires — services/crypto/initEnvelopeGuard
+// does `require('react-native-mmkv')` at call time — which run after the isolate
+// closes and therefore resolve against the shared registry. That leak is silent,
+// and silent cross-talk between the two "devices" is the one failure this bench
+// must never have.
+//
+// Process isolation has no such holes, and it is also what the thing being
+// modelled actually is: a device is a process. Two bots ⇒ two processes, paired
+// by rendezvous.ts.
+import React from 'react';
+import { act } from 'react';
+import TestRenderer from 'react-test-renderer';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { Message, UserRegistration } from '@quilibrium/quorum-shared';
+import AuthContext, { type UserInfo } from '@/context/AuthContext';
+import StorageContext from '@/context/StorageContext';
+import { WebSocketProvider, useWebSocket, deleteInboxMessages } from '@/context/WebSocketContext';
+import { getApiConfig } from '@/services/api/config';
+import { getDeviceKeyset } from '@/services/onboarding/secureStorage';
+import { useSendDirectMessage } from '@/hooks/chat/useSendDirectMessage';
+import { getMMKVAdapter } from '@/services/storage/mmkvAdapter';
+import { getQuorumClient } from '@/services/api/quorumClient';
+import { loadOrCreateIdentity, type HarnessIdentity } from './identity';
+
+/**
+ * Timestamps of every frame queued on a device inbox.
+ *
+ * Mobile's own client has no inbox FETCH — the app only ever receives frames
+ * pushed over the socket, so there is nothing here to reuse. The relay does
+ * expose the endpoint (desktop's client wraps it as getInbox), so the harness
+ * reads it directly. Deletes still go through mobile's own signed path.
+ */
+async function fetchInboxTimestamps(inboxAddress: string): Promise<number[]> {
+  const res = await fetch(`${getApiConfig().baseUrl}/inbox/${inboxAddress}`);
+  if (!res.ok) throw new Error(`[harness] inbox fetch failed: ${res.status}`);
+  const body: unknown = await res.json();
+  const frames = (Array.isArray(body) ? body : ((body as { data?: unknown })?.data ?? [])) as {
+    timestamp: number;
+  }[];
+  return frames.map((f) => f.timestamp).filter((t) => typeof t === 'number');
+}
+
+/** DM conversation ids are `<partner>/<partner>` — the app's own convention. */
+export const conversationIdFor = (partnerAddress: string) =>
+  `${partnerAddress}/${partnerAddress}`;
+
+export interface MobileBot {
+  identity: HarnessIdentity;
+  /** Every message mobile's own code persisted, in the order it persisted them. */
+  captured: Message[];
+  /** Fires as each message is persisted (received, or locally saved on send). */
+  onSaved?: (m: Message) => void;
+  connectionState(): string;
+  /** Resolves once the provider's own connect() has reached 'connected'. */
+  waitForConnected(timeoutMs?: number): Promise<void>;
+  /** Send a DM through mobile's real useSendDirectMessage mutation. */
+  send(toAddress: string, text: string): Promise<void>;
+  /** Registration as the relay currently reports it — device count included. */
+  registration(): Promise<UserRegistration | null>;
+  /**
+   * Fetch and delete everything queued on this bot's device inbox. Returns how
+   * many were removed.
+   *
+   * Un-acked frames are redelivered on every listen, so without this a run
+   * begins on whatever a previous run left undecryptable and counts those as
+   * fresh losses. Desktop's harness drains for the same reason.
+   */
+  drainInbox(): Promise<number>;
+  /**
+   * How many frames are sitting on this bot's device inbox right now, without
+   * removing them.
+   *
+   * This is what separates the two very different explanations for a missing
+   * message: frames still queued here reached the relay and were never taken by
+   * this client (a subscribe/push problem), while an empty inbox means they
+   * were consumed — or never posted at all. Guessing between those from a
+   * delivery count alone is not possible.
+   */
+  inboxDepth(): Promise<number>;
+  stop(): Promise<void>;
+}
+
+/**
+ * react-test-renderer refuses to mount outside act() when this is set, but React
+ * also WARNS when a state update lands outside act() while it is set — and this
+ * bot's updates arrive from a socket, not from test code. So it is enabled only
+ * around mount/unmount and disabled in between, which keeps the mount legal
+ * without burying a real run in act() warnings.
+ */
+function setActEnvironment(on: boolean): void {
+  (globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = on;
+}
+
+export async function createBot(
+  name: string,
+  opts: { privateKeyHex?: string } = {}
+): Promise<MobileBot> {
+  // Registers the account if new, and seeds SecureStore so the provider's
+  // initializeDeviceKeys finds an existing keyset instead of minting a device.
+  const identity = await loadOrCreateIdentity(name, opts);
+
+  const captured: Message[] = [];
+  const bot: Partial<MobileBot> = { identity, captured };
+
+  // Capture seam: tee the storage adapter's saveMessage. Every DM the receive
+  // path keeps funnels through it, so what lands in `captured` is exactly the
+  // Message object mobile's own code chose to persist — no parallel bookkeeping
+  // that could disagree with the app. Patching the singleton is safe precisely
+  // because this process holds one bot (see header).
+  const adapter = getMMKVAdapter();
+  const origSave = adapter.saveMessage.bind(adapter);
+  (adapter as unknown as { saveMessage: typeof adapter.saveMessage }).saveMessage = async (
+    message: Message,
+    ...rest: unknown[]
+  ) => {
+    captured.push(message);
+    (bot as MobileBot).onSaved?.(message);
+    return (origSave as (...a: unknown[]) => Promise<void>)(message, ...rest);
+  };
+
+  const user: UserInfo = {
+    address: identity.address,
+    // QNS-only; no DM path reads it. Left empty rather than faked into something
+    // that looks like a real Quilibrium address.
+    quilibriumAddress: '',
+    publicKey: identity.publicKeyHex,
+    displayName: name,
+    privacyLevel: 'standard',
+  };
+
+  // Only the fields the DM paths touch are real. The rest throw if reached, so a
+  // path that quietly depends on auth behaviour cannot pass unnoticed.
+  const notUsed = (fn: string) => () => {
+    throw new Error(`[harness] AuthContext.${fn} is not implemented for the bot`);
+  };
+  const auth = {
+    authState: 'authenticated' as const,
+    user,
+    isAuthenticated: true,
+    isLoading: false,
+    farcasterAuthToken: null,
+    signIn: notUsed('signIn'),
+    signOut: notUsed('signOut'),
+    updateProfile: notUsed('updateProfile'),
+    signMessage: notUsed('signMessage'),
+    refreshFarcasterToken: notUsed('refreshFarcasterToken'),
+  };
+
+  let ws: ReturnType<typeof useWebSocket> | null = null;
+  let sender: ReturnType<typeof useSendDirectMessage> | null = null;
+
+  const Probe = () => {
+    // Reassigned every render, so reads below always see the current value —
+    // connectionState in particular changes as the socket comes up.
+    ws = useWebSocket();
+    sender = useSendDirectMessage();
+    return null;
+  };
+
+  const queryClient = new QueryClient({
+    // A bench must not hide a failed fetch behind a retry that masks timing.
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+
+  const tree = React.createElement(
+    QueryClientProvider,
+    { client: queryClient },
+    React.createElement(
+      AuthContext.Provider,
+      { value: auth },
+      React.createElement(
+        StorageContext.Provider,
+        { value: adapter },
+        // Mounting authenticated is what triggers the provider's own connect
+        // effect. The bot never calls connect() itself.
+        React.createElement(WebSocketProvider, null, React.createElement(Probe, null))
+      )
+    )
+  );
+
+  let renderer: { unmount: () => void } | undefined;
+  setActEnvironment(true);
+  await act(async () => {
+    renderer = TestRenderer.create(tree) as unknown as { unmount: () => void };
+  });
+  setActEnvironment(false);
+
+  const full: MobileBot = {
+    identity,
+    captured,
+    connectionState: () => (ws?.connectionState as string) ?? 'unknown',
+    waitForConnected: async (timeoutMs = 60_000) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        if (ws?.isConnected) return;
+        await new Promise((r) => setTimeout(r, 250));
+      }
+      throw new Error(
+        `[harness] ${name} did not connect within ${timeoutMs}ms ` +
+          `(state=${ws?.connectionState ?? 'unknown'})`
+      );
+    },
+    send: async (toAddress: string, text: string) => {
+      if (!sender) throw new Error('[harness] send hook not mounted');
+      // Only the three required params: the hook fetches both registrations and
+      // builds the device fan-out itself, which is the behaviour under test.
+      await sender.mutateAsync({
+        conversationId: conversationIdFor(toAddress),
+        recipientAddress: toAddress,
+        text,
+      });
+    },
+    registration: async () =>
+      (await getQuorumClient().fetchUserRegistration(identity.address, {
+        fresh: true,
+      })) as UserRegistration | null,
+    inboxDepth: async () => (await fetchInboxTimestamps(identity.inboxAddress)).length,
+    drainInbox: async () => {
+      const timestamps = await fetchInboxTimestamps(identity.inboxAddress);
+      if (timestamps.length) {
+        const keyset = await getDeviceKeyset();
+        if (!keyset) throw new Error('[harness] no device keyset to sign the inbox delete');
+        await deleteInboxMessages(identity.inboxAddress, timestamps, keyset);
+      }
+      return timestamps.length;
+    },
+    stop: async () => {
+      ws?.disconnect();
+      setActEnvironment(true);
+      await act(async () => {
+        renderer?.unmount();
+      });
+      setActEnvironment(false);
+    },
+  };
+
+  Object.assign(bot, full);
+  return bot as MobileBot;
+}

--- a/dev/harness/context-barrel-shim.ts
+++ b/dev/harness/context-barrel-shim.ts
@@ -1,0 +1,59 @@
+// Replacement for mobile's `@/context` barrel.
+//
+// The barrel re-exports EVERY context, so importing it for one hook drags in all
+// of them. useSendDirectMessage — squarely on the DM send path — imports
+// `{ useAuth, useWebSocket }` from it, and that single line pulls
+// OnboardingContext (→ expo-router, untransformable JSX in node_modules) and the
+// two calling contexts (→ WebRTC native modules). None of it is reachable from a
+// DM.
+//
+// So this re-exports the REAL implementations of the three contexts the DM paths
+// use, straight from their own modules, and omits the rest. The app code is
+// unchanged; only the barrel's breadth is narrowed.
+//
+// ⚠️ The omitted exports are not silently absent — reaching one throws by name.
+// A silent `undefined` would surface later as a confusing "not a function" deep
+// inside app code, and a scenario that genuinely needs a call context should say
+// so loudly rather than appear to work.
+export {
+  StorageProvider,
+  useStorageAdapter,
+} from '@/context/StorageContext';
+export {
+  AuthProvider,
+  useAuth,
+  useUser,
+  useIsAuthenticated,
+} from '@/context/AuthContext';
+export type {
+  AuthState,
+  PrivacyLevel,
+  FarcasterInfo,
+  UserInfo,
+} from '@/context/AuthContext';
+export {
+  WebSocketProvider,
+  useWebSocket,
+  useWebSocketConnection,
+} from '@/context/WebSocketContext';
+
+function omitted(name: string): never {
+  throw new Error(
+    `[harness] ${name} is not available: the harness narrows the @/context ` +
+      `barrel to the DM contexts (Storage, Auth, WebSocket). ${name} belongs to ` +
+      `a UI or calling context whose module graph cannot load in Node. If a ` +
+      `scenario genuinely needs it, widen dev/harness/context-barrel-shim.ts ` +
+      `and expect to shim its native dependencies.`
+  );
+}
+
+export const ApiClientProvider = () => omitted('ApiClientProvider');
+export const useApiClient = () => omitted('useApiClient');
+export const useApiClientContext = () => omitted('useApiClientContext');
+export const OnboardingProvider = () => omitted('OnboardingProvider');
+export const useOnboarding = () => omitted('useOnboarding');
+export const useOnboardingState = () => omitted('useOnboardingState');
+export const CallProvider = () => omitted('CallProvider');
+export const useCall = () => omitted('useCall');
+export const SpaceCallProvider = () => omitted('SpaceCallProvider');
+export const useSpaceCall = () => omitted('useSpaceCall');

--- a/dev/harness/crypto-barrel-shim.ts
+++ b/dev/harness/crypto-barrel-shim.ts
@@ -1,0 +1,12 @@
+// Replacement for mobile's `services/crypto` barrel.
+//
+// The barrel re-exports the two providers from their own modules. Those modules
+// are individually mapped to the WASM shims, but an import of the BARREL bypasses
+// both patterns and reaches the real files — which load the uniffi native module
+// and cannot exist in Node. AuthContext imports this way.
+//
+// Re-exporting the shims here closes that hole. Keep this in sync with
+// services/crypto/index.ts: if the barrel grows an export, add it here or an
+// importer gets `undefined` with no explanation.
+export { NativeCryptoProvider } from './wasm-provider-shim';
+export { NativeSigningProvider } from './wasm-signing-shim';

--- a/dev/harness/dm-two-bot.scenario.ts
+++ b/dev/harness/dm-two-bot.scenario.ts
@@ -1,0 +1,200 @@
+// NETWORKED. The measurement this whole harness was built for: two headless
+// mobile clients exchange numbered DMs and count what actually arrives.
+//
+//   yarn harness:dm                 (runs BOTH sides; do not invoke directly)
+//
+// One process per bot — this file runs twice, with HARNESS_ROLE=a and =b. Both
+// sides run mobile's real client code; the only thing that is not mobile's is
+// the WebSocket implementation underneath, which here is Node's rather than
+// React Native's.
+//
+// ── What a result means ────────────────────────────────────────────────────
+//
+// This isolates the residual that the transport investigation could not close:
+// client-side visibility ends at ws.send into RN's native layer, so a drop
+// inside that layer could not be excluded. Removing RN's socket while keeping
+// every other line of mobile's code is the experiment that separates them.
+//
+//   loss ≈ 0 both directions  ⟹ mobile's own send/receive logic is not losing
+//     these messages. Attention moves to RN's native WebSocket (and to the node
+//     write path, which desktop's harness already exercised at 0% loss).
+//   loss > 0                  ⟹ RN native is exonerated for that share, and
+//     there is now a headless, re-runnable repro of the real defect.
+//
+// Neither answer is proof on its own — a fresh throwaway pair may simply be the
+// population least likely to exhibit an intermittent, account-aged fault. Read
+// it as moving probability, not settling the question.
+//
+// ⚠️ Talks to the PRODUCTION relay with throwaway accounts. See identity.ts.
+import { createBot, type MobileBot } from './bot';
+import { awaitPeer, publish, waitUntil, type Role } from './rendezvous';
+
+const ROUNDS = Number(process.env.HARNESS_ROUNDS ?? 20);
+const SEND_INTERVAL_MS = Number(process.env.HARNESS_SEND_INTERVAL_MS ?? 1500);
+const SETTLE_MS = Number(process.env.HARNESS_SETTLE_MS ?? 20_000);
+
+const ROLE = (process.env.HARNESS_ROLE ?? '') as Role;
+const OFFLINE = process.env.HARNESS_OFFLINE === '1';
+const maybe = OFFLINE || (ROLE !== 'a' && ROLE !== 'b') ? describe.skip : describe;
+
+interface Hello {
+  address: string;
+  inboxAddress: string;
+  readyAt: number;
+}
+
+/** `A→B #7` / `B→A #7` — the numbering is what makes loss countable per message. */
+const label = (from: Role, n: number) => (from === 'a' ? `A→B #${n}` : `B→A #${n}`);
+const parse = (text: string): { from: Role; n: number } | null => {
+  const m = /^([AB])→[AB] #(\d+)$/.exec(text);
+  if (!m) return null;
+  return { from: m[1] === 'A' ? 'a' : 'b', n: Number(m[2]) };
+};
+
+function textOf(m: { content?: { type?: string; text?: string } }): string {
+  return m.content?.type === 'post' ? (m.content.text ?? '') : '';
+}
+
+maybe(`dm-two-bot (role ${ROLE} — production relay)`, () => {
+  it('exchanges numbered DMs with the peer process and counts arrivals', async () => {
+    const peer: Role = ROLE === 'a' ? 'b' : 'a';
+    const bot: MobileBot = await createBot(`dm-bot-${ROLE}`);
+
+    // Numbers this side RECEIVED from the peer, deduped: the relay redelivers
+    // un-acked frames, so a raw arrival count would overstate delivery. A set of
+    // distinct message numbers is the honest measure of "did it get through".
+    const receivedFromPeer = new Set<number>();
+    const sentByMe: number[] = [];
+
+    try {
+      await bot.waitForConnected();
+
+      // Clear the device inbox BEFORE pairing. Un-acked frames are redelivered
+      // on every listen, so a previous run's undecryptable leftovers would
+      // otherwise arrive during this one — and since they carry no readable
+      // text they cannot be told apart from this run's traffic by content. The
+      // first measured runs saw exactly that: six failures whose timestamps
+      // belonged to a run fifteen minutes earlier.
+      // Device count is load-bearing, not decoration: a send fans out to EVERY
+      // registered device, so a stale device makes every message produce frames
+      // nobody holds keys for. Printing it here means a run can never be read
+      // without knowing how many devices were in play.
+      const myReg = await bot.registration();
+      // eslint-disable-next-line no-console
+      console.log(
+        `[dm-two-bot ${ROLE}] devices=${(myReg?.device_registrations ?? []).length} ` +
+          `myInbox=${bot.identity.inboxAddress.slice(0, 16)}`
+      );
+
+      const drained = await bot.drainInbox();
+      if (drained > 0) {
+        // eslint-disable-next-line no-console
+        console.log(`[dm-two-bot ${ROLE}] drained ${drained} stale frame(s) before starting`);
+      }
+
+      publish(ROLE, 'hello', {
+        address: bot.identity.address,
+        inboxAddress: bot.identity.inboxAddress,
+        readyAt: Date.now(),
+      } satisfies Hello);
+
+      const theirs = await awaitPeer<Hello>(ROLE, 'hello');
+      const mine = { readyAt: Date.now() };
+
+      // Both sides derive the same instant from the same two numbers, so neither
+      // starts sending before the other is listening. A bot that began early
+      // would post frames to an unsubscribed inbox and count them as lost.
+      const startAt = Math.max(theirs.readyAt, mine.readyAt) + 5_000;
+      const endAt = startAt + ROUNDS * SEND_INTERVAL_MS + SETTLE_MS;
+
+      // eslint-disable-next-line no-console
+      console.log(
+        `[dm-two-bot ${ROLE}] me=${bot.identity.address.slice(0, 12)} ` +
+          `peer=${theirs.address.slice(0, 12)} rounds=${ROUNDS}`
+      );
+
+      const trySend = async (n: number) => {
+        try {
+          await bot.send(theirs.address, label(ROLE, n));
+          sentByMe.push(n);
+        } catch (err) {
+          // A send that throws is a different failure from a message that
+          // vanishes silently, and conflating them would misattribute the loss.
+          // eslint-disable-next-line no-console
+          console.error(`[dm-two-bot ${ROLE}] send #${n} threw:`, (err as Error).message);
+        }
+      };
+
+      bot.onSaved = (m) => {
+        const text = textOf(m);
+        const tag = text ? parse(text) : null;
+        // Only the peer's messages count as arrivals — the save seam also fires
+        // for this bot's own outgoing messages, which would otherwise inflate
+        // the received count to a perfect score no matter what the wire did.
+        if (!tag || tag.from !== peer) return;
+        const isNew = !receivedFromPeer.has(tag.n);
+        receivedFromPeer.add(tag.n);
+        // B answers each distinct message once. Replying on a redelivery would
+        // send the same number twice and corrupt the sent list.
+        if (ROLE === 'b' && isNew) void trySend(tag.n);
+      };
+
+      await waitUntil(startAt);
+
+      // ONE initiator. Both sides sending from the same instant looked like the
+      // natural design and was wrong: it makes the pair establish sessions in
+      // both directions simultaneously, and a 25-round run failed all 50
+      // messages on X3DH while the frames themselves arrived perfectly. That is
+      // a session-establishment race, not transport loss, and mixing the two
+      // makes the number meaningless.
+      //
+      // So A initiates and B echoes each message it receives. Both directions
+      // are still measured — B's replies traverse the wire independently — but
+      // only one side opens the session, which is also how a real conversation
+      // starts. (Simultaneous open is worth a scenario of its own; it is a real
+      // and interesting case, just not this baseline.)
+      if (ROLE === 'a') {
+        for (let n = 1; n <= ROUNDS; n++) {
+          await trySend(n);
+          await waitUntil(startAt + n * SEND_INTERVAL_MS);
+        }
+      }
+
+      await waitUntil(endAt);
+
+      publish(ROLE, 'result', {
+        role: ROLE,
+        address: bot.identity.address,
+        sent: sentByMe,
+        received: [...receivedFromPeer].sort((x, y) => x - y),
+      });
+
+      // A bare "received 0" cannot distinguish "nothing arrived" from "arrived
+      // but was not recognised", and those point at completely different
+      // suspects. The breakdown of what the app actually persisted separates
+      // them.
+      const leftOnInbox = await bot.inboxDepth();
+      const kinds = new Map<string, number>();
+      for (const m of bot.captured) {
+        const k = (m.content as { type?: string } | undefined)?.type ?? '<none>';
+        kinds.set(k, (kinds.get(k) ?? 0) + 1);
+      }
+      // eslint-disable-next-line no-console
+      console.log(
+        `[dm-two-bot ${ROLE}] sent=${sentByMe.length}/${ROUNDS} ` +
+          `received_from_peer=${receivedFromPeer.size} ` +
+          `persisted=${bot.captured.length} ` +
+          `leftOnMyInbox=${leftOnInbox} ` +
+          `kinds={${[...kinds].map(([k, v]) => `${k}:${v}`).join(',')}} ` +
+          `texts=[${bot.captured.map(textOf).filter(Boolean).slice(0, 12).join('|')}]`
+      );
+
+      // Local assertion only. The pass/fail on LOSS is the orchestrator's, because
+      // only it sees both sides — this side cannot know how many the peer sent.
+      // B's send count is driven by what arrives, so only A's is fixed.
+      if (ROLE === 'a') expect(sentByMe.length).toBe(ROUNDS);
+    } finally {
+      await bot.stop();
+    }
+  }, 60 * 60 * 1000);
+});

--- a/dev/harness/identity.ts
+++ b/dev/harness/identity.ts
@@ -1,0 +1,164 @@
+// Identity for a headless bot, driven through mobile's REAL onboarding code.
+//
+// Nothing here reimplements key derivation or registration: keyPairFromHex,
+// deriveAddress, initializeEncryptionKeys and uploadUserRegistration are
+// mobile's own, unchanged. This file only supplies what a device would have
+// supplied — a seeded SecureStore — and persists the result so re-runs reuse it.
+//
+// ─── Why persistence is not optional ────────────────────────────────────────
+//
+// initializeEncryptionKeys returns the existing device keyset when ALL FIVE
+// SecureStore items are present, and regenerates the whole thing when any one is
+// missing. uploadUserRegistration then MERGES the new device into the account's
+// registration and never removes the old entry.
+//
+// So a harness that did not persist would mint and register a brand-new device
+// on every run, permanently. That is the ghost-device accumulation problem the
+// investigation already documents (deviceCount: 11 seen), and it makes every
+// send fan out wider — the canonical desktop run measured ~9 frames per message
+// on real accounts. A bench that inflates the very quantity it is measuring is
+// worse than no bench.
+//
+// ⚠️ Account private keys are NEVER written to .state/. Only the device keyset
+// is. A key supplied via env is re-read from env each run, so .state/ can be
+// deleted at any time without losing account access — and cannot leak one.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import {
+  deriveAddress,
+  initializeEncryptionKeys,
+  keyPairFromHex,
+  uploadUserRegistration,
+  type DeviceEncryptionKeyset,
+} from '@/services/onboarding/keyService';
+import {
+  storeIdentityX448,
+  storeInboxAddress,
+  storeInboxEncryptionKey,
+  storeInboxSigningKey,
+  storePreKey,
+  storePrivateKey,
+  storePublicKey,
+} from '@/services/onboarding/secureStorage';
+import { NativeCryptoProvider } from './wasm-provider-shim';
+
+const STATE_DIR = resolve(__dirname, '.state');
+
+export interface HarnessIdentity {
+  name: string;
+  /** Account address, derived by mobile's own deriveAddress. */
+  address: string;
+  publicKeyHex: string;
+  privateKeyHex: string;
+  keyset: DeviceEncryptionKeyset;
+  /** This device's inbox — where frames addressed to this bot arrive. */
+  inboxAddress: string;
+}
+
+interface PersistedState {
+  /** Present ONLY for generated throwaways. Never written for env-supplied keys. */
+  privateKeyHex?: string;
+  keyset: DeviceEncryptionKeyset;
+}
+
+const statePath = (name: string) => resolve(STATE_DIR, `${name}.json`);
+
+function readState(name: string): PersistedState | null {
+  const p = statePath(name);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as PersistedState;
+  } catch {
+    // A corrupt state file must not silently mint a new device — that is the
+    // exact path to a ghost. Surface it instead.
+    throw new Error(
+      `[harness] ${p} is unreadable. Delete it deliberately if you accept ` +
+        `registering a NEW device for "${name}", or restore it.`
+    );
+  }
+}
+
+function writeState(name: string, state: PersistedState): void {
+  mkdirSync(STATE_DIR, { recursive: true });
+  writeFileSync(statePath(name), JSON.stringify(state, null, 2), 'utf8');
+}
+
+/** Seed every SecureStore item a device would hold, so mobile does not regenerate. */
+async function seedSecureStore(
+  privateKeyHex: string,
+  publicKeyHex: string,
+  keyset: DeviceEncryptionKeyset
+): Promise<void> {
+  const j = (v: number[]) => JSON.stringify(v);
+  await storePrivateKey(privateKeyHex);
+  await storePublicKey(publicKeyHex);
+  await storeIdentityX448(j(keyset.identityKey.privateKey), j(keyset.identityKey.publicKey));
+  await storePreKey(j(keyset.preKey.privateKey), j(keyset.preKey.publicKey));
+  await storeInboxEncryptionKey(
+    j(keyset.inboxEncryptionKey.privateKey),
+    j(keyset.inboxEncryptionKey.publicKey)
+  );
+  await storeInboxSigningKey(
+    j(keyset.inboxSigningKey.privateKey),
+    j(keyset.inboxSigningKey.publicKey)
+  );
+  await storeInboxAddress(keyset.inboxAddress);
+}
+
+/**
+ * Load a bot's identity, or create and register one.
+ *
+ * @param name       state file name — stable across runs, so the device is reused
+ * @param privateKeyHex  an existing account key (env). Omit to mint a throwaway.
+ */
+export async function loadOrCreateIdentity(
+  name: string,
+  opts: { privateKeyHex?: string } = {}
+): Promise<HarnessIdentity> {
+  const persisted = readState(name);
+  const fromEnv = Boolean(opts.privateKeyHex);
+
+  // Account key: env wins, then persisted throwaway, then mint a new one.
+  let privateKeyHex = opts.privateKeyHex ?? persisted?.privateKeyHex;
+  if (!privateKeyHex) {
+    const ed = await new NativeCryptoProvider().generateEd448();
+    privateKeyHex = Buffer.from(new Uint8Array(ed.private_key)).toString('hex');
+  }
+
+  // Mobile's own derivation — not reimplemented here.
+  const pair = keyPairFromHex(privateKeyHex);
+  const publicKeyHex =
+    typeof pair.publicKey === 'string'
+      ? pair.publicKey
+      : Buffer.from(pair.publicKey as unknown as Uint8Array).toString('hex');
+  const address = deriveAddress(pair.publicKey as never);
+
+  // Seed BEFORE initializeEncryptionKeys: with all five items present it returns
+  // the existing keyset, and only generates when something is missing.
+  if (persisted?.keyset) {
+    await seedSecureStore(privateKeyHex, publicKeyHex, persisted.keyset);
+  } else {
+    await storePrivateKey(privateKeyHex);
+    await storePublicKey(publicKeyHex);
+  }
+
+  const keyset = await initializeEncryptionKeys(publicKeyHex);
+
+  // Persist the DEVICE keyset always; the account key only when we minted it.
+  writeState(name, {
+    ...(fromEnv ? {} : { privateKeyHex }),
+    keyset,
+  });
+
+  // Registration merges this device into the account, exactly as onboarding does.
+  await uploadUserRegistration(address, publicKeyHex, privateKeyHex, keyset);
+
+  return {
+    name,
+    address,
+    publicKeyHex,
+    privateKeyHex,
+    keyset,
+    inboxAddress: keyset.inboxAddress,
+  };
+}

--- a/dev/harness/ping.scenario.ts
+++ b/dev/harness/ping.scenario.ts
@@ -1,0 +1,65 @@
+// NETWORKED. Registers a throwaway account on PRODUCTION and subscribes to its
+// device inbox — the full identity path, through mobile's own onboarding code.
+//
+// This is the last piece before two bots can exchange DMs. It proves mobile's
+// real keyService + quorumClient + transport work headlessly end to end:
+// derive → register → connect → listen.
+//
+// ⚠️ Creates a REAL registration on the live relay. Throwaway account only. The
+// device keyset persists to .state/, so re-runs reuse the same device instead of
+// registering a new one each time — see identity.ts for why that matters.
+//
+// Run: yarn harness ping          (skip with HARNESS_OFFLINE=1)
+import { RNWebSocketClient } from '@quilibrium/quorum-shared';
+import { loadOrCreateIdentity } from './identity';
+import { getQuorumClient } from '@/services/api/quorumClient';
+
+const WS_URL = process.env.QUORUM_WS_URL ?? 'wss://api.quorummessenger.com/ws';
+const OFFLINE = process.env.HARNESS_OFFLINE === '1';
+const maybe = OFFLINE ? describe.skip : describe;
+
+maybe('ping (networked — production relay)', () => {
+  it('registers a throwaway account and subscribes to its inbox', async () => {
+    // Stable name → same device across runs. Changing it registers a new device.
+    const bot = await loadOrCreateIdentity('ping-bot');
+
+    expect(bot.address).toMatch(/^Qm/);
+    expect(bot.inboxAddress).toMatch(/^Qm/);
+
+    // The relay is the source of truth, not our local state: read the
+    // registration back and confirm this device is actually in it. Without this
+    // the test would pass on a silently failed upload — and a device missing
+    // from the registration is precisely how the investigation's "desktop prunes
+    // sessions for an unregistered device" failure begins.
+    const client = getQuorumClient();
+    const reg = await client.fetchUserRegistration(bot.address, { fresh: true });
+    expect(reg).toBeTruthy();
+
+    const devices = reg?.device_registrations ?? [];
+    const inboxes = devices.map(
+      (d: { inbox_registration?: { inbox_address?: string } }) =>
+        d.inbox_registration?.inbox_address
+    );
+    expect(inboxes).toContain(bot.inboxAddress);
+
+    // Re-running must NOT add a device. This assertion is the guard against the
+    // harness itself feeding ghost-device accumulation.
+    const again = await loadOrCreateIdentity('ping-bot');
+    expect(again.inboxAddress).toBe(bot.inboxAddress);
+
+    const after = await client.fetchUserRegistration(bot.address, { fresh: true });
+    expect((after?.device_registrations ?? []).length).toBe(devices.length);
+
+    // Now subscribe, over mobile's own transport.
+    const ws = new RNWebSocketClient({ url: WS_URL, maxReconnectAttempts: 1 });
+    try {
+      await ws.connect();
+      expect(ws.state).toBe('connected');
+      await ws.listen?.([bot.inboxAddress]);
+      await new Promise((r) => setTimeout(r, 1500));
+      expect(ws.state).toBe('connected');
+    } finally {
+      ws.disconnect?.();
+    }
+  }, 180_000);
+});

--- a/dev/harness/rendezvous.ts
+++ b/dev/harness/rendezvous.ts
@@ -1,0 +1,84 @@
+// File-based pairing for two bots that live in SEPARATE PROCESSES.
+//
+// Two bots cannot share a process (see bot.ts — mobile's storage is module
+// singletons, and lazy requires defeat jest's module isolation), so the pair is
+// two jest runs coordinated through disk. That is enough: the only things the
+// two sides must agree on are each other's addresses and when to start.
+//
+// Everything lives under a per-run directory keyed by HARNESS_RUN_ID, so a
+// crashed run can never be mistaken for a live peer — the failure mode of a
+// fixed path is a bot pairing with yesterday's file and reporting nonsense.
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '.state', 'rendezvous');
+
+export type Role = 'a' | 'b';
+
+export const peerOf = (role: Role): Role => (role === 'a' ? 'b' : 'a');
+
+function runDir(): string {
+  const id = process.env.HARNESS_RUN_ID;
+  if (!id) {
+    throw new Error(
+      '[harness] HARNESS_RUN_ID is not set. The two-bot scenario is started by ' +
+        'dev/harness/run-two-bots.mjs, which sets it and pairs the two processes. ' +
+        'Run `yarn harness:dm` rather than invoking the scenario directly.'
+    );
+  }
+  return resolve(ROOT, id);
+}
+
+const filePath = (role: Role, kind: string) => resolve(runDir(), `${role}.${kind}.json`);
+
+export function publish(role: Role, kind: string, data: unknown): void {
+  mkdirSync(runDir(), { recursive: true });
+  // Write-then-rename would be tidier, but a partially written file is already
+  // handled: readers JSON.parse inside try/catch and simply wait for the next
+  // poll, so a torn read costs one 250ms tick rather than a bad pairing.
+  writeFileSync(filePath(role, kind), JSON.stringify(data, null, 2), 'utf8');
+}
+
+export function read<T>(role: Role, kind: string): T | null {
+  const p = filePath(role, kind);
+  if (!existsSync(p)) return null;
+  try {
+    return JSON.parse(readFileSync(p, 'utf8')) as T;
+  } catch {
+    return null;
+  }
+}
+
+/** Poll until the peer publishes `kind`, or fail with a diagnosable message. */
+export async function awaitPeer<T>(
+  role: Role,
+  kind: string,
+  timeoutMs = 120_000
+): Promise<T> {
+  const peer = peerOf(role);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const value = read<T>(peer, kind);
+    if (value) return value;
+    await new Promise((r) => setTimeout(r, 250));
+  }
+  throw new Error(
+    `[harness] role ${role} waited ${timeoutMs}ms for peer ${peer}'s "${kind}" and it never ` +
+      `appeared. The peer process most likely failed to start or crashed before ` +
+      `publishing — check the other jest run's output, not this one.`
+  );
+}
+
+/** Sleep until an absolute epoch ms, so both sides begin on the same instant. */
+export async function waitUntil(epochMs: number): Promise<void> {
+  const delay = epochMs - Date.now();
+  if (delay > 0) await new Promise((r) => setTimeout(r, delay));
+}
+
+/** Drop rendezvous directories from previous runs. Called by the orchestrator. */
+export function pruneOldRuns(keepId: string): void {
+  if (!existsSync(ROOT)) return;
+  for (const entry of readdirSync(ROOT)) {
+    if (entry !== keepId) rmSync(resolve(ROOT, entry), { recursive: true, force: true });
+  }
+}

--- a/dev/harness/run-two-bots.mjs
+++ b/dev/harness/run-two-bots.mjs
@@ -1,0 +1,116 @@
+// Orchestrator for the two-bot DM measurement.
+//
+//   yarn harness:dm
+//
+// Starts the dm-two-bot scenario TWICE, as two separate OS processes (one per
+// bot — see bot.ts for why they cannot share one), pairs them through a run
+// directory, then reads both result files and reports loss in each direction.
+//
+// The loss verdict lives here rather than in the scenario because neither bot
+// can compute it alone: each knows what it sent and what it received, and loss
+// needs one side's sends matched against the other side's arrivals.
+import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = resolve(HERE, '../..');
+// Must match rendezvous.ts. Kept as a literal because that file is TypeScript
+// and this orchestrator is plain node — if you change the layout there, change
+// it here too.
+const RENDEZVOUS_ROOT = resolve(HERE, '.state', 'rendezvous');
+
+const runId = `run-${Date.now()}`;
+
+// Old run directories are pruned here, not in the scenario: the scenario cannot
+// know whether a sibling directory belongs to a live peer or a dead one.
+if (existsSync(RENDEZVOUS_ROOT)) {
+  for (const entry of readdirSync(RENDEZVOUS_ROOT)) {
+    if (entry !== runId) rmSync(resolve(RENDEZVOUS_ROOT, entry), { recursive: true, force: true });
+  }
+}
+
+function startRole(role) {
+  const child = spawn(
+    'npx',
+    ['jest', '--config', 'jest.harness.config.js', 'dm-two-bot'],
+    {
+      cwd: REPO,
+      env: { ...process.env, HARNESS_ROLE: role, HARNESS_RUN_ID: runId },
+      shell: true,
+    }
+  );
+  // Both children write to the same terminal, so every line is tagged. Without
+  // this an interleaved failure is very hard to attribute to a side.
+  const tag = (stream, prefix) => {
+    let buffered = '';
+    stream.on('data', (chunk) => {
+      buffered += chunk.toString();
+      const lines = buffered.split('\n');
+      buffered = lines.pop() ?? '';
+      for (const line of lines) console.log(`[${prefix}] ${line}`);
+    });
+  };
+  tag(child.stdout, role);
+  tag(child.stderr, role);
+
+  return new Promise((res) => child.on('close', (code) => res({ role, code })));
+}
+
+console.log(`[dm] run ${runId} — starting both bots`);
+const outcomes = await Promise.all([startRole('a'), startRole('b')]);
+
+for (const { role, code } of outcomes) {
+  if (code !== 0) console.log(`[dm] role ${role} exited ${code}`);
+}
+
+const readResult = (role) => {
+  const p = resolve(RENDEZVOUS_ROOT, runId, `${role}.result.json`);
+  return existsSync(p) ? JSON.parse(readFileSync(p, 'utf8')) : null;
+};
+
+const a = readResult('a');
+const b = readResult('b');
+
+if (!a || !b) {
+  console.error(
+    `[dm] FAIL — missing results (a=${!!a} b=${!!b}). A bot crashed before ` +
+      `publishing; read that role's output above. No loss figure is reported ` +
+      `because a partial run cannot produce an honest one.`
+  );
+  process.exit(1);
+}
+
+// A message counts as delivered when the RECEIVER recorded its number. The
+// receiver's set is deduped, so relay redelivery cannot inflate it.
+function direction(from, to, label) {
+  const sent = from.sent.length;
+  const got = to.received.filter((n) => from.sent.includes(n)).length;
+  const missing = from.sent.filter((n) => !to.received.includes(n));
+  const pct = sent === 0 ? 0 : ((sent - got) / sent) * 100;
+  console.log(
+    `[dm] ${label}: sent=${sent} arrived=${got} loss=${pct.toFixed(1)}%` +
+      (missing.length ? `  missing=[${missing.join(',')}]` : '')
+  );
+  return { sent, got, missing };
+}
+
+console.log('');
+console.log(`[dm] run ${runId}`);
+const ab = direction(a, b, 'A→B');
+const ba = direction(b, a, 'B→A');
+
+const lost = ab.missing.length + ba.missing.length;
+const total = ab.sent + ba.sent;
+console.log(`[dm] total: ${total - lost}/${total} delivered`);
+
+if (total === 0) {
+  console.error('[dm] FAIL — nothing was sent; this measured nothing.');
+  process.exit(1);
+}
+if (lost > 0) {
+  console.error(`[dm] LOSS DETECTED — ${lost}/${total} messages did not arrive.`);
+  process.exit(1);
+}
+console.log('[dm] no loss.');

--- a/dev/harness/shim.ts
+++ b/dev/harness/shim.ts
@@ -47,3 +47,21 @@ if (!w.Buffer) w.Buffer = NodeBuffer;
 // Node 22 provides globalThis.crypto (webcrypto). Mirror it onto window for the
 // SDK's window.crypto.subtle paths.
 if (g.crypto && !w.crypto) w.crypto = g.crypto;
+
+// __DEV__ alone is not enough to see mobile's own diagnostics: quorum-shared's
+// logger defaults to minLevel 'log', which drops every logger.debug call. Those
+// are precisely the lines that say which inboxes were subscribed and how a frame
+// was routed — the difference between "the message was lost" and "it went
+// somewhere nobody was listening".
+//
+// Off by default because a busy run emits a great deal of it. HARNESS_LOG_DEBUG=1
+// turns it on.
+if (process.env.HARNESS_LOG_DEBUG === '1') {
+  // Required lazily: this file is a setupFile and runs before the module
+  // mappings matter, but the import must still resolve through them.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { logger } = require('@quilibrium/quorum-shared') as {
+    logger: { configure(c: { minLevel: string }): void };
+  };
+  logger.configure({ minLevel: 'debug' });
+}

--- a/dev/harness/two-bot-feasibility.scenario.ts
+++ b/dev/harness/two-bot-feasibility.scenario.ts
@@ -1,0 +1,149 @@
+// OFFLINE probe. Answers the two design questions that decide how a mobile bot
+// can exist at all. It asserts capabilities of the runtime, not app behaviour —
+// keep it, because if either answer flips the bot silently becomes wrong.
+//
+//   yarn harness two-bot-feasibility
+//
+// ── Q1: can two bots live in ONE process? ANSWER: no. ───────────────────────
+//
+// Desktop gives each bot its own MessageDB, so two bots in one process are
+// naturally independent. Mobile cannot do that: its storage is reached through
+// MODULE SINGLETONS — mmkvStorage, encryptionStateStorage, the messagesDb
+// module, the SecureStore wrapper. Two bots sharing those would not be two
+// clients; the second would overwrite the first's identity and ratchet state,
+// and the run would measure nothing.
+//
+// jest.isolateModulesAsync looked like the answer, and the tests below show it
+// genuinely does give each require-graph its own registry. It was still
+// REJECTED, because that isolation covers only STATIC imports: app code also
+// reaches storage through lazy requires (services/crypto/initEnvelopeGuard does
+// `require('react-native-mmkv')` at call time), and those run after the isolate
+// has closed, resolving against the shared registry instead.
+//
+// The leak is silent, it would fuse the two "devices" the bench is comparing,
+// and any future lazy require would reopen it with nothing failing. So bots get
+// one PROCESS each (see bot.ts) — which is also what a device actually is.
+//
+// These tests are kept anyway: they pin the behaviour the decision rests on, so
+// if a jest upgrade changes it the reasoning can be rechecked rather than
+// re-derived.
+//
+// ── Q2: can mobile's DM receive path run without a device? ──────────────────
+//
+// On desktop the receive path is MessageService, a plain class. Mobile's is
+// ~4000 lines of useCallback INSIDE WebSocketProvider, a React component. There
+// is no non-React seam, so the only faithful way to drive it is to render the
+// provider — which is viable precisely because it renders no native views, just
+// a context around its children.
+import React from 'react';
+import { act } from 'react';
+import TestRenderer from 'react-test-renderer';
+
+// react-test-renderer refuses to update outside act() unless this is set.
+(globalThis as unknown as { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('two-bot feasibility (offline)', () => {
+  it('Q1: isolateModulesAsync gives each bot its own storage singletons', async () => {
+    // 'react-native-mmkv' resolves to the harness shim, whose stores live in one
+    // module-level Map — exactly the sharing that would fuse two bots into one.
+    const readBack = async (write: string) => {
+      let value: string | undefined;
+      await jest.isolateModulesAsync(async () => {
+        const { createMMKV } = require('react-native-mmkv') as typeof import('./mmkv-shim');
+        const store = createMMKV({ id: 'quorum-config' });
+        // Same id in both isolates: real MMKV would hand back the SAME store.
+        value = store.getString('whoami');
+        store.set('whoami', write);
+      });
+      return value;
+    };
+
+    // First isolate writes; second must NOT see it. If it does, the registries
+    // are shared and two bots in one process is off the table.
+    expect(await readBack('bot-a')).toBeUndefined();
+    expect(await readBack('bot-b')).toBeUndefined();
+  });
+
+  it('Q1b: isolated copies of a stateful app module do not share state', async () => {
+    // The shim is harness-owned; this checks the property holds for MOBILE's own
+    // module-scope state too, which is what actually matters.
+    const idOf = async () => {
+      let id: unknown;
+      await jest.isolateModulesAsync(async () => {
+        const mod = require('../../services/storage/mmkvAdapter');
+        id = mod.getMMKVAdapter();
+      });
+      return id;
+    };
+    const a = await idOf();
+    const b = await idOf();
+    expect(a).toBeTruthy();
+    // Different object identity ⇒ different module instance ⇒ different state.
+    expect(a).not.toBe(b);
+  });
+
+  it('Q2: WebSocketProvider renders headlessly and yields its context value', async () => {
+    const { QueryClient, QueryClientProvider } = require('@tanstack/react-query');
+    const { WebSocketProvider, useWebSocket } = require('@/context/WebSocketContext');
+    const AuthContext = require('@/context/AuthContext').default;
+    const StorageContext = require('@/context/StorageContext').default;
+    const { getMMKVAdapter } = require('@/services/storage/mmkvAdapter');
+
+    let captured: Record<string, unknown> | null = null;
+    const Probe = () => {
+      captured = useWebSocket() as Record<string, unknown>;
+      return null;
+    };
+
+    // Deliberately unauthenticated: this probe asks whether the component TREE
+    // mounts and exposes its API, not whether it connects. Connecting is the
+    // bot's job and needs a real identity.
+    const auth = {
+      authState: 'unauthenticated',
+      user: null,
+      isAuthenticated: false,
+      isLoading: false,
+      farcasterAuthToken: null,
+      signIn: async () => {},
+      signOut: async () => {},
+      updateProfile: () => {},
+      signMessage: async () => '',
+      refreshFarcasterToken: async () => ({ error: 'no-credentials' as const }),
+    };
+
+    const tree = React.createElement(
+      QueryClientProvider,
+      { client: new QueryClient() },
+      React.createElement(
+        AuthContext.Provider,
+        { value: auth },
+        React.createElement(
+          StorageContext.Provider,
+          { value: getMMKVAdapter() },
+          React.createElement(WebSocketProvider, null, React.createElement(Probe, null))
+        )
+      )
+    );
+
+    let renderer: { unmount: () => void } | undefined;
+    await act(async () => {
+      renderer = TestRenderer.create(tree) as unknown as { unmount: () => void };
+    });
+
+    try {
+      expect(captured).toBeTruthy();
+      // The four entry points a bot needs: connect, subscribe to its inbox,
+      // push frames, and read connection state.
+      const value = captured as unknown as Record<string, unknown>;
+      expect(typeof value.connect).toBe('function');
+      expect(typeof value.subscribe).toBe('function');
+      expect(typeof value.enqueueOutbound).toBe('function');
+      expect(typeof value.disconnect).toBe('function');
+      expect(value.connectionState).toBeDefined();
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+    }
+  }, 60_000);
+});

--- a/dev/harness/wasm-provider-shim.ts
+++ b/dev/harness/wasm-provider-shim.ts
@@ -35,6 +35,7 @@ const WASM_PATH =
   );
 
 let initialised = false;
+let wrapped: Record<string, unknown> | null = null;
 
 /**
  * Initialise the crate's WASM binding exactly once per process.
@@ -43,12 +44,69 @@ let initialised = false;
  * `wasm` var, so this initialises both. Calling initSync twice throws, hence the
  * guard — scenarios construct providers freely and must not have to coordinate.
  */
+/**
+ * The crate signals failure by RETURNING an error string, and quorum-shared's
+ * parseWasmResult only recognises some of them — it tests for `invalid`/`error`
+ * prefixes and the substrings `failed`/`Error`. A crate error outside that set
+ * (e.g. one beginning "Decryption ...") falls through to JSON.parse and reaches
+ * the app as a bare `SyntaxError: Unexpected token 'D'`, with no indication of
+ * which crypto call produced it.
+ *
+ * This wrapper does not change behaviour — a failure is still a failure — it
+ * makes it SAY WHERE IT CAME FROM, by prefixing unrecognised non-JSON returns
+ * with `error:` and the function name. Diagnosing a decrypt failure without this
+ * means bisecting a dozen candidate calls by hand.
+ */
+// A Proxy cannot do this: the wasm bindings are non-writable, non-configurable
+// data properties, and a `get` trap returning anything other than the actual
+// value violates a proxy invariant (it throws at the first access). So build a
+// plain object of wrapped functions instead.
+function nameCrateErrors(mod: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(mod)) {
+    const value = mod[key];
+    if (typeof value !== 'function' || !key.startsWith('js_')) {
+      out[key] = value;
+      continue;
+    }
+    out[key] = (...args: unknown[]) => {
+      const result = (value as (...a: unknown[]) => unknown).apply(mod, args);
+      if (typeof result !== 'string') return result;
+      // Valid JSON, or a quoted string: a normal success return.
+      try {
+        JSON.parse(result);
+        return result;
+      } catch {
+        /* not JSON — fall through */
+      }
+      if (result.startsWith('"')) return result;
+      if (process.env.HARNESS_CRYPTO_DEBUG === '1') {
+        // eslint-disable-next-line no-console
+        console.error(`[harness] ${key} returned a crate error: ${result.slice(0, 300)}`);
+      }
+      // Already recognisable to parseWasmResult? Leave it exactly as the crate
+      // wrote it, so error text the app may match on is not altered.
+      if (
+        result.startsWith('invalid') ||
+        result.startsWith('error') ||
+        result.includes('failed') ||
+        result.includes('Error')
+      ) {
+        return result;
+      }
+      return `error: ${key}: ${result}`;
+    };
+  }
+  return out;
+}
+
 export function initHarnessCrypto(): ChannelWasmModule {
   if (!initialised) {
     channel_raw.initSync(readFileSync(WASM_PATH));
     initialised = true;
+    wrapped = nameCrateErrors(channel_raw as unknown as Record<string, unknown>);
   }
-  return channel_raw as unknown as ChannelWasmModule;
+  return wrapped as unknown as ChannelWasmModule;
 }
 
 /** Methods that exist ONLY in the native module — no WASM or JS equivalent. */
@@ -97,6 +155,83 @@ export class NativeCryptoProvider extends WasmCryptoProvider {
       // pass an unusable "signature" on to a peer that cannot verify it.
       throw new Error(`[harness] signEd448 failed: ${result}`);
     }
+  }
+
+  /**
+   * The two backends disagree on how a decrypt FAILURE is reported, and mobile's
+   * app code is written against the native one.
+   *
+   *   native: returns { ratchet_state: <unchanged>, message: [], decryptionError }
+   *           and never throws — encryption-service checks exactly that shape and
+   *           falls through to the next decryption strategy.
+   *   wasm:   parseWasmResult() THROWS on strings it recognises as errors, and
+   *           JSON.parses anything else — so a crate error it does not recognise
+   *           (e.g. one starting "Decryption ...") surfaces as a bare SyntaxError
+   *           from deep inside the provider.
+   *
+   * Either way mobile's graceful fallback never runs, and a recoverable failure
+   * is turned into a hard one. Presenting the native convention here is what
+   * makes the harness faithful to the app's own error handling.
+   */
+  async doubleRatchetDecrypt(
+    stateAndEnvelope: { ratchet_state: string; envelope: string }
+  ): Promise<{ ratchet_state: string; message: number[]; decryptionError?: string }> {
+    const wasm = initHarnessCrypto() as unknown as {
+      js_double_ratchet_decrypt(input: string): string;
+    };
+    const result = wasm.js_double_ratchet_decrypt(
+      JSON.stringify({
+        ratchet_state: stateAndEnvelope.ratchet_state,
+        envelope: stateAndEnvelope.envelope,
+      })
+    );
+
+    const fail = (why: string) => {
+      if (process.env.HARNESS_CRYPTO_DEBUG === '1') {
+        // eslint-disable-next-line no-console
+        console.error('[harness] doubleRatchetDecrypt failed:', why.slice(0, 300));
+      }
+      return { ratchet_state: stateAndEnvelope.ratchet_state, message: [], decryptionError: why };
+    };
+
+    let parsed: { ratchet_state?: unknown; message?: unknown };
+    try {
+      parsed = JSON.parse(result) as typeof parsed;
+    } catch {
+      return fail(result);
+    }
+    if (typeof parsed.ratchet_state !== 'string') return fail('ratchet_state is not a string');
+
+    // The crate returns `message` as EITHER a base64 string or a byte array.
+    // parseWasmResult does not normalise this, so on the string form mobile's
+    // code ends up doing new Uint8Array("<base64>") — which yields nothing, with
+    // no error anywhere. Mobile's native parser base64-decodes; match it.
+    let messageBytes: number[];
+    if (typeof parsed.message === 'string') {
+      messageBytes = Array.from(Buffer.from(parsed.message, 'base64'));
+    } else if (Array.isArray(parsed.message)) {
+      messageBytes = parsed.message as number[];
+    } else {
+      return fail('message is neither string nor array');
+    }
+
+    // The crate also reports failure by putting the error INSIDE the message
+    // bytes of an otherwise successful-looking result. Mobile's native parser
+    // catches that; the WASM one does not, so the error text travelled onward as
+    // if it were plaintext and surfaced far away as
+    // `SyntaxError: Unexpected token 'D'` when the app JSON.parsed it.
+    if (messageBytes.length > 0) {
+      const asText = new TextDecoder().decode(new Uint8Array(messageBytes));
+      if (
+        asText.startsWith('Decryption failed:') ||
+        asText.startsWith('invalid') ||
+        asText.includes('aead::Error')
+      ) {
+        return fail(`Double ratchet decryption error: ${asText}`);
+      }
+    }
+
+    return { ratchet_state: parsed.ratchet_state, message: messageBytes };
   }
 
   /** Mirrors native-provider sealInboxEnvelope. */

--- a/dev/harness/wasm-provider-shim.ts
+++ b/dev/harness/wasm-provider-shim.ts
@@ -73,6 +73,66 @@ export class NativeCryptoProvider extends WasmCryptoProvider {
     super(initHarnessCrypto());
   }
 
+  // ---- methods NativeCryptoProvider has that WasmCryptoProvider lacks ----
+  //
+  // The two backends are not symmetric: mobile's provider adds ten methods on
+  // top of the shared CryptoProvider interface. Of those, all but the batch pair
+  // are ordinary JS built on interface primitives, so they are reproduced here.
+  //
+  // ⚠️ DRIFT RISK, stated plainly: these mirror
+  // services/crypto/native-provider.ts. They are small and stable, but if that
+  // file's versions change, change these to match. The alternative — importing
+  // the real class — is impossible, since importing it loads the native module.
+
+  /** Base64 in, base64 out. Registration signs with this. */
+  async signEd448(privateKey: string, message: string): Promise<string> {
+    const wasm = initHarnessCrypto() as unknown as {
+      js_sign_ed448(k: string, m: string): string;
+    };
+    const result = wasm.js_sign_ed448(privateKey, message);
+    try {
+      return JSON.parse(result) as string;
+    } catch {
+      // The crate returns a bare error string on failure. Fail here rather than
+      // pass an unusable "signature" on to a peer that cannot verify it.
+      throw new Error(`[harness] signEd448 failed: ${result}`);
+    }
+  }
+
+  /** Mirrors native-provider sealInboxEnvelope. */
+  async sealInboxEnvelope(
+    recipientPubKeyBase64: string,
+    message: string
+  ): Promise<{ inbox_public_key: string; ephemeral_public_key: string; envelope: unknown }> {
+    const ephemeral = await this.generateX448();
+    const recipientPubKey = Array.from(Buffer.from(recipientPubKeyBase64, 'base64'));
+    const envelope = await this.encryptInboxMessage({
+      inbox_public_key: recipientPubKey,
+      ephemeral_private_key: ephemeral.private_key,
+      plaintext: Array.from(new TextEncoder().encode(message)),
+    } as never);
+    return {
+      inbox_public_key: Buffer.from(recipientPubKeyBase64, 'base64').toString('hex'),
+      ephemeral_public_key: Buffer.from(new Uint8Array(ephemeral.public_key)).toString('hex'),
+      envelope,
+    };
+  }
+
+  /** Mirrors native-provider unsealInboxEnvelope. */
+  async unsealInboxEnvelope(
+    recipientPrivKey: number[],
+    envelope: { ephemeral_public_key: string; envelope: string }
+  ): Promise<string> {
+    const ephemeralPublicKey = Array.from(Buffer.from(envelope.ephemeral_public_key, 'hex'));
+    const ciphertext = JSON.parse(envelope.envelope) as Record<string, unknown>;
+    const decrypted = await this.decryptInboxMessage({
+      inbox_private_key: recipientPrivKey,
+      ephemeral_public_key: ephemeralPublicKey,
+      ciphertext,
+    } as never);
+    return new TextDecoder().decode(new Uint8Array(decrypted as number[]));
+  }
+
   // ---- native-only surface: fail loudly rather than silently degrade ----
   //
   // These are direct QuorumCrypto.* uniffi calls in the real provider. The batch
@@ -87,6 +147,26 @@ export class NativeCryptoProvider extends WasmCryptoProvider {
 
   async batchUnsealEnvelopes(): Promise<never> {
     return nativeOnly('batchUnsealEnvelopes');
+  }
+
+  // Hub and sync envelopes belong to the SPACE paths, which this harness does
+  // not cover (DM transport only, same boundary the desktop harness draws).
+  // Reproducing them unexercised would be speculative code that drifts silently;
+  // throwing names exactly what to add if a space scenario ever needs them.
+  async sealHubEnvelope(): Promise<never> {
+    return nativeOnly('sealHubEnvelope (space path — out of DM scope)');
+  }
+  async unsealHubEnvelope(): Promise<never> {
+    return nativeOnly('unsealHubEnvelope (space path — out of DM scope)');
+  }
+  async sealSyncEnvelope(): Promise<never> {
+    return nativeOnly('sealSyncEnvelope (space path — out of DM scope)');
+  }
+  async unsealSyncEnvelope(): Promise<never> {
+    return nativeOnly('unsealSyncEnvelope (space path — out of DM scope)');
+  }
+  async tripleRatchetResizeForInvites(): Promise<never> {
+    return nativeOnly('tripleRatchetResizeForInvites (space path — out of DM scope)');
   }
 }
 

--- a/dev/harness/wasm-signing-shim.ts
+++ b/dev/harness/wasm-signing-shim.ts
@@ -1,0 +1,38 @@
+// Drop-in for services/crypto/native-signing-provider's NativeSigningProvider.
+//
+// Same reasoning as the crypto shim: the real one calls QuorumCrypto.signEd448
+// through uniffi, which cannot load in Node. This implements the identical
+// SigningProvider contract against the crate's WASM binding instead.
+//
+// Kept separate from wasm-provider-shim because the modules are separate in the
+// app, and the harness alias matches module paths — collapsing them would make
+// `native-provider` and `native-signing-provider` resolve to one file and
+// quietly change what each import site receives.
+import { initHarnessCrypto } from './wasm-provider-shim';
+
+/** Same base64-in / base64-out contract as SigningProvider in quorum-shared. */
+export class NativeSigningProvider {
+  async signEd448(privateKey: string, message: string): Promise<string> {
+    const wasm = initHarnessCrypto() as unknown as {
+      js_sign_ed448(k: string, m: string): string;
+    };
+    const result = wasm.js_sign_ed448(privateKey, message);
+    // The crate returns a JSON-quoted string on success and a bare error string
+    // on failure. Parse rather than trust, so a failure surfaces here instead of
+    // travelling onward as a "signature" that no peer can verify.
+    try {
+      return JSON.parse(result) as string;
+    } catch {
+      throw new Error(`[harness] signEd448 failed: ${result}`);
+    }
+  }
+
+  async verifyEd448(publicKey: string, message: string, signature: string): Promise<boolean> {
+    const wasm = initHarnessCrypto() as unknown as {
+      js_verify_ed448(p: string, m: string, s: string): string;
+    };
+    return wasm.js_verify_ed448(publicKey, message, signature) === 'true';
+  }
+}
+
+export default NativeSigningProvider;

--- a/jest.harness.config.js
+++ b/jest.harness.config.js
@@ -53,6 +53,10 @@ module.exports = {
     // '@/services/crypto/native-provider' from elsewhere. It deliberately does
     // NOT match native-signing-provider, which is a different module.
     '^(.*/)?native-provider$': '<rootDir>/dev/harness/wasm-provider-shim.ts',
+    // Separate module in the app, so a separate shim here. Collapsing the two
+    // would make both import paths resolve to one file and quietly change what
+    // each call site receives.
+    '^(.*/)?native-signing-provider$': '<rootDir>/dev/harness/wasm-signing-shim.ts',
 
     // ---- native modules that cannot exist in Node ----
     // Each is a real device API with no Node equivalent. Swapping them here
@@ -98,7 +102,23 @@ module.exports = {
   transform: {
     '^.+\\.[jt]sx?$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],
   },
+  // These packages ship ESM that jest's CJS runner cannot execute directly, so
+  // babel must transform them. The list grows as scenarios reach deeper into
+  // mobile's real code — keyService alone pulls @scure/bip39 and multihashes.
+  // Everything else in node_modules stays untransformed, which keeps runs fast.
   transformIgnorePatterns: [
-    'node_modules/(?!(@quilibrium/quorum-shared|multiformats|@noble|bs58|base-x|uint8arrays))',
+    'node_modules/(?!(' +
+      [
+        '@quilibrium/quorum-shared',
+        'multiformats',
+        'multihashes',
+        '@noble',
+        '@scure',
+        'bs58',
+        'base-x',
+        'uint8arrays',
+        'varint',
+      ].join('|') +
+      '))',
   ],
 };

--- a/jest.harness.config.js
+++ b/jest.harness.config.js
@@ -38,9 +38,15 @@ module.exports = {
   setupFiles: ['<rootDir>/dev/harness/shim.ts'],
   // Scenarios talk to a live relay; the default 5s kills them mid-handshake.
   testTimeout: 4 * 60 * 60 * 1000,
+  // ORDER MATTERS: jest tries these in declaration order and takes the first
+  // match, so every specific pattern must come BEFORE the broad '^@/(.*)$'
+  // alias. Appending a specific rule at the bottom silently does nothing.
   moduleNameMapper: {
-    // Mobile's tsconfig path alias, spelled out for jest.
-    '^@/(.*)$': '<rootDir>/$1',
+    // Narrow the @/context barrel to the DM contexts. The barrel re-exports
+    // every context, so importing it for one hook pulls OnboardingContext
+    // (→ expo-router) and the calling contexts (→ WebRTC natives) — none of
+    // which a DM touches. See context-barrel-shim.ts.
+    '^@/context$': '<rootDir>/dev/harness/context-barrel-shim.ts',
 
     // ---- THE crypto seam ----
     // Swap mobile's uniffi-backed provider for the WASM one. This is the single
@@ -52,11 +58,20 @@ module.exports = {
     // within services/crypto, '../crypto/native-provider' from siblings, and
     // '@/services/crypto/native-provider' from elsewhere. It deliberately does
     // NOT match native-signing-provider, which is a different module.
+    //
+    // These MUST stay above the '^@/(.*)$' alias. When they sat below it, an
+    // '@/services/crypto/native-provider' import matched the alias first and
+    // loaded the REAL uniffi provider — which then failed on expo-modules-core.
+    // A loud failure was luck; the same shadowing on a module that happens to
+    // import cleanly would have silently run unshimmed code.
     '^(.*/)?native-provider$': '<rootDir>/dev/harness/wasm-provider-shim.ts',
     // Separate module in the app, so a separate shim here. Collapsing the two
     // would make both import paths resolve to one file and quietly change what
     // each call site receives.
     '^(.*/)?native-signing-provider$': '<rootDir>/dev/harness/wasm-signing-shim.ts',
+    // The services/crypto barrel re-exports both providers, so importing it
+    // reaches the real modules without going through either pattern above.
+    '^(.*/)?services/crypto$': '<rootDir>/dev/harness/crypto-barrel-shim.ts',
 
     // ---- native modules that cannot exist in Node ----
     // Each is a real device API with no Node equivalent. Swapping them here
@@ -72,6 +87,24 @@ module.exports = {
     // messagesDb imports the /legacy entrypoint; same module either way.
     '^expo-file-system/legacy$': '<rootDir>/dev/harness/filesystem-shim.ts',
     '^expo-file-system$': '<rootDir>/dev/harness/filesystem-shim.ts',
+    // ---- UI cut ----
+    // The harness renders WebSocketProvider (mobile's DM receive path lives
+    // inside it) but never renders UI. StorageContext — needed only for its
+    // context object — imports MigrationModal at module scope, and that one
+    // import pulls the entire theme chain: ThemeProvider → fontLoader →
+    // expo-font, which ships untransformable ESM.
+    //
+    // Stubbing this ONE leaf severs the whole UI subtree, which is both smaller
+    // and more honest than allowlisting expo-font and whatever it drags behind
+    // it. Safe because MigrationModal is referenced only inside StorageProvider's
+    // JSX, and the harness supplies the adapter via StorageContext.Provider
+    // directly rather than mounting that provider.
+    '^(.*/)?components/MigrationModal$': '<rootDir>/jest/empty-module.js',
+
+    // Mobile's tsconfig path alias. LAST of the '@/'-matching rules by design:
+    // it is a catch-all, so anything specific above it must be declared first.
+    '^@/(.*)$': '<rootDir>/$1',
+
     '^@quilibrium/quilibrium-js-sdk-channels$': SDK,
     // SDK is reached via desktop's node_modules, which on this machine is a
     // yarn-link SYMLINK to the SDK source checkout — and that checkout has no
@@ -100,7 +133,13 @@ module.exports = {
       '<rootDir>/jest/empty-module.js',
   },
   transform: {
-    '^.+\\.[jt]sx?$': ['babel-jest', { configFile: path.resolve(__dirname, 'babel.config.js') }],
+    // The app's babel config plus one harness-only transform (lazy `import()`
+    // → require, which jest's CJS runtime cannot do). babel.config.js itself is
+    // untouched — see dev/harness/babel.harness.js.
+    '^.+\\.[jt]sx?$': [
+      'babel-jest',
+      { configFile: path.resolve(__dirname, 'dev/harness/babel.harness.js') },
+    ],
   },
   // These packages ship ESM that jest's CJS runner cannot execute directly, so
   // babel must transform them. The list grows as scenarios reach deeper into

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "prebuild:snapshot": "scripts/snapshot-ios-customizations.sh",
     "prebuild:restore": "scripts/restore-ios-customizations.sh",
     "postinstall": "patch-package && watchman watch-del-all 2>/dev/null; rm -rf $TMPDIR/metro-* .expo node_modules/.cache 2>/dev/null || true",
-    "clean": "watchman watch-del-all 2>/dev/null; rm -rf $TMPDIR/metro-* $TMPDIR/haste-map-* .expo node_modules/.cache 2>/dev/null; echo 'Caches cleared'"
+    "clean": "watchman watch-del-all 2>/dev/null; rm -rf $TMPDIR/metro-* $TMPDIR/haste-map-* .expo node_modules/.cache 2>/dev/null; echo 'Caches cleared'",
+    "harness:dm": "node dev/harness/run-two-bots.mjs"
   },
   "dependencies": {
     "@bitcoin-js/tiny-secp256k1-asmjs": "2.2.4",


### PR DESCRIPTION
Completes the mobile headless harness. Mobile's real client code now runs end to
end in Node — onboarding, connect, subscribe, DM send, DM receive — and
`yarn harness:dm` reports delivery loss per direction.

## Result

Production relay, two throwaway accounts, one device each:

```
[dm] A→B: sent=40 arrived=40 loss=0.0%
[dm] B→A: sent=40 arrived=40 loss=0.0%
[dm] total: 80/80 delivered — no loss.
```

Zero decrypt failures, both device inboxes empty at the end.

**Read it as one variable eliminated, not a verdict.** Mobile's own send/receive
logic does not lose these messages once RN's native WebSocket is out of the loop
— the single-variable experiment the transport investigation could never run,
since every previous round changed platform, transport and client code together.
It does not isolate RN native: a fresh two-device pair is plausibly the
population least likely to exhibit an intermittent, account-aged fault, the same
caveat that applied to the two desktop `dm-loss` nulls.

## How the bot is built, and why it differs from desktop's

Desktop constructs `new MessageService(deps)`. Mobile has no equivalent seam: its
DM receive path is ~4000 lines of `useCallback` *inside* `WebSocketProvider`
(`handleIncomingMessage` alone spans lines 762-3540). Extracting it would have
meant refactoring shipping code.

So the bot **renders** the provider (react-test-renderer; it emits no native
views) and mounts it authenticated, at which point mobile's own effect connects,
loads device keys and subscribes. A probe child calls mobile's own
`useWebSocket` and `useSendDirectMessage`, so `send()` is the app's send path —
nonce, message-id hash, Ed448 signing, device fan-out included. Capture is a tee
on the storage adapter's `saveMessage`, so what is counted is what the app itself
persisted. Nothing extracted, nothing reimplemented.

**One bot per process.** Mobile reaches storage through module singletons, so two
bots in one process would share identity and ratchet state.
`jest.isolateModulesAsync` does isolate static require-graphs (measured; the test
is kept) but not lazy `require()`s — `services/crypto/initEnvelopeGuard` does one
at call time, after the isolate closes. That leak is silent and would fuse the
two devices being compared, so bots are paired across processes.

## Findings worth keeping

1. **`NativeCryptoProvider` and `WasmCryptoProvider` are not interchangeable at
   the error level**, despite both implementing `CryptoProvider`. Native reports a
   decrypt failure as `{message: [], decryptionError}` and base64-decodes a string
   `message`; the WASM one throws for errors matching its pattern list and
   JSON-parses everything else. Mobile's code is written against the native
   conventions, so the mismatch turned a *recoverable* failure into
   `SyntaxError: Unexpected token 'D'` raised far from its cause. The shim now
   mirrors the native conventions.
2. **Simultaneous session open forks the pair.** Both bots sending from the same
   instant failed all 50 messages of a 25-round run on X3DH while every frame
   arrived intact — and the forked state persisted into later runs via retained
   undecryptable frames that re-ran X3DH on redelivery. The baseline has one
   initiator; simultaneous open deserves its own scenario.
3. **A delivery count cannot distinguish "lost" from "delivered and refused."**
   The run reports frames still queued on each device inbox. That is what turned
   an apparent 100% loss into 40 frames delivered perfectly and rejected by the
   receiver's session — the opposite diagnosis.

## Blast radius on the app

| concern | status |
|---|---|
| `jest.config.js` | untouched — scenarios are `*.scenario.ts`, the app's `testMatch` is `**/*.test.ts` |
| dependencies / `yarn.lock` | **no dependency added, lockfile never modified** |
| `package.json` | one script line (`harness:dm`) |
| app source | one `export` keyword on an existing function + its comment |
| app bundle | nothing in `app/`, `components/`, `services/`, `hooks/` imports `dev/harness` |

The single app-source change exports `deleteInboxMessages` from
`WebSocketContext` so the harness reuses the real signed inbox-delete instead of
duplicating its crypto glue. No behaviour change.

Lazy `import()` (which jest's CJS runtime cannot execute) is lowered by a
harness-only babel config that reuses the app's config verbatim — chosen over
adding `babel-plugin-dynamic-import-node` precisely to keep the lockfile
untouched.

## Verification

- App suite: **13 suites / 108 tests**, unchanged.
- Harness: 7 suites / 16 tests networked; 13 passed / 4 skipped with
  `HARNESS_OFFLINE=1`.
- `dev/harness/.state/` and `logs/` are gitignored — they hold real device
  keysets and ratchet material.

## Not done

Mobile↔desktop (the field's reported worst case) and a simultaneous-open
scenario. Both are cheap now that the bot exists.
