### PR TITLE
ui: settings polish, translation off option, chat scroll fixes

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -20,6 +20,15 @@ installGlobalErrorReporter();
 import { installReactQueryRnBridges } from '@/services/observability/reactQueryRnBridges';
 installReactQueryRnBridges();
 
+// quorum-shared's transport rejects its connect promise on socket error, and
+// its reconnect timer calls doConnect() uncaught — so flaky connectivity
+// floods dev builds with an "Uncaught (in promise) Error: WebSocket error"
+// LogBox toast on every retry, covering the tab bar. Dev-only UI suppression;
+// metro/terminal logs are unaffected. Remove once quorum-shared catches the
+// reconnect rejection (transport/rn-websocket.ts).
+import { LogBox } from 'react-native';
+LogBox.ignoreLogs([/WebSocket error/]);
+
 import { QueryClient } from '@tanstack/react-query';
 import { PersistQueryClientProvider } from '@tanstack/react-query-persist-client';
 import { Slot, router, useSegments, useRootNavigationState } from 'expo-router';

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -219,7 +219,7 @@ export function DMSettingsSheet({
           )}
           {onSetReadReceipts && effectiveDelivery && (
             <ActionRow
-              icon="checkmark.circle"
+              icon="checkmark.double"
               label="Read receipts"
               sublabel={receiptSublabel(readOverridden, onResetRead)}
               trailing={

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -132,14 +132,15 @@ export function DMSettingsSheet({
       title: 'Fix Encryption',
       message: `This will reset the encryption session with ${displayName}. The next message will establish a fresh secure connection.\n\nUse this if messages are failing to send or decrypt.`,
       confirmLabel: 'Reset Session',
+      variant: 'primary',
     });
     setIsConfirming(false);
     if (!ok) return;
     resetDMSession(conversationId);
     onClose();
     Alert.alert(
-      'Session Reset',
-      'The encryption session has been reset. Your next message will establish a fresh secure connection.'
+      'Encryption Reset',
+      'Your next message will establish a fresh secure connection.'
     );
   };
 
@@ -249,7 +250,7 @@ export function DMSettingsSheet({
           <ActionRow
             icon="arrow.triangle.2.circlepath"
             label="Fix Encryption"
-            sublabel="Reset if messages fail to send/decrypt"
+            sublabel="Reset if messages fail to send or decrypt"
             onPress={handleFixEncryption}
           />
           <ActionRow

--- a/components/Chat/MentionableText.tsx
+++ b/components/Chat/MentionableText.tsx
@@ -100,6 +100,14 @@ function emojiOnlyScale(count: number): number {
   return 1;
 }
 
+// Line box for enlarged emoji. Emoji glyphs draw beyond the nominal em box on
+// both platforms, so the line box needs ~20% headroom: pinning lineHeight to
+// the font size clips the glyph tops/bottoms, while leaving it unset gives
+// Android's emoji font an oversized line box (the old empty-gap-below bug).
+function emojiLineHeight(size: number): number {
+  return Math.round(size * 1.2);
+}
+
 // Count emoji clusters in an emoji-only string (whitespace ignored).
 function countEmojiClusters(text: string): number {
   const matches = text.replace(/\s+/g, '').match(EMOJI_CLUSTER_REGEX);
@@ -455,15 +463,14 @@ function MentionableTextBase({
     if (isEmojiOnly) {
       const base = style?.fontSize || 16;
       const size = base * emojiOnlyScale(countEmojiClusters(text));
-      // Pin lineHeight to the font size: a large emoji Text with no lineHeight
-      // gets an oversized line box on Android (extra emoji-font ascent/descent),
-      // which showed as a big empty gap below emoji-only messages.
+      // Line height via emojiLineHeight — see its comment for why neither
+      // unset nor font-size-pinned works.
       // Emoji-only: lay out in a bottom-aligned row so the (small) trailing
       // indicators sit at the bottom of the (large) emoji rather than floating
       // up the tall line box. `receipt` is a <Text>-wrapped node, valid here.
       return renderWithToggle(
         <View style={{ flexDirection: 'row', alignItems: 'flex-end' }}>
-          <Text style={[style, { fontSize: size, lineHeight: size }]}>{text}</Text>
+          <Text style={[style, { fontSize: size, lineHeight: emojiLineHeight(size) }]}>{text}</Text>
           {receipt}
         </View>
       );
@@ -504,10 +511,10 @@ function MentionableTextBase({
   const effectiveEmojiSize = isEmojiOnlyMessage
     ? (largeEmojiSize / 2) * emojiScale
     : emojiSize;
-  // lineHeight pinned to the font so the enlarged emoji row doesn't reserve the
-  // oversized emoji-font line box on Android (the empty-gap-below bug).
+  // Line height via emojiLineHeight — see its comment for why neither unset
+  // nor font-size-pinned works.
   const effectiveStyle = isEmojiOnlyMessage
-    ? { ...style, fontSize: scaledFont, lineHeight: scaledFont }
+    ? { ...style, fontSize: scaledFont, lineHeight: emojiLineHeight(scaledFont) }
     : style;
 
   // Mention/channel styling — color-only (no highlighted background). The bg

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -277,7 +277,7 @@ export function MessageActionSheet({
                 />
               )}
               {canTranslate && (
-                <ActionRow icon="globe" label="Translate" onPress={handleTranslate} />
+                <ActionRow icon="language" label="Translate" onPress={handleTranslate} />
               )}
               {onBookmark && (
                 <ActionRow

--- a/components/Chat/MessageActionSheet.tsx
+++ b/components/Chat/MessageActionSheet.tsx
@@ -14,11 +14,17 @@ import { IconSymbol } from '@/components/ui/IconSymbol';
 import { ActionRow, ActionRowGroup } from '@/components/shared';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
 import { getRecentEmojis } from '@/services/emojiFrecency';
+import { useMMKVString } from 'react-native-mmkv';
 import { requestTranslateText } from '@/services/translation/forceTranslate';
 import {
   ensureAvailabilityProbed,
   translationAvailableCached,
 } from '@/services/translation/availability';
+import {
+  translationPrefsStore,
+  K_TARGET_LANGUAGE,
+  isTranslationOff,
+} from '@/services/translation/translationPrefs';
 import * as Skin from '@/theme/skins/geometry';
 
 const { width: SCREEN_WIDTH } = Dimensions.get('window');
@@ -88,14 +94,20 @@ export function MessageActionSheet({
   const [quickEmojis, setQuickEmojis] = useState<string[]>(DEFAULT_QUICK_REACTIONS);
 
   // "Translate" is shown only when on-device translation is available
-  // (optimistic until the one-time probe resolves).
+  // (optimistic until the one-time probe resolves) and not disabled by the
+  // "Do not translate" preference.
   const [translateAvailable, setTranslateAvailable] = useState(
     translationAvailableCached() ?? true
   );
   useEffect(() => {
     ensureAvailabilityProbed().then(setTranslateAvailable);
   }, []);
-  const canTranslate = translateAvailable && !!messageText && messageText.trim().length > 0;
+  const [storedTarget] = useMMKVString(K_TARGET_LANGUAGE, translationPrefsStore);
+  const canTranslate =
+    translateAvailable &&
+    !isTranslationOff(storedTarget) &&
+    !!messageText &&
+    messageText.trim().length > 0;
 
   // Load frecency emojis when modal opens
   useEffect(() => {

--- a/components/Chat/MessagesList.tsx
+++ b/components/Chat/MessagesList.tsx
@@ -5,6 +5,7 @@ import { TouchableOpacity } from '@/components/ui/SkinTouchable';
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import Animated, { useSharedValue, useAnimatedStyle, withTiming, withDelay, withSequence } from 'react-native-reanimated';
 import { ChatKeyboardScrollView } from './ChatKeyboardScrollView';
+import { composerBottomBusySV } from '@/services/ui/composerPanelVisible';
 import BrowserLink from '@/components/BrowserLink';
 import { haptics } from '@/utils/haptics';
 import { useToast } from '@/context/ToastContext';
@@ -460,6 +461,23 @@ export const MessagesList = forwardRef<MessagesListHandle, MessagesListProps>(fu
     const isOwnMessage = !!currentUserId && newLastMsg?.userId === currentUserId;
     if (isOwnMessage || distanceFromBottomRef.current <= 80) {
       flatListRef.current?.scrollToEnd({ animated: true });
+      // The animated scroll targets the content size measured BEFORE the new
+      // cell lays out. Cells much taller than the running row height — emoji-
+      // only messages render at up to 6x the body font — leave the list off
+      // the true end once the anchor applies the measured delta (visible as an
+      // over-scroll while the keyboard's bottom inset gives it room). A second
+      // pass after measurement snaps to the real end; it's a no-op when the
+      // first pass already landed right. Skipped if the user scrolled away.
+      const correct = setTimeout(() => {
+        // Never snap while the emoji panel owns the bottom (open or mid
+        // keyboard hand-off): the panel runs its own list choreography
+        // (freeze / cold-open lift) and a snap here fights it.
+        if (composerBottomBusySV.value === 1) return;
+        if (distanceFromBottomRef.current <= 400) {
+          flatListRef.current?.scrollToEnd({ animated: false });
+        }
+      }, 350);
+      return () => clearTimeout(correct);
     }
   }, [orderedMessages, currentUserId]);
 

--- a/components/Chat/SpaceCallBubble.tsx
+++ b/components/Chat/SpaceCallBubble.tsx
@@ -49,7 +49,7 @@ export function SpaceCallBubble({
   theme,
 }: SpaceCallBubbleProps) {
   const isVideo = message.spaceCallMediaType === 'video';
-  const iconName = isVideo ? 'video.fill' : 'speaker.wave.2.fill';
+  const iconName = isVideo ? 'video' : 'speaker.wave.2';
   const label = isVideo ? 'Video' : 'Voice';
   const callId = message.spaceCallId;
 
@@ -182,10 +182,7 @@ export function SpaceCallBubble({
               {joining ? (
                 <ActivityIndicator size="small" color="#fff" />
               ) : (
-                <>
-                  <IconSymbol name="phone.fill" size={14} color="#fff" />
-                  <Text style={styles.joinButtonText}>Join</Text>
-                </>
+                <Text style={styles.joinButtonText}>Join</Text>
               )}
             </TouchableOpacity>
           )}

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -165,40 +165,6 @@ export type ProfileSection = 'profile' | 'premium' | 'settings' | 'farcaster';
 
 const { height: SCREEN_HEIGHT } = Dimensions.get('window');
 
-function CallScreeningSection({ theme }: { theme: AppTheme }) {
-  const [enabled, setEnabled] = React.useState(() => {
-    const { getCallScreening } = require('@/context/CallContext');
-    return getCallScreening();
-  });
-
-  return (
-    <View style={{ marginBottom: Skin.space(24) }}>
-      <Text style={{ fontSize: Skin.font(16), fontFamily: theme.fonts.bold.fontFamily, fontWeight: theme.fonts.bold.fontWeight, color: theme.colors.textMain, marginBottom: Skin.space(12) }}>
-        Calls
-      </Text>
-      <View style={{ backgroundColor: theme.colors.surface2, borderRadius: Skin.radius(8), padding: Skin.space(16) }}>
-        <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
-          <View style={{ flex: 1, marginRight: Skin.space(12) }}>
-            <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>Screen Unknown Callers</Text>
-            <Text style={{ fontSize: Skin.font(12), color: theme.colors.textSubtle, marginTop: Skin.space(2) }}>
-              Only ring for people you have a conversation with
-            </Text>
-          </View>
-          <Switch
-            value={enabled}
-            onValueChange={(v) => {
-              const { setCallScreening } = require('@/context/CallContext');
-              setCallScreening(v);
-              setEnabled(v);
-            }}
-            trackColor={{ true: theme.colors.primary }}
-          />
-        </View>
-      </View>
-    </View>
-  );
-}
-
 function DevModeSection({ theme }: { theme: AppTheme }) {
   const [isLocal, setIsLocal] = React.useState(isDevModeLocal());
   const config = getApiConfig();
@@ -692,14 +658,15 @@ export default function ProfileModal({
   const handleResetAllSessions = React.useCallback(() => {
     void (async () => {
       const ok = await confirm({
-        title: 'Reset All DM Sessions',
+        title: 'Fix DM Encryption',
         message:
-          'This will reset all your encrypted DM sessions. Your next message to each contact will establish a fresh secure connection.\n\nUse this if you are experiencing persistent decryption errors.',
+          'This will reset the encryption sessions for all your DM conversations. Your next message to each contact will establish a fresh secure connection.\n\nUse this if messages are failing to send or decrypt.',
         confirmLabel: 'Reset All',
+        variant: 'primary',
       });
       if (!ok) return;
       encryptionStateStorage.clearAll();
-      Alert.alert('Success', 'All DM sessions have been reset. Your next message to each contact will establish a fresh secure connection.');
+      Alert.alert('Encryption Reset', 'Your next message to each contact will establish a fresh secure connection.');
     })();
   }, [confirm]);
 
@@ -2300,7 +2267,7 @@ export default function ProfileModal({
                     style={styles.actionButton}
                     onPress={() => setShowFarcasterImport(true)}
                   >
-                    <IconSymbol name="person.badge.plus" size={20} color={theme.colors.textMain} />
+                    <IconSymbol name="person.badge.plus" size={20} color={theme.colors.primary} />
                     <Text style={styles.actionButtonText}>Connect Farcaster Account</Text>
                     <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
                   </TouchableOpacity>
@@ -2407,9 +2374,6 @@ export default function ProfileModal({
               onResetAllSessions={handleResetAllSessions}
             />
 
-            {/* Calls */}
-            <CallScreeningSection theme={theme} />
-
             {/* App Updates (OTA) */}
             <OtaUpdateSection theme={theme} />
 
@@ -2418,9 +2382,9 @@ export default function ProfileModal({
 
             {/* Danger Zone */}
             <View style={styles.section}>
-              <Text style={styles.sectionTitle}>Danger Zone</Text>
+              <Text style={[styles.sectionTitle, styles.dangerText]}>Danger Zone</Text>
               <TouchableOpacity style={[styles.actionButton, styles.dangerButton]} onPress={() => setShowResetConfirm(true)}>
-                <IconSymbol name="arrow.counterclockwise" size={20} color={theme.colors.danger} />
+                <IconSymbol name="trash" size={20} color={theme.colors.danger} />
                 <Text style={[styles.actionButtonText, styles.dangerText]}>Reset App Data</Text>
               </TouchableOpacity>
             </View>
@@ -2435,11 +2399,10 @@ export default function ProfileModal({
             {user?.farcaster ? (
               // Connected state
               <>
-                {/* Account card with Disconnect — first item. Icon top-aligned
-                    to match the Warpcast import row. */}
-                <View style={[styles.farcasterConnected, { alignItems: 'flex-start' }]}>
-                  <View style={[styles.farcasterInfo, { alignItems: 'flex-start' }]}>
-                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} style={{ marginTop: Skin.space(2) }} />
+                {/* Account card with Disconnect — first item. */}
+                <View style={styles.farcasterConnected}>
+                  <View style={styles.farcasterInfo}>
+                    <IconSymbol name="checkmark.circle.fill" size={20} color={theme.colors.success} />
                     <View style={styles.farcasterDetails}>
                       <Text style={styles.farcasterUsername}>@{user.farcaster.username}</Text>
                       <Text style={styles.farcasterFid}>FID: {user.farcaster.fid}</Text>
@@ -2513,7 +2476,7 @@ export default function ProfileModal({
                 {/* Warpcast Wallet Import */}
                 {hasWarpcastWallet && !hasImportedWarpcastWallet && onOpenWarpcastImport && (
                   <TouchableOpacity
-                    style={[styles.actionButton, { alignItems: 'flex-start' }]}
+                    style={styles.actionButton}
                     onPress={() => {
                       if (isRouteMode) {
                         // In route mode, just open the import modal directly (no need to close ProfileModal)
@@ -2525,14 +2488,14 @@ export default function ProfileModal({
                       }
                     }}
                   >
-                    <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                    <IconSymbol name="wallet.pass.fill" size={20} color={theme.colors.primary} />
                     <View style={{ flex: 1 }}>
                       <Text style={styles.actionButtonText}>Import Warpcast Wallet</Text>
                       <Text style={[styles.settingDescription, { marginTop: Skin.space(4), marginLeft: Skin.space(12) }]}>
                         Import your Warpcast embedded wallet to use alongside your Quorum wallet
                       </Text>
                     </View>
-                    <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} style={{ marginTop: Skin.space(2) }} />
+                    <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
                   </TouchableOpacity>
                 )}
                 {hasImportedWarpcastWallet && importedWallet && (
@@ -2552,8 +2515,8 @@ export default function ProfileModal({
                 {/* Merge profiles — shown when currently unmerged (parent gates
                     the callback on splitMode). */}
                 {onMergeProfiles && (
-                  <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleMergeProfiles}>
-                    <IconSymbol name="merge" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                  <TouchableOpacity style={styles.actionButton} onPress={handleMergeProfiles}>
+                    <IconSymbol name="merge" size={20} color={theme.colors.primary} />
                     <View style={styles.actionButtonContent}>
                       <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Merge profiles</Text>
                       <Text style={styles.actionButtonSubtext}>Combine your Quorum and Farcaster profiles into one</Text>
@@ -2563,8 +2526,8 @@ export default function ProfileModal({
                 {/* Keep separate (unmerge) — shown when currently merged. Purely a
                     display change; no data is altered. */}
                 {onUnmergeProfiles && (
-                  <TouchableOpacity style={[styles.actionButton, { alignItems: 'flex-start' }]} onPress={handleUnmergeProfiles}>
-                    <IconSymbol name="split" size={20} color={theme.colors.primary} style={{ marginTop: Skin.space(2) }} />
+                  <TouchableOpacity style={styles.actionButton} onPress={handleUnmergeProfiles}>
+                    <IconSymbol name="split" size={20} color={theme.colors.primary} />
                     <View style={styles.actionButtonContent}>
                       <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Separate profiles</Text>
                       <Text style={styles.actionButtonSubtext}>Show and edit your Quorum and Farcaster profiles separately</Text>
@@ -4228,6 +4191,12 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
    *  Account Info card). */
   privacyLevel?: string;
 }) {
+  // Call screening lives in CallContext (module-level, not config-synced);
+  // lazy require avoids an import cycle with the call stack.
+  const [screenUnknownCallers, setScreenUnknownCallers] = React.useState(() => {
+    const { getCallScreening } = require('@/context/CallContext');
+    return getCallScreening();
+  });
   return (
     <>
       {/* Privacy & Sync Settings */}
@@ -4260,6 +4229,24 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             disabled={syncDisabled}
             trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
             thumbColor={allowSync ? '#ffffff' : '#f4f3f4'}
+          />
+        </View>
+        <View style={styles.settingRow}>
+          <View style={styles.settingLeft}>
+            <Text style={styles.settingLabel}>Screen Unknown Callers</Text>
+            <Text style={styles.settingDescription}>
+              Only ring for people you have a conversation with
+            </Text>
+          </View>
+          <Switch
+            value={screenUnknownCallers}
+            onValueChange={(v) => {
+              const { setCallScreening } = require('@/context/CallContext');
+              setCallScreening(v);
+              setScreenUnknownCallers(v);
+            }}
+            trackColor={{ false: theme.colors.surface4, true: theme.colors.accent }}
+            thumbColor={screenUnknownCallers ? '#ffffff' : '#f4f3f4'}
           />
         </View>
         <View style={styles.settingRow}>
@@ -4356,7 +4343,7 @@ const AccountRecoverySection = React.memo(function AccountRecoverySection({
       <Text style={styles.sectionTitle}>Account</Text>
       {!showRecoveryPhrase ? (
         <TouchableOpacity style={styles.actionButton} onPress={onExport}>
-          <IconSymbol name="key.fill" size={20} color={theme.colors.textMain} />
+          <IconSymbol name="key.fill" size={20} color={theme.colors.primary} />
           <Text style={styles.actionButtonText}>Export Recovery Key</Text>
           <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
         </TouchableOpacity>
@@ -4512,10 +4499,10 @@ const DeviceKeysSection = React.memo(function DeviceKeysSection({
         style={[styles.actionButton, { marginTop: Skin.space(16) }]}
         onPress={onResetAllSessions}
       >
-        <IconSymbol name="arrow.triangle.2.circlepath" size={20} color={theme.colors.warning} />
+        <IconSymbol name="arrow.triangle.2.circlepath" size={20} color={theme.colors.primary} />
         <View style={styles.actionButtonContent}>
-          <Text style={styles.actionButtonText}>Reset All DM Sessions</Text>
-          <Text style={styles.actionButtonSubtext}>Fix persistent encryption errors</Text>
+          <Text style={[styles.actionButtonText, { marginLeft: 0 }]}>Fix DM Encryption</Text>
+          <Text style={styles.actionButtonSubtext}>Reset if messages fail to send or decrypt</Text>
         </View>
       </TouchableOpacity>
     </View>

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -170,13 +170,16 @@ function DevModeSection({ theme }: { theme: AppTheme }) {
   const [isLocal, setIsLocal] = React.useState(isDevModeLocal());
   const config = getApiConfig();
 
+  // Warning-tinted dashed box — same "dev builds only" visual language as the
+  // Apex modal's debug panel.
   return (
     <View style={{ marginBottom: Skin.space(24) }}>
-      <Text style={{ fontSize: Skin.font(16), fontFamily: theme.fonts.bold.fontFamily, fontWeight: theme.fonts.bold.fontWeight, color: theme.colors.textMain, marginBottom: Skin.space(12) }}>
-        Developer
+      <Text style={{ fontSize: Skin.font(16), fontFamily: theme.fonts.bold.fontFamily, fontWeight: theme.fonts.bold.fontWeight, color: theme.colors.warning, marginBottom: Skin.space(12) }}>
+        Developer (dev builds only)
       </Text>
-      <View style={{ backgroundColor: theme.colors.surface2, borderRadius: Skin.radius(8), padding: Skin.space(16) }}>
+      <View style={{ backgroundColor: theme.colors.surface2, borderRadius: Skin.radius(8), padding: Skin.space(16), borderWidth: 1, borderStyle: 'dashed', borderColor: theme.colors.warning }}>
         <View style={{ flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' }}>
+          <IconSymbol name="chevron.left.forwardslash.chevron.right" size={20} color={theme.colors.warning} style={{ marginRight: Skin.space(12) }} />
           <View style={{ flex: 1, marginRight: Skin.space(12) }}>
             <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>Use Local API</Text>
             <Text style={{ fontSize: Skin.font(12), color: theme.colors.textSubtle, marginTop: Skin.space(2) }}>
@@ -2236,6 +2239,7 @@ export default function ProfileModal({
             <View style={styles.section}>
               <Text style={styles.sectionTitle}>Appearance</Text>
               <TouchableOpacity style={styles.settingRow} onPress={() => setSkinsOpen(true)}>
+                <IconSymbol name="paintpalette" size={20} color={theme.colors.primary} style={styles.settingIcon} />
                 <View style={styles.settingLeft}>
                   <Text style={styles.settingLabel}>Skins</Text>
                   <Text style={styles.settingDescription}>
@@ -2247,6 +2251,7 @@ export default function ProfileModal({
                 <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
               </TouchableOpacity>
               <TouchableOpacity style={styles.settingRow} onPress={() => setTranslateOpen(true)}>
+                <IconSymbol name="language" size={20} color={theme.colors.primary} style={styles.settingIcon} />
                 <View style={styles.settingLeft}>
                   <Text style={styles.settingLabel}>Translate to</Text>
                   <Text style={styles.settingDescription}>
@@ -2431,6 +2436,7 @@ export default function ProfileModal({
                 {/* Feed display preferences — Farcaster-only (drive useFarcasterFeed).
                     Plain settingRow → uniform 8px marginBottom like every card. */}
                 <View style={styles.settingRow}>
+                  <IconSymbol name="bubble.left.and.bubble.right" size={20} color={theme.colors.primary} style={styles.settingIcon} />
                   <View style={styles.settingLeft}>
                     <Text style={styles.settingLabel}>Show replies in main feed</Text>
                     <Text style={styles.settingDescription}>
@@ -2445,6 +2451,7 @@ export default function ProfileModal({
                   />
                 </View>
                 <View style={styles.settingRow}>
+                  <IconSymbol name="bubble.left.and.bubble.right" size={20} color={theme.colors.primary} style={styles.settingIcon} />
                   <View style={styles.settingLeft}>
                     <Text style={styles.settingLabel}>Show replies from non-followed in main feed</Text>
                     <Text style={styles.settingDescription}>
@@ -2461,6 +2468,7 @@ export default function ProfileModal({
                 </View>
                 {/* Hypersnap signer opt-in */}
                 <View style={styles.farcasterConnected}>
+                  <IconSymbol name="bolt" size={20} color={theme.colors.primary} style={styles.settingIcon} />
                   <View style={{ flex: 1, marginRight: Skin.space(12) }}>
                     <Text style={{ fontSize: Skin.font(15), color: theme.colors.textMain }}>Hypersnap Signer</Text>
                     <Text style={{ fontSize: Skin.font(12), color: theme.colors.textSubtle, marginTop: Skin.space(2) }}>
@@ -3463,6 +3471,9 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       borderRadius: Skin.radius(8),
       marginBottom: Skin.space(8),
     },
+    settingIcon: {
+      marginRight: Skin.space(12),
+    },
     settingLeft: {
       flex: 1,
       marginRight: Skin.space(16),
@@ -4207,6 +4218,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Privacy & Sync</Text>
         <View style={styles.settingRow}>
+          <IconSymbol name="eye" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Public Profile</Text>
             <Text style={styles.settingDescription}>
@@ -4221,6 +4233,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
           />
         </View>
         <View style={styles.settingRow}>
+          <IconSymbol name="arrow.2.circlepath" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Enable Sync</Text>
             <Text style={styles.settingDescription}>
@@ -4236,6 +4249,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
           />
         </View>
         <View style={styles.settingRow}>
+          <IconSymbol name="phone" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Screen Unknown Callers</Text>
             <Text style={styles.settingDescription}>
@@ -4254,6 +4268,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
           />
         </View>
         <View style={styles.settingRow}>
+          <IconSymbol name="checkmark" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Delivery receipts</Text>
             <Text style={styles.settingDescription}>
@@ -4272,6 +4287,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             desktop, which hides this row while delivery is off). */}
         {deliveryReceipts && (
           <View style={styles.settingRow}>
+            <IconSymbol name="checkmark.double" size={20} color={theme.colors.primary} style={styles.settingIcon} />
             <View style={styles.settingLeft}>
               <Text style={styles.settingLabel}>Read receipts</Text>
               <Text style={styles.settingDescription}>
@@ -4293,6 +4309,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
             ships. (issue #58) */}
         {/* Privacy Level — read-only (moved from the old Account Info card). */}
         <View style={styles.settingRow}>
+          <IconSymbol name="shield" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Privacy Level</Text>
           </View>
@@ -4306,6 +4323,7 @@ const PrivacySettingsSection = React.memo(function PrivacySettingsSection({
       <View style={styles.section}>
         <Text style={styles.sectionTitle}>Notifications</Text>
         <View style={styles.settingRow}>
+          <IconSymbol name="bell" size={20} color={theme.colors.primary} style={styles.settingIcon} />
           <View style={styles.settingLeft}>
             <Text style={styles.settingLabel}>Push Notifications</Text>
             <Text style={styles.settingDescription}>Receive notifications on your device</Text>

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -50,6 +50,7 @@ import { useMMKVBoolean, useMMKVString } from 'react-native-mmkv';
 import {
   translationPrefsStore,
   K_TARGET_LANGUAGE,
+  isTranslationOff,
   resolveTarget,
 } from '@/services/translation/translationPrefs';
 import { languageName } from '@/components/translation/languages';
@@ -392,6 +393,7 @@ export default function ProfileModal({
   const [skinsOpen, setSkinsOpen] = React.useState(false);
   const [translateOpen, setTranslateOpen] = React.useState(false);
   const [storedTarget] = useMMKVString(K_TARGET_LANGUAGE, translationPrefsStore);
+  const translationOff = isTranslationOff(storedTarget);
   const targetLanguageName = languageName(resolveTarget(storedTarget));
   const [showNamePickerModal, setShowNamePickerModal] = React.useState(false);
 
@@ -2248,7 +2250,9 @@ export default function ProfileModal({
                 <View style={styles.settingLeft}>
                   <Text style={styles.settingLabel}>Translate to</Text>
                   <Text style={styles.settingDescription}>
-                    {`On-device translation target: ${targetLanguageName}`}
+                    {translationOff
+                      ? 'Translation is turned off'
+                      : `On-device translation target: ${targetLanguageName}`}
                   </Text>
                 </View>
                 <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -1908,7 +1908,7 @@ export default function ProfileModal({
                     }
                   }}
                 >
-                  <IconSymbol name="tag.fill" size={18} color={theme.colors.primary} />
+                  <IconSymbol name="tag" size={18} color={theme.colors.primary} />
                   <Text style={styles.marketplaceButtonText}>List on Marketplace</Text>
                 </TouchableOpacity>
               </View>
@@ -1920,21 +1920,21 @@ export default function ProfileModal({
                 style={styles.marketplaceButton}
                 onPress={() => onOpenMarketplace ? onOpenMarketplace() : setMarketplaceModalVisible(true)}
               >
-                <IconSymbol name="storefront.fill" size={18} color={theme.colors.primary} />
+                <IconSymbol name="storefront" size={18} color={theme.colors.primary} />
                 <Text style={styles.marketplaceButtonText}>Browse Marketplace</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={styles.marketplaceButton}
                 onPress={() => onOpenAuctions ? onOpenAuctions() : setAuctionsModalVisible(true)}
               >
-                <IconSymbol name="hammer.fill" size={18} color={theme.colors.primary} />
+                <IconSymbol name="hammer" size={18} color={theme.colors.primary} />
                 <Text style={styles.marketplaceButtonText}>Auctions</Text>
               </TouchableOpacity>
               <TouchableOpacity
                 style={styles.marketplaceButton}
                 onPress={() => onOpenOffers ? onOpenOffers() : setOffersModalVisible(true)}
               >
-                <IconSymbol name="envelope.fill" size={18} color={theme.colors.primary} />
+                <IconSymbol name="envelope" size={18} color={theme.colors.primary} />
                 <Text style={styles.marketplaceButtonText}>Offers</Text>
               </TouchableOpacity>
             </View>
@@ -2174,13 +2174,13 @@ export default function ProfileModal({
             <View style={styles.benefitsSection}>
               <Text style={styles.sectionTitle}>Benefits</Text>
               <View style={styles.benefitItem}>
-                <IconSymbol name="person.badge.shield.checkmark.fill" size={20} color={theme.colors.primary} />
+                <IconSymbol name="person.badge.shield.checkmark" size={20} color={theme.colors.primary} />
                 <Text style={styles.benefitText}>
                   Unique identity across the Quilibrium network
                 </Text>
               </View>
               <View style={styles.benefitItem}>
-                <IconSymbol name="hand.thumbsup.fill" size={20} color={theme.colors.primary} />
+                <IconSymbol name="hand.thumbsup" size={20} color={theme.colors.primary} />
                 <Text style={styles.benefitText}>
                   Earn governance points to participate in QNS decisions
                 </Text>

--- a/components/SocialFeed/CastOverflowButton.tsx
+++ b/components/SocialFeed/CastOverflowButton.tsx
@@ -106,7 +106,7 @@ export function CastOverflowButton({
       ? [
           {
             label: 'Translate',
-            icon: 'globe',
+            icon: 'language',
             onPress: () => requestTranslateText(castText!),
           },
         ]

--- a/components/SocialFeed/CastOverflowButton.tsx
+++ b/components/SocialFeed/CastOverflowButton.tsx
@@ -17,11 +17,17 @@ import { useBlockedFids } from '@/hooks/useBlockedFids';
 import { useMutedFids } from '@/hooks/useMutedFids';
 import { useUserVisibilityActions } from '@/hooks/useUserVisibilityActions';
 import { useConfirmDialog } from '@/hooks/useConfirmDialog';
+import { useMMKVString } from 'react-native-mmkv';
 import { requestTranslateText } from '@/services/translation/forceTranslate';
 import {
   ensureAvailabilityProbed,
   translationAvailableCached,
 } from '@/services/translation/availability';
+import {
+  translationPrefsStore,
+  K_TARGET_LANGUAGE,
+  isTranslationOff,
+} from '@/services/translation/translationPrefs';
 import type { AppTheme } from '@/theme';
 
 interface CastOverflowButtonProps {
@@ -68,7 +74,12 @@ export function CastOverflowButton({
   React.useEffect(() => {
     ensureAvailabilityProbed().then(setTranslateAvailable);
   }, []);
-  const canTranslate = translateAvailable && !!castText && castText.trim().length > 0;
+  const [storedTarget] = useMMKVString(K_TARGET_LANGUAGE, translationPrefsStore);
+  const canTranslate =
+    translateAvailable &&
+    !isTranslationOff(storedTarget) &&
+    !!castText &&
+    castText.trim().length > 0;
 
   const who = authorUsername ? `@${authorUsername}` : 'this user';
   const fail = (verb: string) =>

--- a/components/apex/ApexSubscribeModal.tsx
+++ b/components/apex/ApexSubscribeModal.tsx
@@ -520,7 +520,10 @@ export default function ApexSubscribeModal({ visible, onClose, mode }: ApexSubsc
         {/* DEV-ONLY debug panel — never rendered in release builds. */}
         {__DEV__ && (
           <View style={styles.debugBox}>
-            <Text style={styles.debugTitle}>Debug (dev builds only)</Text>
+            <View style={{ flexDirection: 'row', alignItems: 'center', gap: Skin.space(6) }}>
+              <IconSymbol name="chevron.left.forwardslash.chevron.right" size={16} color={theme.colors.warning} />
+              <Text style={styles.debugTitle}>Debug (dev builds only)</Text>
+            </View>
             <Text style={styles.debugHint}>
               Walk the Apex flow without paying. Empty slot picks are padded
               with debug spaces; state is local-only.

--- a/components/shared/ActionRow.tsx
+++ b/components/shared/ActionRow.tsx
@@ -65,18 +65,13 @@ export function ActionRow(props: ActionRowProps) {
 
   const interactive = !!props.onPress && !props.disabled;
 
-  // Single-line rows center the leading glyph (aligned with the one line);
-  // multi-line rows (with a sublabel) TOP-align it so it pairs with the TITLE,
-  // not the gap between title and sublabel — the standard iOS/Material pattern.
-  // Single-line behavior is unchanged from before.
-  const multiline = !!props.sublabel;
-  const leadingNudge = multiline ? styles.leadingTopNudge : undefined;
-
+  // Leading icon and trailing control are vertically CENTERED against the full
+  // row height, on single- and multi-line rows alike (product decision — no
+  // top-aligned glyphs anywhere).
   return (
     <TouchableOpacity
       style={[
         styles.row,
-        multiline && styles.rowMultiline,
         props.isLast && styles.rowLast,
         props.style,
       ]}
@@ -88,13 +83,11 @@ export function ActionRow(props: ActionRowProps) {
       accessibilityState={{ disabled: !!props.disabled }}
     >
       {props.leading ? (
-        // Top-nudge a custom leading node too (channel icon, avatar) so it lines
-        // up with the title on multi-line rows.
-        multiline ? <View style={leadingNudge}>{props.leading}</View> : props.leading
+        props.leading
       ) : props.icon ? (
         // icon name is validated by IconSymbol's mapping at runtime; the strict
         // union type is too narrow for a generic wrapper.
-        <IconSymbol name={props.icon as IconSymbolName} size={20} color={color} style={leadingNudge} />
+        <IconSymbol name={props.icon as IconSymbolName} size={20} color={color} />
       ) : (
         <View style={styles.iconSpacer} />
       )}
@@ -113,16 +106,9 @@ export function ActionRow(props: ActionRowProps) {
       </View>
 
       {props.trailing === 'chevron' ? (
-        <IconSymbol
-          name="chevron.right"
-          size={16}
-          color={theme.colors.textMuted}
-          style={multiline ? styles.trailingCenter : undefined}
-        />
+        <IconSymbol name="chevron.right" size={16} color={theme.colors.textMuted} />
       ) : props.trailing ? (
-        // Keep the trailing control (Switch, chevron…) vertically centered even
-        // when the row top-aligns its leading icon + text for a sublabel.
-        multiline ? <View style={styles.trailingCenter}>{props.trailing}</View> : props.trailing
+        props.trailing
       ) : null}
     </TouchableOpacity>
   );
@@ -173,25 +159,11 @@ const createRowStyles = (theme: AppTheme) =>
       borderBottomWidth: Skin.border(1),
       borderBottomColor: theme.colors.surface4,
     },
-    rowMultiline: {
-      // Top-align leading icon + text column for two-line rows (icon pairs with
-      // the title). The trailing control is re-centered via `trailingCenter`.
-      alignItems: 'flex-start',
-    },
     rowLast: {
       borderBottomWidth: 0,
     },
     iconSpacer: {
       width: 20,
-    },
-    // Optical nudge so a 20px glyph sits on the title's text line (not the very
-    // cap top) when the row is top-aligned.
-    leadingTopNudge: {
-      marginTop: Skin.space(2),
-    },
-    // Re-center a trailing control against the full row height on multi-line rows.
-    trailingCenter: {
-      alignSelf: 'center',
     },
     labelColumn: {
       flex: 1,

--- a/components/translation/TranslateLanguageModal.tsx
+++ b/components/translation/TranslateLanguageModal.tsx
@@ -2,6 +2,8 @@
  * TranslateLanguageModal — "Translate to…" picker. Lets the user override the
  * device language used as the translation target. Selecting "Device default"
  * clears the override (stored as ''), so the app follows the device language.
+ * "Do not translate" stores the TRANSLATION_OFF sentinel, disabling the
+ * feature everywhere (no inline toggles, no context-menu Translate).
  *
  * The value is read/written reactively via MMKV so visible casts/messages
  * re-evaluate their translation toggle the moment it changes.
@@ -18,6 +20,7 @@ import * as Skin from '@/theme/skins/geometry';
 import {
   translationPrefsStore,
   K_TARGET_LANGUAGE,
+  TRANSLATION_OFF,
   deviceLanguage,
 } from '@/services/translation/translationPrefs';
 import { TRANSLATE_LANGUAGES, languageName } from './languages';
@@ -57,6 +60,17 @@ export function TranslateLanguageModal({
             <Text style={s.rowDescription}>{languageName(device)}</Text>
           </View>
           {effective === '' && (
+            <IconSymbol name="checkmark" size={18} color={theme.colors.accent} />
+          )}
+        </TouchableOpacity>
+
+        {/* Do not translate — disables the feature everywhere */}
+        <TouchableOpacity style={s.row} onPress={() => select(TRANSLATION_OFF)}>
+          <View style={s.rowLeft}>
+            <Text style={s.rowLabel}>Do not translate</Text>
+            <Text style={s.rowDescription}>Never show translation options</Text>
+          </View>
+          {effective === TRANSLATION_OFF && (
             <IconSymbol name="checkmark" size={18} color={theme.colors.accent} />
           )}
         </TouchableOpacity>

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -68,6 +68,7 @@ const SF_TO_TABLER = {
   'checkmark.circle': tabler('IconCircleCheck'),
   'checkmark.circle.fill': tabler('IconCircleCheck', 'IconCircleCheckFilled'),
   'checkmark': tabler('IconCheck'),
+  'checkmark.double': tabler('IconChecks'),
   'checkmark.seal.fill': tabler('IconRosetteDiscountCheck', 'IconRosetteDiscountCheckFilled'),
 
   // Documents
@@ -79,6 +80,7 @@ const SF_TO_TABLER = {
   // Geometry
   'circle': tabler('IconCircle', 'IconCircleFilled'),
   'paintbrush': tabler('IconBrush'),
+  'paintpalette': tabler('IconPalette', 'IconPaletteFilled'),
   'square.grid.2x2': tabler('IconLayoutGrid'),
   'square.grid.2x2.fill': tabler('IconLayoutGrid'),
   'rectangle.grid.2x2': tabler('IconLayoutGrid'),
@@ -162,6 +164,7 @@ const SF_TO_TABLER = {
 
   // Globe / web
   'globe': tabler('IconWorld'),
+  'language': tabler('IconLanguage'),
   'world-map': tabler('IconWorldMap'),
   'safari': tabler('IconCompass'),
   'safari.fill': tabler('IconCompass', 'IconCompassFilled'),
@@ -190,6 +193,7 @@ const SF_TO_TABLER = {
   'eye.slash.fill': tabler('IconEyeOff'),
 
   // Hardware / signals
+  'bolt': tabler('IconBolt', 'IconBoltFilled'),
   'bolt.fill': tabler('IconBolt', 'IconBoltFilled'),
   'server.rack': tabler('IconServer'),
   'wifi.slash': tabler('IconWifiOff'),

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -180,9 +180,11 @@ const SF_TO_TABLER = {
   'person.crop.circle': tabler('IconUserCircle'),
   'person.crop.circle.fill': tabler('IconUserCircle', 'IconUserCircleFilled'),
   'person.crop.circle.badge.exclamationmark': tabler('IconUserExclamation'),
+  'person.badge.shield.checkmark': tabler('IconShieldCheck', 'IconShieldCheckFilled'),
   'person.badge.shield.checkmark.fill': tabler('IconShieldCheck', 'IconShieldCheckFilled'),
   'hand.raised.fill': tabler('IconHandStop'),
   'hand.raised.slash.fill': tabler('IconHandOff'),
+  'hand.thumbsup': tabler('IconThumbUp', 'IconThumbUpFilled'),
   'hand.thumbsup.fill': tabler('IconThumbUp', 'IconThumbUpFilled'),
   'hand.thumbsdown.fill': tabler('IconThumbDown', 'IconThumbDownFilled'),
 
@@ -233,6 +235,7 @@ const SF_TO_TABLER = {
 
   // Building / share
   'building.columns': tabler('IconBuildingBank'),
+  'storefront': tabler('IconBuildingStore', 'IconBuildingStoreFilled'),
   'storefront.fill': tabler('IconBuildingStore', 'IconBuildingStoreFilled'),
   'square.and.arrow.up': tabler('IconShare'),
   'square.and.arrow.down': tabler('IconDownload'),
@@ -317,6 +320,7 @@ const SF_TO_TABLER = {
   'clock.arrow.circlepath': tabler('IconHistory'),
 
   // Tags
+  'tag': tabler('IconTag', 'IconTagFilled'),
   'tag.fill': tabler('IconTag', 'IconTagFilled'),
   'tag.slash': tabler('IconTagOff'),
 

--- a/components/ui/tablerIconRegistry.ts
+++ b/components/ui/tablerIconRegistry.ts
@@ -24,6 +24,7 @@ import IconAlertCircle from '@tabler/icons-react-native/IconAlertCircle';
 import IconAlertCircleFilled from '@tabler/icons-react-native/IconAlertCircleFilled';
 import IconAlertTriangle from '@tabler/icons-react-native/IconAlertTriangle';
 import IconAlertTriangleFilled from '@tabler/icons-react-native/IconAlertTriangleFilled';
+import IconAnkh from '@tabler/icons-react-native/IconAnkh';
 import IconArrowBackUp from '@tabler/icons-react-native/IconArrowBackUp';
 import IconArrowDownLeft from '@tabler/icons-react-native/IconArrowDownLeft';
 import IconArrowDownRight from '@tabler/icons-react-native/IconArrowDownRight';
@@ -44,6 +45,8 @@ import IconBellFilled from '@tabler/icons-react-native/IconBellFilled';
 import IconBellOff from '@tabler/icons-react-native/IconBellOff';
 import IconBolt from '@tabler/icons-react-native/IconBolt';
 import IconBoltFilled from '@tabler/icons-react-native/IconBoltFilled';
+import IconBomb from '@tabler/icons-react-native/IconBomb';
+import IconBombFilled from '@tabler/icons-react-native/IconBombFilled';
 import IconBook from '@tabler/icons-react-native/IconBook';
 import IconBookFilled from '@tabler/icons-react-native/IconBookFilled';
 import IconBookmark from '@tabler/icons-react-native/IconBookmark';
@@ -67,6 +70,7 @@ import IconCertificate from '@tabler/icons-react-native/IconCertificate';
 import IconChartBar from '@tabler/icons-react-native/IconChartBar';
 import IconChartLine from '@tabler/icons-react-native/IconChartLine';
 import IconCheck from '@tabler/icons-react-native/IconCheck';
+import IconChecks from '@tabler/icons-react-native/IconChecks';
 import IconChevronDown from '@tabler/icons-react-native/IconChevronDown';
 import IconChevronLeft from '@tabler/icons-react-native/IconChevronLeft';
 import IconChevronRight from '@tabler/icons-react-native/IconChevronRight';
@@ -96,9 +100,12 @@ import IconCompass from '@tabler/icons-react-native/IconCompass';
 import IconCompassFilled from '@tabler/icons-react-native/IconCompassFilled';
 import IconConfetti from '@tabler/icons-react-native/IconConfetti';
 import IconConfettiFilled from '@tabler/icons-react-native/IconConfettiFilled';
+import IconConfucius from '@tabler/icons-react-native/IconConfucius';
 import IconCopy from '@tabler/icons-react-native/IconCopy';
 import IconCreditCard from '@tabler/icons-react-native/IconCreditCard';
 import IconCreditCardFilled from '@tabler/icons-react-native/IconCreditCardFilled';
+import IconCross from '@tabler/icons-react-native/IconCross';
+import IconCrossFilled from '@tabler/icons-react-native/IconCrossFilled';
 import IconCrown from '@tabler/icons-react-native/IconCrown';
 import IconCrownFilled from '@tabler/icons-react-native/IconCrownFilled';
 import IconCurrencyBitcoin from '@tabler/icons-react-native/IconCurrencyBitcoin';
@@ -131,21 +138,28 @@ import IconFlame from '@tabler/icons-react-native/IconFlame';
 import IconFlameFilled from '@tabler/icons-react-native/IconFlameFilled';
 import IconFlask from '@tabler/icons-react-native/IconFlask';
 import IconFlaskFilled from '@tabler/icons-react-native/IconFlaskFilled';
+import IconFlower from '@tabler/icons-react-native/IconFlower';
 import IconFolder from '@tabler/icons-react-native/IconFolder';
 import IconFolderFilled from '@tabler/icons-react-native/IconFolderFilled';
+import IconGenderFemale from '@tabler/icons-react-native/IconGenderFemale';
+import IconGenderMale from '@tabler/icons-react-native/IconGenderMale';
+import IconGhost from '@tabler/icons-react-native/IconGhost';
+import IconGhost3 from '@tabler/icons-react-native/IconGhost3';
+import IconGhost3Filled from '@tabler/icons-react-native/IconGhost3Filled';
 import IconGift from '@tabler/icons-react-native/IconGift';
 import IconGiftFilled from '@tabler/icons-react-native/IconGiftFilled';
 import IconGripVertical from '@tabler/icons-react-native/IconGripVertical';
 import IconHammer from '@tabler/icons-react-native/IconHammer';
+import IconHandLoveYou from '@tabler/icons-react-native/IconHandLoveYou';
 import IconHandOff from '@tabler/icons-react-native/IconHandOff';
 import IconHandStop from '@tabler/icons-react-native/IconHandStop';
-import IconHandTwoFingers from '@tabler/icons-react-native/IconHandTwoFingers';
 import IconHash from '@tabler/icons-react-native/IconHash';
 import IconHeadphones from '@tabler/icons-react-native/IconHeadphones';
 import IconHeadset from '@tabler/icons-react-native/IconHeadset';
 import IconHeadsetFilled from '@tabler/icons-react-native/IconHeadsetFilled';
 import IconHeart from '@tabler/icons-react-native/IconHeart';
 import IconHeartFilled from '@tabler/icons-react-native/IconHeartFilled';
+import IconHeartHandshake from '@tabler/icons-react-native/IconHeartHandshake';
 import IconHelpCircle from '@tabler/icons-react-native/IconHelpCircle';
 import IconHelpCircleFilled from '@tabler/icons-react-native/IconHelpCircleFilled';
 import IconHistory from '@tabler/icons-react-native/IconHistory';
@@ -153,9 +167,12 @@ import IconHome from '@tabler/icons-react-native/IconHome';
 import IconHomeFilled from '@tabler/icons-react-native/IconHomeFilled';
 import IconInfoCircle from '@tabler/icons-react-native/IconInfoCircle';
 import IconInfoCircleFilled from '@tabler/icons-react-native/IconInfoCircleFilled';
+import IconJewishStar from '@tabler/icons-react-native/IconJewishStar';
+import IconJewishStarFilled from '@tabler/icons-react-native/IconJewishStarFilled';
 import IconKey from '@tabler/icons-react-native/IconKey';
 import IconKeyFilled from '@tabler/icons-react-native/IconKeyFilled';
 import IconKeyboard from '@tabler/icons-react-native/IconKeyboard';
+import IconLanguage from '@tabler/icons-react-native/IconLanguage';
 import IconLayoutGrid from '@tabler/icons-react-native/IconLayoutGrid';
 import IconLeaf from '@tabler/icons-react-native/IconLeaf';
 import IconLifebuoy from '@tabler/icons-react-native/IconLifebuoy';
@@ -170,6 +187,7 @@ import IconMailOpened from '@tabler/icons-react-native/IconMailOpened';
 import IconMapPin from '@tabler/icons-react-native/IconMapPin';
 import IconMapPinFilled from '@tabler/icons-react-native/IconMapPinFilled';
 import IconMaximize from '@tabler/icons-react-native/IconMaximize';
+import IconMenorah from '@tabler/icons-react-native/IconMenorah';
 import IconMenu2 from '@tabler/icons-react-native/IconMenu2';
 import IconMessage from '@tabler/icons-react-native/IconMessage';
 import IconMessageFilled from '@tabler/icons-react-native/IconMessageFilled';
@@ -180,12 +198,12 @@ import IconMicrophoneFilled from '@tabler/icons-react-native/IconMicrophoneFille
 import IconMicrophoneOff from '@tabler/icons-react-native/IconMicrophoneOff';
 import IconMinimize from '@tabler/icons-react-native/IconMinimize';
 import IconMinus from '@tabler/icons-react-native/IconMinus';
-import IconMoodHappy from '@tabler/icons-react-native/IconMoodHappy';
 import IconMoodHappyFilled from '@tabler/icons-react-native/IconMoodHappyFilled';
 import IconMoodSmile from '@tabler/icons-react-native/IconMoodSmile';
 import IconMoodSmileFilled from '@tabler/icons-react-native/IconMoodSmileFilled';
 import IconMoon from '@tabler/icons-react-native/IconMoon';
 import IconMoonFilled from '@tabler/icons-react-native/IconMoonFilled';
+import IconOm from '@tabler/icons-react-native/IconOm';
 import IconPalette from '@tabler/icons-react-native/IconPalette';
 import IconPaletteFilled from '@tabler/icons-react-native/IconPaletteFilled';
 import IconPaperclip from '@tabler/icons-react-native/IconPaperclip';
@@ -234,12 +252,12 @@ import IconShieldX from '@tabler/icons-react-native/IconShieldX';
 import IconSparkles from '@tabler/icons-react-native/IconSparkles';
 import IconSparklesFilled from '@tabler/icons-react-native/IconSparklesFilled';
 import IconSpeakerphone from '@tabler/icons-react-native/IconSpeakerphone';
+import IconSpiral from '@tabler/icons-react-native/IconSpiral';
 import IconSquare from '@tabler/icons-react-native/IconSquare';
 import IconSquareFilled from '@tabler/icons-react-native/IconSquareFilled';
 import IconStack from '@tabler/icons-react-native/IconStack';
 import IconStack2 from '@tabler/icons-react-native/IconStack2';
 import IconStack2Filled from '@tabler/icons-react-native/IconStack2Filled';
-import IconStackFilled from '@tabler/icons-react-native/IconStackFilled';
 import IconStar from '@tabler/icons-react-native/IconStar';
 import IconStarFilled from '@tabler/icons-react-native/IconStarFilled';
 import IconSun from '@tabler/icons-react-native/IconSun';
@@ -248,6 +266,7 @@ import IconSword from '@tabler/icons-react-native/IconSword';
 import IconTag from '@tabler/icons-react-native/IconTag';
 import IconTagFilled from '@tabler/icons-react-native/IconTagFilled';
 import IconTagOff from '@tabler/icons-react-native/IconTagOff';
+import IconTank from '@tabler/icons-react-native/IconTank';
 import IconTarget from '@tabler/icons-react-native/IconTarget';
 import IconThumbDown from '@tabler/icons-react-native/IconThumbDown';
 import IconThumbDownFilled from '@tabler/icons-react-native/IconThumbDownFilled';
@@ -278,27 +297,6 @@ import IconWifiOff from '@tabler/icons-react-native/IconWifiOff';
 import IconWorld from '@tabler/icons-react-native/IconWorld';
 import IconWorldMap from '@tabler/icons-react-native/IconWorldMap';
 import IconX from '@tabler/icons-react-native/IconX';
-// Channel-icon-picker additions (2026-06-26).
-import IconSticker from '@tabler/icons-react-native/IconSticker';
-import IconTank from '@tabler/icons-react-native/IconTank';
-import IconGenderFemale from '@tabler/icons-react-native/IconGenderFemale';
-import IconGenderMale from '@tabler/icons-react-native/IconGenderMale';
-import IconBomb from '@tabler/icons-react-native/IconBomb';
-import IconBombFilled from '@tabler/icons-react-native/IconBombFilled';
-import IconOm from '@tabler/icons-react-native/IconOm';
-import IconCross from '@tabler/icons-react-native/IconCross';
-import IconCrossFilled from '@tabler/icons-react-native/IconCrossFilled';
-import IconMenorah from '@tabler/icons-react-native/IconMenorah';
-import IconAnkh from '@tabler/icons-react-native/IconAnkh';
-import IconJewishStar from '@tabler/icons-react-native/IconJewishStar';
-import IconJewishStarFilled from '@tabler/icons-react-native/IconJewishStarFilled';
-import IconConfucius from '@tabler/icons-react-native/IconConfucius';
-import IconGhost3 from '@tabler/icons-react-native/IconGhost3';
-import IconGhost3Filled from '@tabler/icons-react-native/IconGhost3Filled';
-import IconSpiral from '@tabler/icons-react-native/IconSpiral';
-import IconHeartHandshake from '@tabler/icons-react-native/IconHeartHandshake';
-import IconFlower from '@tabler/icons-react-native/IconFlower';
-import IconHandLoveYou from '@tabler/icons-react-native/IconHandLoveYou';
 
 export const TablerIcons = {
   IconAi,
@@ -306,6 +304,7 @@ export const TablerIcons = {
   IconAlertCircleFilled,
   IconAlertTriangle,
   IconAlertTriangleFilled,
+  IconAnkh,
   IconArrowBackUp,
   IconArrowDownLeft,
   IconArrowDownRight,
@@ -326,6 +325,8 @@ export const TablerIcons = {
   IconBellOff,
   IconBolt,
   IconBoltFilled,
+  IconBomb,
+  IconBombFilled,
   IconBook,
   IconBookFilled,
   IconBookmark,
@@ -349,6 +350,7 @@ export const TablerIcons = {
   IconChartBar,
   IconChartLine,
   IconCheck,
+  IconChecks,
   IconChevronDown,
   IconChevronLeft,
   IconChevronRight,
@@ -378,9 +380,12 @@ export const TablerIcons = {
   IconCompassFilled,
   IconConfetti,
   IconConfettiFilled,
+  IconConfucius,
   IconCopy,
   IconCreditCard,
   IconCreditCardFilled,
+  IconCross,
+  IconCrossFilled,
   IconCrown,
   IconCrownFilled,
   IconCurrencyBitcoin,
@@ -413,21 +418,28 @@ export const TablerIcons = {
   IconFlameFilled,
   IconFlask,
   IconFlaskFilled,
+  IconFlower,
   IconFolder,
   IconFolderFilled,
+  IconGenderFemale,
+  IconGenderMale,
+  IconGhost,
+  IconGhost3,
+  IconGhost3Filled,
   IconGift,
   IconGiftFilled,
   IconGripVertical,
   IconHammer,
+  IconHandLoveYou,
   IconHandOff,
   IconHandStop,
-  IconHandTwoFingers,
   IconHash,
   IconHeadphones,
   IconHeadset,
   IconHeadsetFilled,
   IconHeart,
   IconHeartFilled,
+  IconHeartHandshake,
   IconHelpCircle,
   IconHelpCircleFilled,
   IconHistory,
@@ -435,9 +447,12 @@ export const TablerIcons = {
   IconHomeFilled,
   IconInfoCircle,
   IconInfoCircleFilled,
+  IconJewishStar,
+  IconJewishStarFilled,
   IconKey,
   IconKeyFilled,
   IconKeyboard,
+  IconLanguage,
   IconLayoutGrid,
   IconLeaf,
   IconLifebuoy,
@@ -452,6 +467,7 @@ export const TablerIcons = {
   IconMapPin,
   IconMapPinFilled,
   IconMaximize,
+  IconMenorah,
   IconMenu2,
   IconMessage,
   IconMessageFilled,
@@ -462,12 +478,12 @@ export const TablerIcons = {
   IconMicrophoneOff,
   IconMinimize,
   IconMinus,
-  IconMoodHappy,
   IconMoodHappyFilled,
   IconMoodSmile,
   IconMoodSmileFilled,
   IconMoon,
   IconMoonFilled,
+  IconOm,
   IconPalette,
   IconPaletteFilled,
   IconPaperclip,
@@ -516,12 +532,12 @@ export const TablerIcons = {
   IconSparkles,
   IconSparklesFilled,
   IconSpeakerphone,
+  IconSpiral,
   IconSquare,
   IconSquareFilled,
   IconStack,
   IconStack2,
   IconStack2Filled,
-  IconStackFilled,
   IconStar,
   IconStarFilled,
   IconSun,
@@ -530,6 +546,7 @@ export const TablerIcons = {
   IconTag,
   IconTagFilled,
   IconTagOff,
+  IconTank,
   IconTarget,
   IconThumbDown,
   IconThumbDownFilled,
@@ -560,25 +577,4 @@ export const TablerIcons = {
   IconWorld,
   IconWorldMap,
   IconX,
-  // Channel-icon-picker additions (2026-06-26).
-  IconSticker,
-  IconTank,
-  IconGenderFemale,
-  IconGenderMale,
-  IconBomb,
-  IconBombFilled,
-  IconOm,
-  IconCross,
-  IconCrossFilled,
-  IconMenorah,
-  IconAnkh,
-  IconJewishStar,
-  IconJewishStarFilled,
-  IconConfucius,
-  IconGhost3,
-  IconGhost3Filled,
-  IconSpiral,
-  IconHeartHandshake,
-  IconFlower,
-  IconHandLoveYou,
 };

--- a/hooks/useComposerPanel.ts
+++ b/hooks/useComposerPanel.ts
@@ -283,11 +283,17 @@ export function useComposerPanel(options: ComposerPanelOptions = {}): ComposerPa
       // never stack over the same zone.
       const restingFootprint = restingChromeHeight + bottomInset;
       const panelHeight = Math.max(lastKeyboardHeight.value, restingFootprint);
-      // On a cold open the spacer ramps the panel in by coldOpenSV — track the
-      // SAME ramp here so the list lift stays in lockstep with the sliding panel
-      // (no gap between the last message and the rising panel during the slide).
-      const rampedPanel = restingFootprint + (panelHeight - restingFootprint) * coldOpenSV.value;
-      return Math.max(0, rampedPanel - liveKeyboardHeight);
+      // Publish the FULL footprint in one step — do NOT track the spacer's
+      // cold-open ramp (coldOpenSV) here. Ramping the published footprint
+      // per-frame breaks the lift on Android: the keyboard library computes
+      // each frame's scroll target as `scroll + delta` from a scroll position
+      // that lags several frames behind its own deferred scrollTo calls, so
+      // successive small deltas overwrite each other instead of accumulating
+      // (measured: ~26px of a ~173px lift). One step = one big delta computed
+      // off a fresh base = the full lift, at the cost of the list rising
+      // slightly ahead of the panel slide (the accepted "single deferred
+      // correction" behavior this feature shipped with).
+      return Math.max(0, panelHeight - liveKeyboardHeight);
     },
     (panelFootprint) => {
       composerPanelFootprintSV.value = panelFootprint;

--- a/services/translation/translationPrefs.ts
+++ b/services/translation/translationPrefs.ts
@@ -9,6 +9,11 @@
  *
  * An empty stored value means "follow the device language", so switching back
  * to the device default just writes ''.
+ *
+ * The sentinel TRANSLATION_OFF ('off' — not a valid ISO-639 code) disables the
+ * feature entirely: no toggles, no context-menu Translate. Consumers gate on
+ * `isTranslationOff(stored)`; the resolve helpers below never leak the sentinel
+ * as a language code.
  */
 
 import { createMMKV } from 'react-native-mmkv';
@@ -17,6 +22,14 @@ import { getLocales } from 'expo-localization';
 export const translationPrefsStore = createMMKV({ id: 'quorum-translation-prefs' });
 
 export const K_TARGET_LANGUAGE = 'targetLanguage';
+
+/** Stored in K_TARGET_LANGUAGE to mean "do not translate anywhere". */
+export const TRANSLATION_OFF = 'off';
+
+/** Whether the stored value disables the translation feature entirely. */
+export function isTranslationOff(stored: string | undefined): boolean {
+  return stored === TRANSLATION_OFF;
+}
 
 /** Device language as an ISO-639 primary code (e.g. "en", "es"). */
 export function deviceLanguage(): string {
@@ -27,10 +40,11 @@ export function deviceLanguage(): string {
   }
 }
 
-/** The effective target language: user override if set, else device language. */
+/** The effective target language: user override if set, else device language.
+ *  Returns the device language for TRANSLATION_OFF — check isTranslationOff. */
 export function getTargetLanguage(): string {
   const v = translationPrefsStore.getString(K_TARGET_LANGUAGE);
-  return v && v.length > 0 ? v : deviceLanguage();
+  return resolveTarget(v);
 }
 
 /** Set a manual override. Pass '' to revert to following the device language. */
@@ -38,7 +52,10 @@ export function setTargetLanguage(code: string): void {
   translationPrefsStore.set(K_TARGET_LANGUAGE, code);
 }
 
-/** Resolve a possibly-reactive stored value to an effective code. */
+/** Resolve a possibly-reactive stored value to an effective code. The OFF
+ *  sentinel resolves to the device language so it never reaches the translator
+ *  as a bogus code — callers gate the feature via isTranslationOff first. */
 export function resolveTarget(stored: string | undefined): string {
-  return stored && stored.length > 0 ? stored : deviceLanguage();
+  if (!stored || stored.length === 0 || stored === TRANSLATION_OFF) return deviceLanguage();
+  return stored;
 }

--- a/services/translation/useTranslatable.ts
+++ b/services/translation/useTranslatable.ts
@@ -23,6 +23,7 @@ import {
   translationPrefsStore,
   K_TARGET_LANGUAGE,
   resolveTarget,
+  isTranslationOff,
 } from './translationPrefs';
 import {
   detectLanguage,
@@ -87,6 +88,9 @@ export interface Translatable {
 
 export function useTranslatable(rawText: string, enabled: boolean): Translatable {
   const [storedTarget] = useMMKVString(K_TARGET_LANGUAGE, translationPrefsStore);
+  // "Do not translate" pref kills the whole feature: no auto-offer, no forced
+  // menu translation. Applied on top of the caller's `enabled`.
+  const off = isTranslationOff(storedTarget);
   const target = primary(resolveTarget(storedTarget));
 
   const [state, setState] = useState<TranslateState>('original');
@@ -122,7 +126,7 @@ export function useTranslatable(rawText: string, enabled: boolean): Translatable
   // anyway"). Self-contained: detects a source if needed.
   const runTranslate = useCallback(async () => {
     const text = (rawText ?? '').trim();
-    if (!text) return;
+    if (!text || off) return;
     if (stateRef.current === 'downloading' || stateRef.current === 'translating') return;
 
     const h = hashText(text);
@@ -166,7 +170,7 @@ export function useTranslatable(rawText: string, enabled: boolean): Translatable
     } catch {
       if (mountedRef.current) setState('error');
     }
-  }, [rawText, target, detectOnce]);
+  }, [rawText, target, off, detectOnce]);
 
   // Keep a stable ref so the force subscription always calls the latest closure.
   const runTranslateRef = useRef(runTranslate);
@@ -180,7 +184,7 @@ export function useTranslatable(rawText: string, enabled: boolean): Translatable
     detectedRef.current = null;
 
     const text = (rawText ?? '').trim();
-    if (!enabled || !longEnough(text)) return;
+    if (!enabled || off || !longEnough(text)) return;
 
     let cancelled = false;
     (async () => {
@@ -203,17 +207,17 @@ export function useTranslatable(rawText: string, enabled: boolean): Translatable
     return () => {
       cancelled = true;
     };
-  }, [rawText, target, enabled, detectOnce]);
+  }, [rawText, target, enabled, off, detectOnce]);
 
   // Subscribe to context-menu "Translate" requests for this exact text.
   useEffect(() => {
-    if (!enabled) return;
+    if (!enabled || off) return;
     const text = (rawText ?? '').trim();
     if (!text) return;
     return subscribeForce(hashText(text), () => {
       runTranslateRef.current();
     });
-  }, [rawText, enabled]);
+  }, [rawText, enabled, off]);
 
   const toggle = useCallback(() => {
     if (stateRef.current === 'translated') {


### PR DESCRIPTION
UI and chat polish across the account settings, Farcaster tab, premium tab, and message list, plus a small translation feature and two chat scroll fixes.

**Settings & profile modal**
- Rename "Reset All DM Sessions" to "Fix DM Encryption"; align row, confirm dialog, and success copy with the per-conversation option (both non-destructive: primary confirm button, accent icon)
- Icons on every settings row (Privacy & Sync, Notifications, Appearance, Farcaster tab); left icons standardize on the accent color; outline variants replace filled ones in the premium tab and call bubble
- Move Screen Unknown Callers into Privacy & Sync and drop the empty Calls section; Danger Zone gets a red title and outline trash icon; Developer section restyled in the warning "dev builds only" language shared with the Apex debug panel
- Centered leading icons and trailing chevrons everywhere (Farcaster tab boxes and the shared ActionRow)

**Translation**
- New "Do not translate" option in the Translate to picker: disables the feature everywhere (inline toggles, both context menus, settings row shows it's off)

**Chat**
- Emoji-only messages: 1.2x line box so enlarged emoji no longer clip top/bottom
- Send: deferred second scroll pass so much-taller-than-average cells (emoji-only) land exactly at the list end instead of over-scrolling
- Emoji panel cold open: publish the panel footprint in one step so the message list lifts the full distance again on Android (per-frame ramping let deltas overwrite each other)

**Dev**
- Silence the "WebSocket error" unhandled-rejection LogBox flood (upstream transport bug; dev-only suppression)

## Commits
- 0965928 ui: settings polish — DM encryption copy, centered row icons, accent icon color
- 0b33d8a translation: add a Do not translate option that disables the feature
- de66f09 dev: silence the WebSocket error unhandled-rejection LogBox flood
- f1677b4 ui: icons on all settings rows, dev sections in warning style
- 7faa6ee ui: outline icons in premium tab and call bubble, fix emoji clipping
- f018ece fix(chat): emoji send over-scroll and cold-open emoji-panel list lift