### PR TITLE
ui: link-style confirmation actions and skin-aware button corners

### DIFF
--- a/components/BlockUserModal.tsx
+++ b/components/BlockUserModal.tsx
@@ -13,7 +13,7 @@ import { truncateAddress } from '@/utils/formatAddress';
 import React, { useCallback } from 'react';
 import { View, Text, StyleSheet, Image } from 'react-native';
 import { BaseModal } from '@/components/shared/BaseModal';
-import { Button } from '@/components/ui/Button';
+import { ConfirmActions } from '@/components/shared/ConfirmActions';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import * as Skin from '@/theme/skins/geometry';
@@ -79,14 +79,12 @@ export function BlockUserModal({
             : `You won't see any of ${userName}'s messages in this space. This only affects your view, and only in this space. You can unblock anytime.`}
         </Text>
 
-        <View style={styles.buttonRow}>
-          <Button variant="secondary" size="lg" onPress={onClose} style={styles.button}>
-            Cancel
-          </Button>
-          <Button variant="primary" size="lg" onPress={handleConfirm} style={styles.button}>
-            {isUnblocking ? 'Unblock' : 'Block'}
-          </Button>
-        </View>
+        <ConfirmActions
+          confirmLabel={isUnblocking ? 'Unblock' : 'Block'}
+          variant={isUnblocking ? 'primary' : 'danger'}
+          onConfirm={handleConfirm}
+          onCancel={onClose}
+        />
       </View>
     </BaseModal>
   );
@@ -146,13 +144,6 @@ const createStyles = (theme: AppTheme) =>
       textAlign: 'center',
       marginBottom: Skin.space(24),
       lineHeight: Skin.font(20),
-    },
-    buttonRow: {
-      flexDirection: 'row',
-      gap: Skin.space(12),
-    },
-    button: {
-      flex: 1,
     },
   });
 

--- a/components/Chat/DMSettingsSheet.tsx
+++ b/components/Chat/DMSettingsSheet.tsx
@@ -4,7 +4,7 @@
 
 import type { AppTheme } from '@/theme';
 import React, { useState } from 'react';
-import { View, Text, StyleSheet, Alert, Switch, Image } from 'react-native';
+import { View, Text, StyleSheet, Switch, Image } from 'react-native';
 import { BaseModal, ActionRow, ActionRowGroup } from '@/components/shared';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { resetDMSession } from '@/hooks/chat/useSendDirectMessage';
@@ -138,10 +138,9 @@ export function DMSettingsSheet({
     if (!ok) return;
     resetDMSession(conversationId);
     onClose();
-    Alert.alert(
-      'Encryption Reset',
-      'Your next message will establish a fresh secure connection.'
-    );
+    // No success alert. The confirm dialog already told the user exactly what
+    // would happen and they agreed to it; a second modal restating the same
+    // sentence is one more tap for no new information.
   };
 
   return (

--- a/components/KickUserModal.tsx
+++ b/components/KickUserModal.tsx
@@ -12,7 +12,7 @@ import { truncateAddress } from '@/utils/formatAddress';
 import React, { useEffect, useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Image } from 'react-native';
 import { BaseModal } from '@/components/shared/BaseModal';
-import { Button } from '@/components/ui/Button';
+import { ConfirmActions } from '@/components/shared/ConfirmActions';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import { useUserKicking } from '@/hooks/chat/useUserKicking';
@@ -120,26 +120,13 @@ export function KickUserModal({
         </Text>
 
         {/* Buttons */}
-        <View style={styles.buttonRow}>
-          <Button
-            variant="secondary"
-            size="lg"
-            onPress={onClose}
-            disabled={isSaving}
-            style={styles.button}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="danger"
-            size="lg"
-            onPress={handleKickWithOverlay}
-            disabled={isSaving || kicking}
-            style={styles.button}
-          >
-            Kick
-          </Button>
-        </View>
+        <ConfirmActions
+          confirmLabel="Kick"
+          onConfirm={handleKickWithOverlay}
+          onCancel={onClose}
+          cancelDisabled={isSaving}
+          confirmDisabled={isSaving || kicking}
+        />
       </View>
     </BaseModal>
   );
@@ -210,13 +197,6 @@ const createStyles = (theme: AppTheme) =>
       fontFamily: theme.fonts.regular.fontFamily,
       textAlign: 'center',
       marginBottom: Skin.space(24),
-    },
-    buttonRow: {
-      flexDirection: 'row',
-      gap: Skin.space(12),
-    },
-    button: {
-      flex: 1,
     },
   });
 

--- a/components/MiniAppApprovalModal.tsx
+++ b/components/MiniAppApprovalModal.tsx
@@ -8,9 +8,8 @@
  * Private keys are never passed to or handled by this modal.
  */
 
-import { BaseModal } from '@/components/shared';
+import { BaseModal, ConfirmActions } from '@/components/shared';
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
-import { Button } from '@/components/ui/Button';
 import WalletSelector from '@/components/wallet/WalletSelector';
 import { useTheme, type AppTheme } from '@/theme';
 import React from 'react';
@@ -299,28 +298,17 @@ export default function MiniAppApprovalModal({
         </ScrollView>
 
         {/* Actions - fixed at bottom */}
-        <View style={styles.actions}>
-          <Button
-            variant="secondary"
-            size="lg"
-            onPress={handleReject}
-            disabled={isProcessing}
-            style={styles.button}
-          >
-            Reject
-          </Button>
-
-          <Button
-            variant="primary"
-            size="lg"
-            onPress={handleApprove}
-            disabled={isProcessing}
-            loading={isProcessing}
-            style={styles.button}
-          >
-            {request.type === 'transaction' ? 'Confirm' : 'Sign'}
-          </Button>
-        </View>
+        <ConfirmActions
+          confirmLabel={request.type === 'transaction' ? 'Confirm' : 'Sign'}
+          cancelLabel="Reject"
+          variant="primary"
+          onConfirm={handleApprove}
+          onCancel={handleReject}
+          cancelDisabled={isProcessing}
+          confirmDisabled={isProcessing}
+          confirmLoading={isProcessing}
+          style={styles.actions}
+        />
       </View>
     </BaseModal>
   );
@@ -464,8 +452,5 @@ const createStyles = (theme: AppTheme, isDark: boolean) =>
       flexDirection: 'row',
       gap: Skin.space(12),
       paddingVertical: Skin.space(16),
-    },
-    button: {
-      flex: 1,
     },
   });

--- a/components/MuteUserModal.tsx
+++ b/components/MuteUserModal.tsx
@@ -14,7 +14,7 @@ import { truncateAddress } from '@/utils/formatAddress';
 import React, { useEffect, useCallback, useState } from 'react';
 import { View, Text, StyleSheet, ActivityIndicator, Image, TextInput } from 'react-native';
 import { BaseModal } from '@/components/shared/BaseModal';
-import { Button } from '@/components/ui/Button';
+import { ConfirmActions } from '@/components/shared/ConfirmActions';
 import { DefaultAvatar } from '@/components/ui/DefaultAvatar';
 import { useTheme, type AppTheme } from '@/theme';
 import { useModMuteUser } from '@/hooks/chat/useModMuteUser';
@@ -142,26 +142,14 @@ export function MuteUserModal({
             : `This user will be muted ${durationLabel} and unable to post in this space. 0 = forever.`}
         </Text>
 
-        <View style={styles.buttonRow}>
-          <Button
-            variant="secondary"
-            size="lg"
-            onPress={onClose}
-            disabled={isSaving}
-            style={styles.button}
-          >
-            Cancel
-          </Button>
-          <Button
-            variant="primary"
-            size="lg"
-            onPress={handleConfirm}
-            disabled={isSaving}
-            style={styles.button}
-          >
-            {isUnmuting ? 'Unmute' : 'Mute'}
-          </Button>
-        </View>
+        <ConfirmActions
+          confirmLabel={isUnmuting ? 'Unmute' : 'Mute'}
+          variant={isUnmuting ? 'primary' : 'danger'}
+          onConfirm={handleConfirm}
+          onCancel={onClose}
+          cancelDisabled={isSaving}
+          confirmDisabled={isSaving}
+        />
       </View>
     </BaseModal>
   );
@@ -261,13 +249,6 @@ const createStyles = (theme: AppTheme) =>
       fontFamily: theme.fonts.regular.fontFamily,
       textAlign: 'center',
       marginBottom: Skin.space(24),
-    },
-    buttonRow: {
-      flexDirection: 'row',
-      gap: Skin.space(12),
-    },
-    button: {
-      flex: 1,
     },
   });
 

--- a/components/ProfileModal.tsx
+++ b/components/ProfileModal.tsx
@@ -671,7 +671,8 @@ export default function ProfileModal({
       });
       if (!ok) return;
       encryptionStateStorage.clearAll();
-      Alert.alert('Encryption Reset', 'Your next message to each contact will establish a fresh secure connection.');
+      // No success alert — the confirm dialog already stated this outcome and
+      // the user accepted it. Restating it in a second modal is pure friction.
     })();
   }, [confirm]);
 

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -8,7 +8,7 @@ import React, { useState } from 'react';
 import { Alert, KeyboardAvoidingView, Modal, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { TouchableOpacity } from '@/components/ui/SkinTouchable';
-import { Button } from '@/components/ui/Button';
+import { ConfirmActions } from '@/components/shared/ConfirmActions';
 import type { AppTheme } from '@/theme';
 import { useTheme } from '@/theme';
 import { useAuth } from '@/context/AuthContext';
@@ -174,27 +174,16 @@ export function ReportModal({ visible, onClose, target, onSubmitted }: ReportMod
               editable={!submitting}
             />
 
-            <View style={styles.actions}>
-              <Button
-                variant="secondary"
-                size="lg"
-                onPress={handleClose}
-                disabled={submitting}
-                style={styles.button}
-              >
-                Cancel
-              </Button>
-              <Button
-                variant="primary"
-                size="lg"
-                onPress={handleSubmit}
-                disabled={!reason || submitting}
-                loading={submitting}
-                style={styles.button}
-              >
-                Submit report
-              </Button>
-            </View>
+            <ConfirmActions
+              confirmLabel="Submit report"
+              variant="primary"
+              onConfirm={handleSubmit}
+              onCancel={handleClose}
+              cancelDisabled={submitting}
+              confirmDisabled={!reason || submitting}
+              confirmLoading={submitting}
+              style={styles.actions}
+            />
           </Pressable>
         </KeyboardAvoidingView>
       </Pressable>
@@ -262,9 +251,6 @@ const createStyles = (theme: AppTheme) =>
       justifyContent: 'flex-end',
       gap: Skin.space(12),
       marginTop: Skin.space(4),
-    },
-    button: {
-      minWidth: 120,
     },
   });
 

--- a/components/TransactionWarningModal.tsx
+++ b/components/TransactionWarningModal.tsx
@@ -1,6 +1,5 @@
 import { IconSymbol, type IconSymbolName } from '@/components/ui/IconSymbol';
-import { BaseModal } from '@/components/shared';
-import { Button } from '@/components/ui/Button';
+import { BaseModal, ConfirmActions } from '@/components/shared';
 import { useTheme, type AppTheme } from '@/theme';
 import type { EdgeInsets } from 'react-native-safe-area-context';
 import React from 'react';
@@ -154,19 +153,13 @@ export default function TransactionWarningModal({
         </>)}
 
       {/* Action Buttons */}
-      <View style={styles.buttonContainer}>
-        <Button variant="secondary" size="lg" onPress={onClose} style={styles.button}>
-          Cancel
-        </Button>
-        <Button
-          variant={warningConfig.severity === 'high' ? 'danger' : 'primary'}
-          size="lg"
-          onPress={onProceed}
-          style={styles.button}
-        >
-          {warningConfig.severity === 'high' ? 'Proceed Anyway' : 'Continue'}
-        </Button>
-      </View>
+      <ConfirmActions
+        confirmLabel={warningConfig.severity === 'high' ? 'Proceed Anyway' : 'Continue'}
+        variant={warningConfig.severity === 'high' ? 'danger' : 'primary'}
+        onConfirm={onProceed}
+        onCancel={onClose}
+        style={styles.buttonContainer}
+      />
     </BaseModal>
   );
 }
@@ -260,8 +253,5 @@ const createStyles = (theme: AppTheme, isDark: boolean, insets: EdgeInsets) =>
       paddingHorizontal: Skin.space(20),
       paddingBottom: insets.bottom + 16,
       gap: Skin.space(12),
-    },
-    button: {
-      flex: 1,
     },
   });

--- a/components/shared/ConfirmActions.tsx
+++ b/components/shared/ConfirmActions.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import { useTheme } from '@/theme';
+import { createTheme } from '@/theme/themes';
+import * as Skin from '@/theme/skins/geometry';
+import { Button } from '@/components/ui/Button';
+
+type ThemeType = ReturnType<typeof createTheme>;
+
+export interface ConfirmActionsProps {
+  /** Label for the action (e.g. "Delete", "Kick", "Block"). */
+  confirmLabel: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** Dismissive label. Not always literally "Cancel" — e.g. "Reject". */
+  cancelLabel?: string;
+  /** 'danger' tints the action red (default). 'primary' for a non-destructive confirm. */
+  variant?: 'danger' | 'primary';
+  confirmDisabled?: boolean;
+  confirmLoading?: boolean;
+  cancelDisabled?: boolean;
+  /** Extra layout the host needs (outer padding, margins). */
+  style?: StyleProp<ViewStyle>;
+  confirmTestID?: string;
+  cancelTestID?: string;
+}
+
+/**
+ * ConfirmActions — the cancel/confirm pair every confirmation surface uses.
+ *
+ * Rendered as right-aligned text links rather than filled slabs. Two filled
+ * buttons side by side give "cancel" and the destructive action equal visual
+ * weight, and a full-width coloured block reads as the modal's subject rather
+ * than its action. The action link carries the danger token (or the accent when
+ * non-destructive); cancel takes a subtle text colour so it stays available
+ * without competing.
+ *
+ * This exists as one component rather than a copied JSX block because it was
+ * previously hand-rolled in eight places, which is how confirmation styling
+ * drifts apart one modal at a time.
+ *
+ * Tap targets stay ~50pt tall: the links trade horizontal padding for a tighter
+ * look but keep the `lg` vertical padding.
+ */
+export function ConfirmActions({
+  confirmLabel,
+  onConfirm,
+  onCancel,
+  cancelLabel = 'Cancel',
+  variant = 'danger',
+  confirmDisabled,
+  confirmLoading,
+  cancelDisabled,
+  style,
+  confirmTestID,
+  cancelTestID,
+}: ConfirmActionsProps) {
+  const { theme } = useTheme();
+  const styles = createStyles(theme);
+
+  return (
+    <View style={[styles.row, style]}>
+      <Button
+        variant="ghost"
+        size="lg"
+        color={theme.colors.textSubtle}
+        disabled={cancelDisabled}
+        onPress={onCancel}
+        style={styles.link}
+        testID={cancelTestID}
+      >
+        {cancelLabel}
+      </Button>
+      <Button
+        variant="ghost"
+        size="lg"
+        color={variant === 'danger' ? theme.colors.danger : theme.colors.primary}
+        disabled={confirmDisabled}
+        loading={confirmLoading}
+        onPress={onConfirm}
+        style={styles.link}
+        testID={confirmTestID}
+      >
+        {confirmLabel}
+      </Button>
+    </View>
+  );
+}
+
+const createStyles = (_theme: ThemeType) =>
+  StyleSheet.create({
+    row: {
+      flexDirection: 'row',
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      gap: Skin.space(4),
+      // The links keep a generous tap target via their own horizontal padding;
+      // pull the row out by that much so the last label optically aligns with
+      // the surrounding text edge rather than sitting inset from it.
+      marginRight: -Skin.space(12),
+    },
+    link: {
+      // Tighter than the `lg` default (28) — these read as links, not slabs.
+      // Vertical padding is untouched, so the tap target stays ~50pt tall.
+      paddingHorizontal: Skin.space(12),
+    },
+  });
+
+export default ConfirmActions;

--- a/components/shared/ConfirmActions.tsx
+++ b/components/shared/ConfirmActions.tsx
@@ -94,10 +94,15 @@ const createStyles = (_theme: ThemeType) =>
       justifyContent: 'flex-end',
       alignItems: 'center',
       gap: Skin.space(4),
-      // The links keep a generous tap target via their own horizontal padding;
-      // pull the row out by that much so the last label optically aligns with
-      // the surrounding text edge rather than sitting inset from it.
+      // The links carry padding on all four sides purely to keep a ~50pt tap
+      // target. That padding is invisible, so it stacks on the host's own
+      // padding and reads as dead space — most obviously below the row, where
+      // the link's 16 and the card's 20 left the labels floating well off the
+      // bottom edge. Pull the row back out by roughly the overhang so the
+      // labels optically align with the surrounding text block, without
+      // shrinking the touch area.
       marginRight: -Skin.space(12),
+      marginBottom: -Skin.space(10),
     },
     link: {
       // Tighter than the `lg` default (28) — these read as links, not slabs.

--- a/components/shared/ConfirmDialog.tsx
+++ b/components/shared/ConfirmDialog.tsx
@@ -85,7 +85,9 @@ const createStyles = (theme: ThemeType) =>
       fontFamily: theme.fonts.regular.fontFamily,
       color: theme.colors.textSubtle,
       lineHeight: Skin.font(20),
-      marginBottom: Skin.space(20),
+      // The action links contribute their own top padding, so this only needs
+      // to cover the difference — 20 here stacked into an oversized gap.
+      marginBottom: Skin.space(12),
     },
   });
 

--- a/components/shared/ConfirmDialog.tsx
+++ b/components/shared/ConfirmDialog.tsx
@@ -25,8 +25,15 @@ export interface ConfirmDialogProps {
 
 /**
  * ConfirmDialog — a center-anchored "are you sure?" for destructive actions
- * (T1/T2). The action button uses the skin danger token, so it's visibly red on
- * BOTH iOS and Android (native Alert.alert can't do this on Android).
+ * (T1/T2).
+ *
+ * Actions render as right-aligned text links, not filled slabs: two filled
+ * buttons side by side give equal visual weight to "cancel" and "destroy", and
+ * a full-width red block reads as the modal's subject rather than its action.
+ * The action link carries the skin danger token (or the accent for a
+ * non-destructive confirm) so intent stays legible on BOTH iOS and Android —
+ * native Alert.alert can't colour its buttons on Android. Cancel is a subtle
+ * text colour, present but not competing.
  *
  * Backdrop tap and Android back resolve to Cancel (owned by CenterModal).
  */
@@ -54,10 +61,22 @@ export function ConfirmDialog({
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.message}>{message}</Text>
       <View style={styles.actions}>
-        <Button variant="secondary" size="lg" onPress={onCancel} style={styles.button}>
+        <Button
+          variant="ghost"
+          size="lg"
+          color={theme.colors.textSubtle}
+          onPress={onCancel}
+          style={styles.button}
+        >
           {cancelLabel}
         </Button>
-        <Button variant={variant} size="lg" onPress={onConfirm} style={styles.button}>
+        <Button
+          variant="ghost"
+          size="lg"
+          color={variant === 'danger' ? theme.colors.danger : theme.colors.primary}
+          onPress={onConfirm}
+          style={styles.button}
+        >
           {confirmLabel}
         </Button>
       </View>
@@ -83,10 +102,18 @@ const createStyles = (theme: ThemeType) =>
     },
     actions: {
       flexDirection: 'row',
-      gap: Skin.space(10),
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      gap: Skin.space(4),
+      // The links keep a generous tap target via their own horizontal padding;
+      // pull the row out by that much so the last label optically aligns with
+      // the card's text edge rather than sitting inset from it.
+      marginRight: -Skin.space(12),
     },
     button: {
-      flex: 1,
+      // Tighter than the `lg` default (28) — these read as links, not slabs.
+      // Vertical padding is untouched, so the tap target stays ~50pt tall.
+      paddingHorizontal: Skin.space(12),
     },
   });
 

--- a/components/shared/ConfirmDialog.tsx
+++ b/components/shared/ConfirmDialog.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text } from 'react-native';
 import { useTheme } from '@/theme';
 import { createTheme } from '@/theme/themes';
 import * as Skin from '@/theme/skins/geometry';
-import { Button } from '@/components/ui/Button';
 import { CenterModal } from './CenterModal';
+import { ConfirmActions } from './ConfirmActions';
 
 type ThemeType = ReturnType<typeof createTheme>;
 
@@ -60,26 +60,13 @@ export function ConfirmDialog({
     >
       <Text style={styles.title}>{title}</Text>
       <Text style={styles.message}>{message}</Text>
-      <View style={styles.actions}>
-        <Button
-          variant="ghost"
-          size="lg"
-          color={theme.colors.textSubtle}
-          onPress={onCancel}
-          style={styles.button}
-        >
-          {cancelLabel}
-        </Button>
-        <Button
-          variant="ghost"
-          size="lg"
-          color={variant === 'danger' ? theme.colors.danger : theme.colors.primary}
-          onPress={onConfirm}
-          style={styles.button}
-        >
-          {confirmLabel}
-        </Button>
-      </View>
+      <ConfirmActions
+        confirmLabel={confirmLabel}
+        cancelLabel={cancelLabel}
+        variant={variant}
+        onConfirm={onConfirm}
+        onCancel={onCancel}
+      />
     </CenterModal>
   );
 }
@@ -99,21 +86,6 @@ const createStyles = (theme: ThemeType) =>
       color: theme.colors.textSubtle,
       lineHeight: Skin.font(20),
       marginBottom: Skin.space(20),
-    },
-    actions: {
-      flexDirection: 'row',
-      justifyContent: 'flex-end',
-      alignItems: 'center',
-      gap: Skin.space(4),
-      // The links keep a generous tap target via their own horizontal padding;
-      // pull the row out by that much so the last label optically aligns with
-      // the card's text edge rather than sitting inset from it.
-      marginRight: -Skin.space(12),
-    },
-    button: {
-      // Tighter than the `lg` default (28) — these read as links, not slabs.
-      // Vertical padding is untouched, so the tap target stays ~50pt tall.
-      paddingHorizontal: Skin.space(12),
     },
   });
 

--- a/components/shared/TypeToConfirmModal.tsx
+++ b/components/shared/TypeToConfirmModal.tsx
@@ -3,8 +3,8 @@ import { KeyboardAvoidingView, Platform, StyleSheet, Text, TextInput, View } fro
 import { useTheme } from '@/theme';
 import { createTheme } from '@/theme/themes';
 import * as Skin from '@/theme/skins/geometry';
-import { Button } from '@/components/ui/Button';
 import { CenterModal } from './CenterModal';
+import { ConfirmActions } from './ConfirmActions';
 
 type ThemeType = ReturnType<typeof createTheme>;
 
@@ -106,27 +106,13 @@ export function TypeToConfirmModal({
           accessibilityLabel={`Type ${keyword} to confirm`}
         />
 
-        <View style={styles.actions}>
-          <Button
-            variant="ghost"
-            size="lg"
-            color={theme.colors.textSubtle}
-            onPress={handleCancel}
-            style={styles.button}
-          >
-            {cancelLabel}
-          </Button>
-          <Button
-            variant="ghost"
-            size="lg"
-            color={theme.colors.danger}
-            onPress={onConfirm}
-            disabled={!matches}
-            style={styles.button}
-          >
-            {confirmLabel}
-          </Button>
-        </View>
+        <ConfirmActions
+          confirmLabel={confirmLabel}
+          cancelLabel={cancelLabel}
+          onConfirm={onConfirm}
+          onCancel={handleCancel}
+          confirmDisabled={!matches}
+        />
       </KeyboardAvoidingView>
     </CenterModal>
   );
@@ -191,18 +177,6 @@ const createStyles = (theme: ThemeType) =>
       fontFamily: theme.fonts.regular.fontFamily,
       color: theme.colors.textMain,
       marginBottom: Skin.space(20),
-    },
-    actions: {
-      flexDirection: 'row',
-      justifyContent: 'flex-end',
-      alignItems: 'center',
-      gap: Skin.space(4),
-      // Matches ConfirmDialog: pull the row out by the links' own horizontal
-      // padding so the last label optically aligns with the card's text edge.
-      marginRight: -Skin.space(12),
-    },
-    button: {
-      paddingHorizontal: Skin.space(12),
     },
   });
 

--- a/components/shared/TypeToConfirmModal.tsx
+++ b/components/shared/TypeToConfirmModal.tsx
@@ -107,12 +107,19 @@ export function TypeToConfirmModal({
         />
 
         <View style={styles.actions}>
-          <Button variant="secondary" size="lg" onPress={handleCancel} style={styles.button}>
+          <Button
+            variant="ghost"
+            size="lg"
+            color={theme.colors.textSubtle}
+            onPress={handleCancel}
+            style={styles.button}
+          >
             {cancelLabel}
           </Button>
           <Button
-            variant="danger"
+            variant="ghost"
             size="lg"
+            color={theme.colors.danger}
             onPress={onConfirm}
             disabled={!matches}
             style={styles.button}
@@ -187,10 +194,15 @@ const createStyles = (theme: ThemeType) =>
     },
     actions: {
       flexDirection: 'row',
-      gap: Skin.space(10),
+      justifyContent: 'flex-end',
+      alignItems: 'center',
+      gap: Skin.space(4),
+      // Matches ConfirmDialog: pull the row out by the links' own horizontal
+      // padding so the last label optically aligns with the card's text edge.
+      marginRight: -Skin.space(12),
     },
     button: {
-      flex: 1,
+      paddingHorizontal: Skin.space(12),
     },
   });
 

--- a/components/shared/index.ts
+++ b/components/shared/index.ts
@@ -6,6 +6,8 @@ export { ActionRow, ActionRowGroup } from './ActionRow';
 export type { ActionRowProps, ActionRowGroupProps } from './ActionRow';
 export { CenterModal } from './CenterModal';
 export type { CenterModalProps } from './CenterModal';
+export { ConfirmActions } from './ConfirmActions';
+export type { ConfirmActionsProps } from './ConfirmActions';
 export { ConfirmDialog } from './ConfirmDialog';
 export type { ConfirmDialogProps } from './ConfirmDialog';
 export { TypeToConfirmModal } from './TypeToConfirmModal';

--- a/components/ui/Button.tsx
+++ b/components/ui/Button.tsx
@@ -5,7 +5,6 @@ import {
   StyleProp,
   Text,
   TouchableOpacity,
-  View,
   ViewStyle,
   TextStyle,
 } from 'react-native';
@@ -165,6 +164,11 @@ const createStyles = (
   color?: string
 ) => {
   const getBackgroundColor = () => {
+    // Ghost/outline stay transparent even when disabled — the disabled fill
+    // would turn a link into what looks like a filled button, which is exactly
+    // backwards (see TypeToConfirmModal, whose action is disabled until the
+    // keyword matches). Disabled is conveyed by the muted label + opacity.
+    if (variant === 'ghost' || variant === 'outline') return 'transparent';
     if (disabled) return theme.colors.surface3;
     switch (variant) {
       case 'primary':
@@ -175,9 +179,6 @@ const createStyles = (
         return color ?? theme.colors.danger;
       case 'success':
         return color ?? theme.colors.success;
-      case 'ghost':
-      case 'outline':
-        return 'transparent';
     }
   };
 
@@ -224,7 +225,9 @@ const createStyles = (
       alignItems: 'center',
       justifyContent: 'center',
       backgroundColor: getBackgroundColor(),
-      borderRadius: size === 'sm' ? 6 : size === 'md' ? 8 : 12,
+      // Skin-scaled like every other corner in the app — without this a 'square'
+      // or 'pill' skin left every button at the default rounding.
+      borderRadius: Skin.radius(size === 'sm' ? 6 : size === 'md' ? 8 : 12),
       ...getPadding(),
       ...(variant === 'outline'
         ? {


### PR DESCRIPTION
Confirmation dialogs now present their actions as right-aligned text links instead of filled buttons, and buttons finally follow the active skin's corner radius.

## Confirmation actions

Two filled buttons side by side gave "cancel" and the destructive action equal visual weight, and a full-width coloured slab read as the modal's subject rather than its action. Both actions are now text links: the action carries the danger token (or the accent when non-destructive), cancel takes a subtle text colour so it stays available without competing.

The cancel/confirm pair had been hand-rolled in **eight** places, each with its own near-identical row style. That is how confirmation styling drifts apart one modal at a time, so it is now a single `ConfirmActions` component and every surface points at it:

`ConfirmDialog`, `TypeToConfirmModal`, `BlockUserModal`, `KickUserModal`, `MuteUserModal`, `TransactionWarningModal`, `MiniAppApprovalModal`, `ReportModal`

Hosts that need their own outer padding pass it through `style`, so the bottom-anchored rows keep their spacing above the safe area.

Block and Mute now tint their action with the danger token rather than the accent — both hide someone's messages. The unblock/unmute direction stays on the accent, since it restores rather than removes.

Two surfaces were deliberately left on filled buttons: `BrowserModal`'s Farcaster prompt, which offers two forward paths ("Close App" / "Import Account") rather than confirm-and-cancel, and `MnemonicDisplayView`, whose single button advances an onboarding step and has nothing to cancel.

## Skin-aware button corners

`Button` hardcoded its corner radius, so a `square` or `pill` skin reshaped the surface around a button while the button itself stayed at the default rounding. Now scaled through the skin like every other corner. An audit of every modal and sheet found the modal windows themselves were already correct; the button was the only offender, and every other non-scaled radius is a deliberate circle (avatars, dots, pills).

Ghost and outline buttons also picked up a filled grey background when disabled, which turned a link into what looked like a filled button. Most visible in `TypeToConfirmModal`, whose action stays disabled until the keyword matches. They now stay transparent and convey disabled through the muted label.

## Redundant reset confirmation

Resetting DM encryption popped a success modal after the confirm dialog, in both the user settings and conversation settings flows. The confirm dialog already stated the outcome and the user accepted it, so the second modal was one more tap for no new information. Removed from both.

## Spacing

The action links pad all four sides purely to hold a ~50pt tap target. That padding is invisible, so it stacked on the host's own padding and read as dead space, worst below the row where the link's 16 plus the card's 20 left the labels floating off the bottom edge. The row is pulled back by roughly the overhang so the labels align optically with the surrounding text, with no change to the touch area.

## Verification

- `npx tsc --noEmit` — 48 errors, identical to the pre-change baseline. Zero new.
- `npx jest` — 108 passed / 13 suites.
- `npx eslint` on all changed files — the 4 remaining items were confirmed pre-existing by re-running against a stashed tree.

**Not visually verified** — no working emulator, and this is a purely visual change. Wants a device pass on both light and dark plus at least one non-default skin to confirm the button corners track.

`MiniAppApprovalModal` is the one worth a careful look: it approves wallet transactions and signatures, and this makes "Confirm"/"Sign" a text link rather than a filled button. Arguably safer against fat-fingering, but it departs from the usual wallet convention.

## Commits

- ui: link-style confirmation actions, skin-aware button corners
- ui: extract ConfirmActions, apply link-style actions to every confirmation
- ui: tighten the dead space around confirmation action links
