### PR TITLE
ui: pill corners follow the skin like every other radius

### DIFF
--- a/theme/themes.ts
+++ b/theme/themes.ts
@@ -122,7 +122,15 @@ const createTheme = (
     sm: skin?.radii?.sm ?? rad(BASE_RADII.sm),
     md: skin?.radii?.md ?? rad(BASE_RADII.md),
     lg: skin?.radii?.lg ?? rad(BASE_RADII.lg),
-    pill: skin?.radii?.pill ?? BASE_RADII.pill,
+    // `pill` scales too, and the huge base value is what makes that safe: a skin
+    // can never make a capsule rounder (999 * 2.2 still clamps to half the
+    // element's height), so the only scale that changes anything is 0 — and a
+    // skin that squares every other corner should square its chips as well,
+    // otherwise a 'square' skin leaves capsule filter rows next to squared tab
+    // rows on the same screen. A `set` skin pins them to its one value. An
+    // explicit `radii.pill` still wins, so capsules-on-a-square-app stays
+    // expressible.
+    pill: skin?.radii?.pill ?? rad(BASE_RADII.pill),
   };
   const spacing: SkinSpacing = {
     xs: skin?.spacing?.xs ?? Math.round(BASE_SPACING.xs * geo.spacingScale),


### PR DESCRIPTION
`theme.radii.pill` was the one radius token that skipped the geometry scale. A 'square' skin squared every card, modal, button and tab row while capsule-shaped chip rows stayed at radius 999.

That mismatch was visible on single screens. Both the profile screen and the wallet modal stack a `variant="segmented"` row (already skin-scaled, via `Skin.radius(12)`/`radius(9)`) directly above a `variant="solid"` capsule filter row (not scaled). On a square skin the first went square and the second stayed a capsule, two rows apart on the same card.

### Why scaling the token is safe

The huge base value is what makes it work: a skin cannot make a capsule rounder, since `999 * 2.2` still clamps to half the element's height. So the only scale that changes anything is 0. A `set` skin pins chips to its one value, and an explicit `radii.pill` still wins for a skin that wants capsules on an otherwise square app.

### Coverage

Of 23 `SegmentedPills` call sites, 4 use `variant="segmented"` and 6 use `pillShape="rect"`; both were already skin-scaled. The remaining 13 read `theme.radii.pill` and now follow the skin too.

Five other places already wrote `Skin.radius(999)` directly (BrowserModal, SpaceCallScreen, three in SocialFeedModal), so this aligns the token with existing precedent rather than introducing a new rule.

Four components read the token, all pill-shaped selectors of the same kind: the SegmentedPills default shape, the appearance toggle and tab row in SkinsModal, and the option row in SkinEditor. No avatar or status dot depends on it.

### Known outlier, not changed here

The chat composer pill hardcodes `borderRadius: 999` in MessageInput, bypassing the skin. Same family, but it has its own rationale (semicircle ends while single-line), so whether a square skin should flatten it is a design call worth making separately.

### Verification

Typecheck is clean in `theme/`, `components/ui/` and `components/skins/`; the remaining repo errors are pre-existing and confined to `services/calling/`, `services/farcasterClient.ts` and the SDK shims.

Not visually verified, no working emulator. Needs a device pass on the Brutalist (square) and Paper (round) skins, checking the profile screen and wallet modal where the two row types sit together.